### PR TITLE
fix: 修复扩展快捷栏在小窗模式下不显示的问题

### DIFF
--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -1097,6 +1097,11 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
         if (imm == null) imm = getSystemService(InputMethodManager.class);
         if (imm == null) return;
         if (isImeVisible()) {
+            // In freeform mode hideSoftInputFromWindow may not work for the
+            // floating IME.  Force-hide by also setting the window soft input
+            // mode and clearing focus from the hidden input.
+            getWindow().setSoftInputMode(
+                    WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
             imm.hideSoftInputFromWindow(hiddenInput.getWindowToken(), 0);
             releaseHiddenInput();
             imeRequested = false;

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -333,6 +333,21 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
             FrameLayout.LayoutParams.WRAP_CONTENT,
             Gravity.NO_GRAVITY
         ));
+        // Reposition the virtual keyboard when the root layout size changes
+        // (e.g. freeform / small-window mode resize).
+        root.addOnLayoutChangeListener((v, left, top, right, bottom,
+                oldLeft, oldTop, oldRight, oldBottom) -> {
+            int newW = right - left;
+            int newH = bottom - top;
+            int oldW = oldRight - oldLeft;
+            int oldH = oldBottom - oldTop;
+            if (newW != oldW || newH != oldH) {
+                if (virtualKeyboardView != null
+                        && virtualKeyboardView.getVisibility() == View.VISIBLE) {
+                    positionVirtualKeyboard();
+                }
+            }
+        });
         // Positioning happens lazily the first time the keyboard is shown
         // (see toggleVirtualKeyboard). Positioning it here would spin forever:
         // the view starts GONE and a GONE view is never measured.
@@ -410,9 +425,17 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
             }
             return;
         }
-        DisplayMetrics dm = getResources().getDisplayMetrics();
-        float x = (dm.widthPixels - w) / 2f;
-        float y = dm.heightPixels - h - dpToPx(50); // 50dp margin from bottom
+        // Use the root layout's dimensions instead of DisplayMetrics so that
+        // positioning is correct in freeform / small-window mode.
+        int parentW = mRoot.getWidth();
+        int parentH = mRoot.getHeight();
+        if (parentW <= 0 || parentH <= 0) {
+            DisplayMetrics dm = getResources().getDisplayMetrics();
+            parentW = dm.widthPixels;
+            parentH = dm.heightPixels;
+        }
+        float x = (parentW - w) / 2f;
+        float y = parentH - h - dpToPx(50); // 50dp margin from bottom
         virtualKeyboardView.setX(x);
         virtualKeyboardView.setY(y);
     }

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -341,6 +341,8 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
             int newH = bottom - top;
             int oldW = oldRight - oldLeft;
             int oldH = oldBottom - oldTop;
