### PR TITLE
fix packed struct alignment

### DIFF
--- a/consumers/anland_v5/android_consumer/app/src/main/jni/camera_service.c
+++ b/consumers/anland_v5/android_consumer/app/src/main/jni/camera_service.c
@@ -500,7 +500,7 @@ static void ctrl_handle_msg(const struct camera_ctrl_msg *hdr, const uint8_t *pa
 {
     switch (hdr->type) {
     case CAMERA_CTRL_GET_INFO: {
-        uint8_t reply[sizeof(struct camera_ctrl_msg) + 1 + MAX_CAMERAS * 4];
+        _Alignas(uint16_t) uint8_t reply[sizeof(struct camera_ctrl_msg) + 1 + MAX_CAMERAS * 4];
         struct camera_ctrl_msg *rh = (struct camera_ctrl_msg *)reply;
         rh->type = CAMERA_CTRL_INFO_REPLY;
         rh->reserved = 0;


### PR DESCRIPTION
_Alignas(uint16_t) guarantees the stack buffer is properly aligned for the packed struct's uint16_t field. Without it, ARM64 generates sturh which can trap on some cores. x86_64 unaffected.