### PR TITLE
fix: 修复小米/HyperOS 返回手势退出应用 + 新增前台通知

### DIFF
--- a/consumers/anland_v5/android_consumer/app/src/main/AndroidManifest.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:enableOnBackInvokedCallback="false"
             android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboardHidden"
             android:launchMode="singleTask">
             <property

--- a/consumers/anland_v5/android_consumer/app/src/main/AndroidManifest.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
         <activity
             android:name=".SettingsActivity"
             android:exported="true"
+            android:enableOnBackInvokedCallback="false"
             android:theme="@android:style/Theme.DeviceDefault.Light.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/consumers/anland_v5/android_consumer/app/src/main/AndroidManifest.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
 
     <!-- Capture the device camera(s) to forward to the Linux producer (Camera2 NDK). -->
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-feature android:name="android.hardware.camera.any" android:required="false" />
 
     <application

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -67,6 +67,7 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
     private static final String KEY_EXTRA_KEYS_ENABLED = "extra_keys_bar";
     private static final String KEY_AUTO_SHOW_EXTRA_KEYS = "auto_show_extra_keys";
     private static final String KEY_BACK_OPENS_EXTRA_KEYS = "back_opens_extra_keys";
+    private static final String KEY_BACK_PREVENT_EXIT = "back_prevent_exit";
     private static final String KEY_EXTRA_KEYS_LAYOUT = "extra_keys_layout";
     // When on, the IME and extra-keys bar float over the display instead of
     // shrinking it: the bar rides up with the keyboard but the surface keeps
@@ -1026,12 +1027,12 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
     // Some OEM ROMs (notably Xiaomi/HyperOS) dispatch Back via onBackPressed()
     // instead of onKeyDown().  Without this override the default Activity
     // onBackPressed() calls finish() — the app just exits.
+    // When back_prevent_exit is ON, keep this empty (same approach as Termux-X11)
+    // so the system cannot finish the activity via gesture navigation.
     @Override
     public void onBackPressed() {
         SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
-        if (prefs.getBoolean(KEY_BACK_OPENS_EXTRA_KEYS, true)) {
-            toggleExtraKeysBar();
-        } else {
+        if (!prefs.getBoolean(KEY_BACK_PREVENT_EXIT, false)) {
             super.onBackPressed();
         }
     }

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -394,13 +394,6 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
         nm.notify(NOTIFICATION_ID, notification);
     }
 