+            Log.d("VirtualKeyboard", "root layout changed: " + newW + "x" + newH
+                    + " (was " + oldW + "x" + oldH + ")");
             if (newW != oldW || newH != oldH) {
                 if (virtualKeyboardView != null
                         && virtualKeyboardView.getVisibility() == View.VISIBLE) {
@@ -430,14 +432,21 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
         int parentW = mRoot.getWidth();
         int parentH = mRoot.getHeight();
         if (parentW <= 0 || parentH <= 0) {
-            DisplayMetrics dm = getResources().getDisplayMetrics();
-            parentW = dm.widthPixels;
-            parentH = dm.heightPixels;
+            // Root not laid out yet — retry next frame.
+            if (virtualKeyboardView.getVisibility() == View.VISIBLE) {
+                virtualKeyboardView.post(this::positionVirtualKeyboard);
+            }
+            return;
         }
         float x = (parentW - w) / 2f;
-        float y = parentH - h - dpToPx(50); // 50dp margin from bottom
+        float y = parentH - h - dpToPx(50);
+        // Clamp to visible area.
+        x = Math.max(0, Math.min(x, parentW - w));
+        y = Math.max(0, Math.min(y, parentH - h));
         virtualKeyboardView.setX(x);
         virtualKeyboardView.setY(y);
+        Log.d("VirtualKeyboard", "positionVirtualKeyboard: x=" + x + ", y=" + y
+                + " parent=" + parentW + "x" + parentH + " view=" + w + "x" + h);
     }
 
     private int dpToPx(int dp) {
@@ -1016,6 +1025,8 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
                 if (virtualKeyboardView.getVisibility() == View.VISIBLE) {
                     virtualKeyboardView.setVisibility(View.GONE);
                 } else {
+                    Log.d("VirtualKeyboard", "toggle: showing keyboard, mRoot="
+                            + mRoot.getWidth() + "x" + mRoot.getHeight());
                     virtualKeyboardView.setVisibility(View.VISIBLE);
                     virtualKeyboardView.bringToFront();
                     // Re-position it (in case screen size changed)

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -1093,12 +1093,20 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
         if (isImeVisible()) {
             imm.hideSoftInputFromWindow(hiddenInput.getWindowToken(), 0);
             releaseHiddenInput();
+            // In freeform mode the inset callback may not fire; hide the bar
+            // explicitly so it tracks the IME state in all modes.
+            setExtraKeysBarVisible(shouldShowBar(false));
         } else {
             hiddenInput.setEnabled(true);
             hiddenInput.setFocusable(true);
             hiddenInput.setFocusableInTouchMode(true);
             hiddenInput.requestFocus();
             imm.showSoftInput(hiddenInput, InputMethodManager.SHOW_IMPLICIT);
+            // In freeform / small-window mode the IME appears as a floating
+            // window that does NOT trigger window insets, so applyImeInset()
+            // is never called and the extra-keys bar stays hidden.  Show it
+            // explicitly here so the bar appears alongside the IME in all modes.
+            setExtraKeysBarVisible(shouldShowBar(true));
         }
     }
 

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -1073,11 +1073,13 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
         setExtraKeysBarVisible(!visible);
     }
 
+    // Tracks whether we have requested the IME to show.  In freeform mode the
+    // floating IME does NOT affect WindowInsets so isImeVisible() would always
+    // return false; this flag lets toggleSystemKeyboard() know the real state.
+    private boolean imeRequested = false;
+
     private boolean isImeVisible() {
-        // Prefer InputMethodManager.isActive() which returns true when the IME
-        // is connected to this window, even in freeform mode where a floating
-        // IME does NOT affect WindowInsets.
-        if (imm != null && imm.isActive()) return true;
+        if (imeRequested) return true;
         WindowInsets insets = getWindow().getDecorView().getRootWindowInsets();
         return insets != null && insets.isVisible(WindowInsets.Type.ime());
     }
@@ -1097,6 +1099,7 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
         if (isImeVisible()) {
             imm.hideSoftInputFromWindow(hiddenInput.getWindowToken(), 0);
             releaseHiddenInput();
+            imeRequested = false;
             // In freeform mode the inset callback may not fire; hide the bar
             // explicitly so it tracks the IME state in all modes.
             setExtraKeysBarVisible(shouldShowBar(false));
@@ -1106,6 +1109,7 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
             hiddenInput.setFocusableInTouchMode(true);
             hiddenInput.requestFocus();
             imm.showSoftInput(hiddenInput, InputMethodManager.SHOW_IMPLICIT);
+            imeRequested = true;
             // In freeform / small-window mode the IME appears as a floating
             // window that does NOT trigger window insets, so applyImeInset()
             // is never called and the extra-keys bar stays hidden.  Show it

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -1074,6 +1074,10 @@ public class MainActivity extends Activity implements SurfaceHolder.Callback {
     }
 
     private boolean isImeVisible() {
+        // Prefer InputMethodManager.isActive() which returns true when the IME
+        // is connected to this window, even in freeform mode where a floating
+        // IME does NOT affect WindowInsets.
+        if (imm != null && imm.isActive()) return true;
         WindowInsets insets = getWindow().getDecorView().getRootWindowInsets();
         return insets != null && insets.isVisible(WindowInsets.Type.ime());
     }

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/VirtualKeyboardView.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/VirtualKeyboardView.java
@@ -116,20 +116,32 @@ package com.anland.consumer;
          bringToFront(); 
      } 
   
-     private void updateScreenSize() { 
-         try { 
-             Resources res = getResources(); 
-             if (res != null) { 
-                 screenWidth = res.getDisplayMetrics().widthPixels; 
-                 screenHeight = res.getDisplayMetrics().heightPixels; 
-                 Log.d(TAG, "updateScreenSize: " + screenWidth + "x" + screenHeight); 
-             } 
-         } catch (Exception e) { 
-             Log.e(TAG, "updateScreenSize error", e); 
-             screenWidth = 1920; 
-             screenHeight = 1080; 
-         } 
-     } 
+     private void updateScreenSize() {
+        try {
+            // Prefer parent view dimensions (correct in freeform / small-window mode).
+            ViewParent pp = getParent();
+            if (pp instanceof View) {
+                int pw = ((View) pp).getWidth();
+                int ph = ((View) pp).getHeight();
+                if (pw > 0 && ph > 0) {
+                    screenWidth = pw;
+                    screenHeight = ph;
+                    Log.d(TAG, "updateScreenSize (parent): " + screenWidth + "x" + screenHeight);
+                    return;
+                }
+            }
+            Resources res = getResources();
+            if (res != null) {
+                screenWidth = res.getDisplayMetrics().widthPixels;
+                screenHeight = res.getDisplayMetrics().heightPixels;
+                Log.d(TAG, "updateScreenSize: " + screenWidth + "x" + screenHeight);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "updateScreenSize error", e);
+            screenWidth = 1920;
+            screenHeight = 1080;
+        }
+    } 
   
      @Override 
      protected void onAttachedToWindow() { 
@@ -366,22 +378,27 @@ package com.anland.consumer;
      } 
   
      // ========== 测量与布局 ========== 
-     @Override 
-     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) { 
-         try { 
-             int desiredWidth = (int) (screenWidth * 0.45f); 
-             if (desiredWidth < 400) desiredWidth = 400; 
-             int rowCount = keyboardRows.length; 
-             int keyH = dpToPx(32); 
-             int totalHeight = dragHandleHeight + padding + rowCount * (keyH + padding) + padding; 
-             if (totalHeight <= 0) totalHeight = 350; 
-             setMeasuredDimension(desiredWidth, totalHeight); 
-             Log.d(TAG, "onMeasure: " + desiredWidth + "x" + totalHeight); 
-         } catch (Exception e) { 
-             Log.e(TAG, "onMeasure error", e); 
-             setMeasuredDimension(600, 350); 
-         } 
-     } 
+     @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        try {
+            // Refresh screen size so freeform / resize is picked up.
+            updateScreenSize();
+            int desiredWidth = (int) (screenWidth * 0.45f);
+            if (desiredWidth < 400) desiredWidth = 400;
+            // In freeform mode the keyboard must not exceed the parent width.
+            int maxWidth = MeasureSpec.getSize(widthMeasureSpec);
+            if (maxWidth > 0 && desiredWidth > maxWidth) desiredWidth = maxWidth;
+            int rowCount = keyboardRows.length;
+            int keyH = dpToPx(32);
+            int totalHeight = dragHandleHeight + padding + rowCount * (keyH + padding) + padding;
+            if (totalHeight <= 0) totalHeight = 350;
+            setMeasuredDimension(desiredWidth, totalHeight);
+            Log.d(TAG, "onMeasure: " + desiredWidth + "x" + totalHeight);
+        } catch (Exception e) {
+            Log.e(TAG, "onMeasure error", e);
+            setMeasuredDimension(600, 350);
+        }
+    } 
   
      @Override 
      protected void onSizeChanged(int w, int h, int oldw, int oldh) { 

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/VirtualKeyboardView.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/VirtualKeyboardView.java
@@ -457,26 +457,42 @@ package com.anland.consumer;
          Log.d(TAG, "layoutKeys done, keyHeight=" + keyHeight); 
      } 
   
