### PR TITLE
fix: add missing return in connect_to_deamon

### DIFF
--- a/libdisplay_consumer/display_consumer.c
+++ b/libdisplay_consumer/display_consumer.c
@@ -217,7 +217,7 @@ static void enter_fallback(display_ctx *ctx)
         ctx->fallback_cb(ctx->fallback_userdata);
 }
 int connect_to_deamon(display_ctx **out, const char *socket_path){
-    connect_to_deamon_with_fd(out, connect_unix(socket_path));
+    return connect_to_deamon_with_fd(out, connect_unix(socket_path));
 }
 int connect_to_deamon_with_fd(display_ctx **out, int ctrl_fd)
 {


### PR DESCRIPTION
connect_to_deamon calls connect_to_deamon_with_fd but discards its return value. The function is declared int with no return statement, which is undefined behavior.

The missing return causes the compiler to eliminate the function body at -O1 and above, leaving only ret. The return value becomes whatever garbage is in the RAX register:

-O0 returns -1
-O2 returns 0
-O3 returns 0
-Og returns 14
all levels with fix return -1

The Android consumer builds with -O3 -flto, exactly where this bug manifests.