### PR TITLE
改进 Anland 无障碍按键拦截

### DIFF
--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/KeyCodeMapper.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/KeyCodeMapper.java
@@ -73,6 +73,10 @@ public class KeyCodeMapper {
         MAP.put(KeyEvent.KEYCODE_CTRL_RIGHT, 97);
         MAP.put(KeyEvent.KEYCODE_ALT_LEFT, 56);
         MAP.put(KeyEvent.KEYCODE_ALT_RIGHT, 100);
+        MAP.put(KeyEvent.KEYCODE_META_LEFT, 125);
+        MAP.put(KeyEvent.KEYCODE_META_RIGHT, 126);
+        MAP.put(KeyEvent.KEYCODE_SEARCH, 125);
+        MAP.put(KeyEvent.KEYCODE_ASSIST, 125);
         MAP.put(KeyEvent.KEYCODE_CAPS_LOCK, 58);
 
         // 方向键
@@ -94,6 +98,18 @@ public class KeyCodeMapper {
         MAP.put(KeyEvent.KEYCODE_F10, 68);
         MAP.put(KeyEvent.KEYCODE_F11, 87);  // 修正
         MAP.put(KeyEvent.KEYCODE_F12, 88);  // 修正
+        MAP.put(KeyEvent.KEYCODE_F13, 183);
+        MAP.put(KeyEvent.KEYCODE_F14, 184);
+        MAP.put(KeyEvent.KEYCODE_F15, 185);
+        MAP.put(KeyEvent.KEYCODE_F16, 186);
+        MAP.put(KeyEvent.KEYCODE_F17, 187);
+        MAP.put(KeyEvent.KEYCODE_F18, 188);
+        MAP.put(KeyEvent.KEYCODE_F19, 189);
+        MAP.put(KeyEvent.KEYCODE_F20, 190);
+        MAP.put(KeyEvent.KEYCODE_F21, 191);
+        MAP.put(KeyEvent.KEYCODE_F22, 192);
+        MAP.put(KeyEvent.KEYCODE_F23, 193);
+        MAP.put(KeyEvent.KEYCODE_F24, 194);
 
         // Home / End
         MAP.put(KeyEvent.KEYCODE_MOVE_HOME, 102);

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/KeyInterceptor.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/KeyInterceptor.java
@@ -69,10 +69,17 @@ public class KeyInterceptor extends AccessibilityService {
     private static void disableImmediately() {
         if (self == null) return;
         android.util.Log.d("KeyInterceptor", "disabling interception service");
-        self.setServiceInfo(new AccessibilityServiceInfo() {{
-            flags = DEFAULT;
-        }});
+        AccessibilityServiceInfo info = self.getServiceInfo();
+        info.flags &= ~AccessibilityServiceInfo.FLAG_REQUEST_FILTER_KEY_EVENTS;
+        self.setServiceInfo(info);
         self.enabled = false;
+    }
+
+    @Override
+    protected void onServiceConnected() {
+        super.onServiceConnected();
+        self = this;
+        recheck();
     }
 
     public static void recheck() {
@@ -82,9 +89,9 @@ public class KeyInterceptor extends AccessibilityService {
             if (shouldBeEnabled) {
                 handler.removeCallbacks(disableImmediatelyCallback);
                 android.util.Log.d("KeyInterceptor", "enabling interception service");
-                self.setServiceInfo(new AccessibilityServiceInfo() {{
-                    flags = FLAG_REQUEST_FILTER_KEY_EVENTS;
-                }});
+                AccessibilityServiceInfo info = self.getServiceInfo();
+                info.flags |= AccessibilityServiceInfo.FLAG_REQUEST_FILTER_KEY_EVENTS;
+                self.setServiceInfo(info);
                 self.enabled = true;
             } else {
                 handler.postDelayed(disableImmediatelyCallback, 120000);
@@ -103,16 +110,19 @@ public class KeyInterceptor extends AccessibilityService {
         if (!instance.hasWindowFocus())
             return false;
 
+        int keyCode = event.getKeyCode();
+        boolean releaseTrackedKey = event.getAction() == KeyEvent.ACTION_UP
+                && pressedKeys.contains(keyCode);
         boolean intercept = instance.isAccessibilityInterceptEnabled();
 
         boolean ret = false;
-        if (intercept || (event.getAction() == KeyEvent.ACTION_UP && pressedKeys.contains(event.getKeyCode())))
+        if (intercept || releaseTrackedKey)
             ret = instance.handleAccessibilityKey(event);
 
-        if (intercept && event.getAction() == KeyEvent.ACTION_DOWN)
-            pressedKeys.add(event.getKeyCode());
+        if (intercept && ret && event.getAction() == KeyEvent.ACTION_DOWN)
+            pressedKeys.add(keyCode);
         else if (event.getAction() == KeyEvent.ACTION_UP)
-            pressedKeys.remove(event.getKeyCode());
+            pressedKeys.remove(keyCode);
 
         recheck();
 

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -933,18 +933,7 @@ public class MainActivity extends Activity
             return true;
         }
 
-        int scanCode = event.getScanCode();
-        if (scanCode != 0) {
-            mNative.sendKey(0, scanCode);
-            return true;
-        }
-
-        // fallback: when scancode is 0 (e.g. Fn key combos), map via KeyCodeMapper
-        int evdev = KeyCodeMapper.getScanCode(keyCode);
-        if (evdev != -1) {
-            mNative.sendKey(0, evdev);
-            return true;
-        }
+        forwardKeyToLinux(event);
         return true;
     }
 
@@ -964,25 +953,38 @@ public class MainActivity extends Activity
         if (event.getRepeatCount() > 0)
             return true;
 
-        int scanCode = event.getScanCode();
-        if (scanCode != 0 && event.getKeyCode() == KeyEvent.KEYCODE_UNKNOWN) {
-            // Some Fn combos deliver KEYCODE_UNKNOWN with a valid scancode
-            mNative.sendKey(event.getAction() == KeyEvent.ACTION_DOWN ? 0 : 1, scanCode);
-            return true;
-        }
+        return forwardKeyToLinux(event);
+    }
 
-        int evdev = KeyCodeMapper.getScanCode(event.getKeyCode());
-        if (evdev != -1) {
-            mNative.sendKey(event.getAction() == KeyEvent.ACTION_DOWN ? 0 : 1, evdev);
-            return true;
-        }
+    private boolean forwardKeyToLinux(KeyEvent event) {
+        int keyCode = event.getKeyCode();
+        int action = event.getAction() == KeyEvent.ACTION_DOWN ? 0 : 1;
+        int evdev = -1;
 
-        // If both keyCode and scancode are unknown, store/replay raw scancode anyway
-        if (scanCode != 0) {
-            mNative.sendKey(event.getAction() == KeyEvent.ACTION_DOWN ? 0 : 1, scanCode);
-            return true;
-        }
+        // Reserved Android keys may carry vendor scan codes that Linux does not
+        // recognize, so prefer their explicit evdev mapping.
+        if (shouldPreferMappedKey(keyCode))
+            evdev = KeyCodeMapper.getScanCode(keyCode);
+
+        if (evdev == -1 && event.getScanCode() != 0)
+            evdev = event.getScanCode();
+
+        if (evdev == -1)
+            evdev = KeyCodeMapper.getScanCode(keyCode);
+
+        if (evdev == -1)
+            return false;
+
+        mNative.sendKey(action, evdev);
         return true;
+    }
+
+    private static boolean shouldPreferMappedKey(int keyCode) {
+        return keyCode == KeyEvent.KEYCODE_META_LEFT
+                || keyCode == KeyEvent.KEYCODE_META_RIGHT
+                || keyCode == KeyEvent.KEYCODE_SEARCH
+                || keyCode == KeyEvent.KEYCODE_ASSIST
+                || (keyCode >= KeyEvent.KEYCODE_F13 && keyCode <= KeyEvent.KEYCODE_F24);
     }
 
     public boolean isAccessibilityInterceptEnabled() {
@@ -992,18 +994,7 @@ public class MainActivity extends Activity
 
     @Override
     public boolean onKeyUp(int keyCode, KeyEvent event) {
-        int scanCode = event.getScanCode();
-        if (scanCode != 0) {
-            mNative.sendKey(1, scanCode);
-            return true;
-        }
-
-        // fallback: when scancode is 0, map via KeyCodeMapper
-        int evdev = KeyCodeMapper.getScanCode(keyCode);
-        if (evdev != -1) {
-            mNative.sendKey(1, evdev);
-            return true;
-        }
+        forwardKeyToLinux(event);
         return true;
     }
 


### PR DESCRIPTION
## 修改概述

增加 Meta、Search、Assist 和 F13-F24 等按键的映射，并将这些按键转换为标准 Linux 键码，通过 Anland 输入通道转发。

同时修复无障碍服务连接后未及时启用按键过滤的问题，并在切换过滤标志时保留原有的无障碍服务配置。

本修改继续遵循 Anland 现有的无障碍按键拦截开关，不改变默认启用状态。

## 修改原因

部分 Android ROM 会优先处理 Meta、Search 或 Assist 等系统保留键。在 OnePlus Pad 2 Pro 官方键盘上，相关按键会被 ColorOS 用于系统功能；即使事件到达 Anland，厂商扫描码也可能无法被 Linux/KDE 正确识别。

因此，本修改为这些按键增加明确的标准 Linux evdev 映射，并统一 Activity 与无障碍服务的按键转发路径。

已在 OnePlus Pad 2 Pro 官方 pogo 键盘上验证 Meta 按键转发


## AI 使用说明

vibe coding 代码，如果不接受 AI 代码，也希望相关按键映射可以作为后续实现的参考。