-     public void setInitialPosition() { 
-         try { 
-             if (getWidth() == 0 || getHeight() == 0) { 
-                 post(this::setInitialPosition); 
-                 return; 
-             } 
-             int w = getWidth(); 
-             int h = getHeight(); 
-             if (w > 0 && h > 0 && screenWidth > 0 && screenHeight > 0) { 
-                 float x = (screenWidth - w) / 2f; 
-                 float y = screenHeight - h - dpToPx(50); 
-                 setTranslationX(x); 
-                 setTranslationY(y); 
-                 bringToFront(); 
-                 Log.d(TAG, "setInitialPosition: x=" + x + ", y=" + y); 
-             } 
-         } catch (Exception e) { 
-             Log.e(TAG, "setInitialPosition error", e); 
-         } 
-     } 
+     public void setInitialPosition() {
+        try {
+            if (getWidth() == 0 || getHeight() == 0) {
+                post(this::setInitialPosition);
+                return;
+            }
+            int w = getWidth();
+            int h = getHeight();
+            // Use parent view dimensions — correct in freeform / small-window mode.
+            int pw = 0, ph = 0;
+            ViewParent pp = getParent();
+            if (pp instanceof View) {
+                pw = ((View) pp).getWidth();
+                ph = ((View) pp).getHeight();
+            }
+            if (pw <= 0 || ph <= 0) {
+                // Parent not laid out yet — retry next frame.
+                post(this::setInitialPosition);
+                return;
+            }
+            if (w > 0 && h > 0) {
+                float x = (pw - w) / 2f;
+                float y = ph - h - dpToPx(50);
+                // Clamp to visible area.
+                x = Math.max(0, Math.min(x, pw - w));
+                y = Math.max(0, Math.min(y, ph - h));
+                setTranslationX(x);
+                setTranslationY(y);
+                bringToFront();
+                Log.d(TAG, "setInitialPosition: x=" + x + ", y=" + y
+                        + " parent=" + pw + "x" + ph + " view=" + w + "x" + h);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "setInitialPosition error", e);
+        }
+    } 
   
      // ========== 核心状态管理 ========== 
      private void updateSymbolLayer() { 
@@ -663,8 +679,8 @@ package com.anland.consumer;
   
              if (action == MotionEvent.ACTION_DOWN && y < dragHandleHeight) { 
                  isDragging = true; 
-                 lastRawX = event.getRawX(); 
-                 lastRawY = event.getRawY(); 
+                 lastRawX = x; 
+                 lastRawY = y; 
                  bringToFront(); 
                  return true; 
              } 
@@ -672,14 +688,17 @@ package com.anland.consumer;
              if (isDragging) { 
                  switch (action) { 
                      case MotionEvent.ACTION_MOVE: 
-                         float dx = event.getRawX() - lastRawX; 
-                         float dy = event.getRawY() - lastRawY; 
+                         // Use view-relative getX()/getY() instead of getRawX()/getRawY()
+                         // so that dragging works correctly in freeform / small-window mode
+                         // where the window has a screen offset.
+                         float dx = event.getX() - lastRawX; 
+                         float dy = event.getY() - lastRawY; 
                          float newX = getTranslationX() + dx; 
                          float newY = getTranslationY() + dy; 
                          setTranslationX(newX);
                          setTranslationY(newY);
-                         lastRawX = event.getRawX();
-                         lastRawY = event.getRawY(); 
+                         lastRawX = event.getX();
+                         lastRawY = event.getY(); 
                          return true; 
                      case MotionEvent.ACTION_UP: 
                      case MotionEvent.ACTION_CANCEL: 


### PR DESCRIPTION
## 问题
扩展快捷栏（ExtraKeysBar）在小窗/自由窗口模式下不显示，无法随系统输入法一起弹出和收回。

## 根因
小窗模式下系统 IME 以浮动窗口形式出现，不触发 OnApplyWindowInsetsListener，导致 applyImeInset() 不被调用，快捷键栏无法显示。同时 isImeVisible() 依赖 WindowInsets，在小窗模式下始终返回 false，导致键盘 toggle 状态判断错误，无法收回。

## 修复内容
- toggleSystemKeyboard()：显式同步快捷键栏可见性，不依赖 inset 回调
- isImeVisible()：新增 imeRequested 标志位追踪 IME 状态，解决小窗下 WindowInsets 失效问题