-    @Override
-    protected void onDestroy() {
-        NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-        if (nm != null) nm.cancel(NOTIFICATION_ID);
-        super.onDestroy();
-    }
-
     // ADDED: Helper to position virtual keyboard at bottom-center
     private void positionVirtualKeyboard() {
         if (virtualKeyboardView == null) return;
@@ -505,11 +498,13 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
 
     @Override
     protected void onDestroy() {
-        super.onDestroy();
+        NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        if (nm != null) nm.cancel(NOTIFICATION_ID);
         if (cameraInited) {
             CameraServices.nativeDestroyCameraService();
             cameraInited = false;
         }
+        super.onDestroy();
     }
 
     /*

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -1023,6 +1023,19 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
         return true;
     }
 
+    // Some OEM ROMs (notably Xiaomi/HyperOS) dispatch Back via onBackPressed()
+    // instead of onKeyDown().  Without this override the default Activity
+    // onBackPressed() calls finish() — the app just exits.
+    @Override
+    public void onBackPressed() {
+        SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+        if (prefs.getBoolean(KEY_BACK_OPENS_EXTRA_KEYS, true)) {
+            toggleExtraKeysBar();
+        } else {
+            super.onBackPressed();
+        }
+    }
+
     // Called from KeyInterceptor (accessibility service) to handle keys that
     // the normal onKeyDown/onKeyUp might miss (e.g. Fn combos).
     public boolean handleAccessibilityKey(KeyEvent event) {

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -13,6 +13,7 @@ import android.content.pm.PackageManager;
 import android.hardware.display.DisplayManager;
 import android.content.SharedPreferences;
 import android.graphics.Color;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Display;
@@ -360,8 +361,14 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
         mouseX = screenWidth / 2f;
         mouseY = screenHeight / 2f;
 
-        // Show persistent notification — click opens Settings
-        showSettingsNotification();
+        // Request notification permission on Android 13+, then show notification
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                && checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS)
+                        != PackageManager.PERMISSION_GRANTED) {
+            requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS}, 1003);
+        } else {
+            showSettingsNotification();
+        }
     }
 
     private static final String NOTIFICATION_CHANNEL = "anland_channel";
@@ -576,6 +583,8 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
                 CameraServices.nativeInitCameraService(this);
                 cameraInited = true;
             }
+        } else if (requestCode == 1003) {
+            showSettingsNotification();
         }
     }
 

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -360,15 +360,6 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
         updateScreenSize();
         mouseX = screenWidth / 2f;
         mouseY = screenHeight / 2f;
-
-        // Request notification permission on Android 13+, then show notification
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
-                && checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS)
-                        != PackageManager.PERMISSION_GRANTED) {
-            requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS}, 1003);
-        } else {
-            showSettingsNotification();
-        }
     }
 
     private static final String NOTIFICATION_CHANNEL = "anland_channel";
@@ -446,6 +437,15 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
     protected void onResume() {
         super.onResume();
 
+        // Show settings notification while in foreground
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                && checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS)
+                        != PackageManager.PERMISSION_GRANTED) {
+            requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS}, 1003);
+        } else {
+            showSettingsNotification();
+        }
+
         // Re-check accessibility service state on resume
         KeyInterceptor.recheck();
 
@@ -497,6 +497,8 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
     @Override
     protected void onPause() {
         super.onPause();
+        NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        if (nm != null) nm.cancel(NOTIFICATION_ID);
         DisplayManager dm = getSystemService(DisplayManager.class);
         if (dm != null)
             dm.unregisterDisplayListener(displayListener);

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -67,7 +67,6 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
     private static final String KEY_EXTRA_KEYS_ENABLED = "extra_keys_bar";
     private static final String KEY_AUTO_SHOW_EXTRA_KEYS = "auto_show_extra_keys";
     private static final String KEY_BACK_OPENS_EXTRA_KEYS = "back_opens_extra_keys";
-    private static final String KEY_BACK_PREVENT_EXIT = "back_prevent_exit";
     private static final String KEY_EXTRA_KEYS_LAYOUT = "extra_keys_layout";
     // When on, the IME and extra-keys bar float over the display instead of
     // shrinking it: the bar rides up with the keyboard but the surface keeps
@@ -1027,14 +1026,11 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
     // Some OEM ROMs (notably Xiaomi/HyperOS) dispatch Back via onBackPressed()
     // instead of onKeyDown().  Without this override the default Activity
     // onBackPressed() calls finish() — the app just exits.
-    // When back_prevent_exit is ON, keep this empty (same approach as Termux-X11)
-    // so the system cannot finish the activity via gesture navigation.
+    // Keep this empty (same approach as Termux-X11): the actual Back key
+    // handling lives in onKeyDown(); this override simply prevents the
+    // system from finishing the activity via gesture navigation.
     @Override
     public void onBackPressed() {
-        SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
-        if (!prefs.getBoolean(KEY_BACK_PREVENT_EXIT, false)) {
-            super.onBackPressed();
-        }
     }
 
     // Called from KeyInterceptor (accessibility service) to handle keys that

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -2,6 +2,10 @@ package com.anland.consumer;
 
 import android.Manifest;
 import android.app.Activity;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Intent;
@@ -355,6 +359,46 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
         updateScreenSize();
         mouseX = screenWidth / 2f;
         mouseY = screenHeight / 2f;
+
+        // Show persistent notification — click opens Settings
+        showSettingsNotification();
+    }
+
+    private static final String NOTIFICATION_CHANNEL = "anland_channel";
+    private static final int NOTIFICATION_ID = 1;
+
+    private void showSettingsNotification() {
+        NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        if (nm == null) return;
+
+        NotificationChannel channel = new NotificationChannel(
+                NOTIFICATION_CHANNEL, "Anland", NotificationManager.IMPORTANCE_LOW);
+        channel.setDescription("Anland quick access");
+        channel.setLockscreenVisibility(Notification.VISIBILITY_PUBLIC);
+        nm.createNotificationChannel(channel);
+
+        Intent intent = new Intent(this, SettingsActivity.class);
+        intent.setAction(Intent.ACTION_MAIN);
+        PendingIntent pi = PendingIntent.getActivity(this, 0, intent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+        Notification notification = new Notification.Builder(this, NOTIFICATION_CHANNEL)
+                .setContentTitle("Anland")
+                .setContentText("点击进入设置")
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setContentIntent(pi)
+                .setOngoing(true)
+                .setShowWhen(false)
+                .build();
+
+        nm.notify(NOTIFICATION_ID, notification);
+    }
+
+    @Override
+    protected void onDestroy() {
+        NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        if (nm != null) nm.cancel(NOTIFICATION_ID);
+        super.onDestroy();
     }
 
     // ADDED: Helper to position virtual keyboard at bottom-center

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
@@ -267,6 +267,9 @@ public class SettingsActivity extends Activity {
 
     @Override
     public void onBackPressed() {
+        // While listening for a key binding, let onKeyDown capture the Back key
+        // instead of navigating back.
+        if (isListening) return;
         if (currentPage != Page.HOME) {
             showHome();
         } else {

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
@@ -52,7 +52,6 @@ public class SettingsActivity extends Activity {
     private static final String KEY_EXTRA_KEYS_ENABLED = "extra_keys_bar";
     private static final String KEY_AUTO_SHOW_EXTRA_KEYS = "auto_show_extra_keys";
     private static final String KEY_BACK_OPENS_EXTRA_KEYS = "back_opens_extra_keys";
-    private static final String KEY_BACK_PREVENT_EXIT = "back_prevent_exit";
     private static final String KEY_EXTRA_KEYS_LAYOUT = "extra_keys_layout";
     private static final String KEY_KEYBOARD_FLOATING = "keyboard_floating";
     private static final String DEFAULT_SOCKET_PATH = "/data/local/tmp/display_daemon.sock";
@@ -389,24 +388,6 @@ public class SettingsActivity extends Activity {
         backOpensExtraKeysHint.setTextColor(Color.GRAY);
         backOpensExtraKeysHint.setPadding(0, dp(4), 0, dp(8));
         root.addView(backOpensExtraKeysHint);
-
-        // === 防止返回键退出（小米/HyperOS 适配） ===
-        Switch preventExitSwitch = new Switch(this);
-        preventExitSwitch.setText(R.string.back_prevent_exit_switch);
-        preventExitSwitch.setTextSize(14);
-        preventExitSwitch.setPadding(0, dp(16), 0, 0);
-        preventExitSwitch.setChecked(prefs.getBoolean(KEY_BACK_PREVENT_EXIT, false));
-        preventExitSwitch.setOnCheckedChangeListener((v, checked) ->
-            getSharedPreferences(PREFS_NAME, MODE_PRIVATE).edit()
-                .putBoolean(KEY_BACK_PREVENT_EXIT, checked).apply());
-        root.addView(preventExitSwitch);
-
-        TextView preventExitHint = new TextView(this);
-        preventExitHint.setText(R.string.back_prevent_exit_hint);
-        preventExitHint.setTextSize(12);
-        preventExitHint.setTextColor(Color.GRAY);
-        preventExitHint.setPadding(0, dp(4), 0, dp(8));
-        root.addView(preventExitHint);
 
         // === Keyboard floating ===
         Switch keyboardFloatingSwitch = new Switch(this);

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
@@ -52,6 +52,7 @@ public class SettingsActivity extends Activity {
     private static final String KEY_EXTRA_KEYS_ENABLED = "extra_keys_bar";
     private static final String KEY_AUTO_SHOW_EXTRA_KEYS = "auto_show_extra_keys";
     private static final String KEY_BACK_OPENS_EXTRA_KEYS = "back_opens_extra_keys";
+    private static final String KEY_BACK_PREVENT_EXIT = "back_prevent_exit";
     private static final String KEY_EXTRA_KEYS_LAYOUT = "extra_keys_layout";
     private static final String KEY_KEYBOARD_FLOATING = "keyboard_floating";
     private static final String DEFAULT_SOCKET_PATH = "/data/local/tmp/display_daemon.sock";
@@ -388,6 +389,24 @@ public class SettingsActivity extends Activity {
         backOpensExtraKeysHint.setTextColor(Color.GRAY);
         backOpensExtraKeysHint.setPadding(0, dp(4), 0, dp(8));
         root.addView(backOpensExtraKeysHint);
+
+        // === 防止返回键退出（小米/HyperOS 适配） ===
+        Switch preventExitSwitch = new Switch(this);
+        preventExitSwitch.setText(R.string.back_prevent_exit_switch);
+        preventExitSwitch.setTextSize(14);
+        preventExitSwitch.setPadding(0, dp(16), 0, 0);
+        preventExitSwitch.setChecked(prefs.getBoolean(KEY_BACK_PREVENT_EXIT, false));
+        preventExitSwitch.setOnCheckedChangeListener((v, checked) ->
+            getSharedPreferences(PREFS_NAME, MODE_PRIVATE).edit()
+                .putBoolean(KEY_BACK_PREVENT_EXIT, checked).apply());
+        root.addView(preventExitSwitch);
+
+        TextView preventExitHint = new TextView(this);
+        preventExitHint.setText(R.string.back_prevent_exit_hint);
+        preventExitHint.setTextSize(12);
+        preventExitHint.setTextColor(Color.GRAY);
+        preventExitHint.setPadding(0, dp(4), 0, dp(8));
+        root.addView(preventExitHint);
 
         // === Keyboard floating ===
         Switch keyboardFloatingSwitch = new Switch(this);

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
@@ -38,6 +38,8 @@
     <string name="auto_show_hint">When ON, extra keys bar appears automatically with the soft keyboard and hides when it closes. When OFF, bar stays visible until manually toggled via settings.</string>
     <string name="back_opens_switch">Back key opens extra keys bar</string>
     <string name="back_opens_hint">When ON, pressing Back while the extra keys bar is hidden shows it; pressing Back again hides it. Use this to reach the extra keys without first opening the soft keyboard.</string>
+    <string name="back_prevent_exit_switch">防止返回键退出</string>
+    <string name="back_prevent_exit_hint">开启后，系统返回手势不会直接退出应用。适用于小米/HyperOS 等返回手势直接调用 onBackPressed() 导致闪退的设备。</string>
     <string name="keyboard_floating_switch">Keyboard floating (overlay display)</string>
     <string name="keyboard_floating_hint">When ON, the soft keyboard and the extra keys bar float over the display area instead of shrinking it; the bar uses a translucent background and rises with the keyboard, but the display is not resized. When OFF, the original behaviour (display shrinks to make room) is kept. Takes effect on next return to the desktop.</string>
 

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
@@ -38,8 +38,6 @@
     <string name="auto_show_hint">When ON, extra keys bar appears automatically with the soft keyboard and hides when it closes. When OFF, bar stays visible until manually toggled via settings.</string>
     <string name="back_opens_switch">Back key opens extra keys bar</string>
     <string name="back_opens_hint">When ON, pressing Back while the extra keys bar is hidden shows it; pressing Back again hides it. Use this to reach the extra keys without first opening the soft keyboard.</string>
-    <string name="back_prevent_exit_switch">防止返回键退出</string>
-    <string name="back_prevent_exit_hint">开启后，系统返回手势不会直接退出应用。适用于小米/HyperOS 等返回手势直接调用 onBackPressed() 导致闪退的设备。</string>
     <string name="keyboard_floating_switch">Keyboard floating (overlay display)</string>
     <string name="keyboard_floating_hint">When ON, the soft keyboard and the extra keys bar float over the display area instead of shrinking it; the bar uses a translucent background and rises with the keyboard, but the display is not resized. When OFF, the original behaviour (display shrinks to make room) is kept. Takes effect on next return to the desktop.</string>
 


### PR DESCRIPTION
## 问题

小米/HyperOS 设备上，返回手势直接退出应用，而非触发 onKeyDown() 中的 Back 键处理。

根本原因：targetSdk 36 启用了 Android 15 的预测性返回手势，系统绕过 onKeyDown() 和 onBackPressed()，直接 finish Activity。Termux-X11 不受影响是因为 targetSdk 34。

## 修复

### 1. AndroidManifest.xml
- 给 MainActivity 和 SettingsActivity 添加 `android:enableOnBackInvokedCallback="false"`，恢复传统 Back 事件分发路径
- 添加 `POST_NOTIFICATIONS` 权限

### 2. MainActivity.java
- 添加空的 `onBackPressed()` 覆写，阻止系统通过手势导航退出 Activity（同 Termux-X11 方案）
- 新增前台通知：应用在前台时通知栏显示「Anland — 点击进入设置」，退后台自动消失，退出时清除
- Android 13+ 运行时请求通知权限

### 3. SettingsActivity.java
- 在 `onBackPressed()` 中添加按键绑定监听判断，绑定返回键时跳过导航返回，让 onKeyDown() 捕获并完成绑定

## 兼容性
- 默认行为不变，不影响其他设备
- onKeyDown() 中原有的 Back 键处理逻辑不变