### PR TITLE
将某些设备的按键KEYCODE_BACK 或 Browser Back 扫描码 158 转换为 Linux Esc

### DIFF
--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -87,6 +87,8 @@ public class MainActivity extends Activity
     private static final String KEY_EXTRA_KEYS_MODE = "extra_keys_mode";
     private static final String KEY_BACK_OPENS_EXTRA_KEYS = "back_opens_extra_keys";
     private static final String KEY_EXTRA_KEYS_LAYOUT = "extra_keys_layout";
+    // Linux input-event-codes.h: KEY_BACK (the browser-back key).
+    private static final int EVDEV_BROWSER_BACK = 158;
     // When on, the IME and extra-keys bar float over the display instead of
     // shrinking it: the bar rides up with the keyboard but the surface keeps
     // its full size. See relayout() and buildExtraKeysBar().
@@ -981,17 +983,30 @@ public class MainActivity extends Activity
         if (event.getRepeatCount() > 0)
             return true;
 
-        return forwardKeyToLinux(event);
+        // Some tablet keyboard layouts expose their physical Esc key as
+        // Android Back (Linux KEY_BACK / Browser Back).  Convert it only on
+        // the accessibility-interception path so the normal Android Back and
+        // extra-keys-bar behaviour is unchanged when interception is off.
+        return forwardKeyToLinux(event, true);
     }
 
     private boolean forwardKeyToLinux(KeyEvent event) {
+        return forwardKeyToLinux(event, false);
+    }
+
+    private boolean forwardKeyToLinux(KeyEvent event, boolean convertBackToEscape) {
         int keyCode = event.getKeyCode();
         int action = event.getAction() == KeyEvent.ACTION_DOWN ? 0 : 1;
         int evdev = -1;
 
+        if (convertBackToEscape
+                && (keyCode == KeyEvent.KEYCODE_BACK
+                    || event.getScanCode() == EVDEV_BROWSER_BACK))
+            evdev = KeyCodeMapper.getScanCode(KeyEvent.KEYCODE_ESCAPE);
+
         // Reserved Android keys may carry vendor scan codes that Linux does not
         // recognize, so prefer their explicit evdev mapping.
-        if (shouldPreferMappedKey(keyCode))
+        if (evdev == -1 && shouldPreferMappedKey(keyCode))
             evdev = KeyCodeMapper.getScanCode(keyCode);
 
         if (evdev == -1 && event.getScanCode() != 0)

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values-zh-rTW/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values-zh-rTW/strings.xml
@@ -41,7 +41,7 @@
 
     <!-- Accessibility -->
     <string name="accessibility_switch">無障礙按鍵攔截</string>
-    <string name="accessibility_hint">透過無障礙服務攔截功能鍵（Fn、F1-F12 等）。如果外接鍵盤的 Fn 組合鍵無法傳到桌面，請啟用此項。需要在系統 設定 &gt; 無障礙 中授予無障礙權限（僅需一次）。</string>
+    <string name="accessibility_hint">透過無障礙服務攔截功能鍵（Fn、F1-F12 等），並將平板鍵盤回報的返回／瀏覽器上一頁鍵轉換為 ESC。如果外接鍵盤的 Fn 組合鍵或 ESC 無法正確傳到桌面，請啟用此項。需要在系統 設定 &gt; 無障礙 中授予無障礙權限（僅需一次）。</string>
 
     <!-- Extra keys bar -->
     <string name="extra_keys_mode_label">擴充按鍵列模式</string>

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
@@ -41,7 +41,7 @@
 
     <!-- Accessibility -->
     <string name="accessibility_switch">无障碍按键拦截</string>
-    <string name="accessibility_hint">通过无障碍服务拦截功能键（Fn、F1-F12 等）。如果外接键盘的 Fn 组合键无法传到桌面，请启用此项。需要在系统 设置 &gt; 无障碍 中授予无障碍权限（仅需一次）。</string>
+    <string name="accessibility_hint">通过无障碍服务拦截功能键（Fn、F1-F12 等），并将平板键盘上报的返回/浏览器后退键转换为 ESC。如果外接键盘的 Fn 组合键或 ESC 无法正确传到桌面，请启用此项。需要在系统 设置 &gt; 无障碍 中授予无障碍权限（仅需一次）。</string>
 
     <!-- Extra keys bar -->
     <string name="extra_keys_mode_label">扩展按键栏模式</string>

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
@@ -41,7 +41,7 @@
 
     <!-- Accessibility -->
     <string name="accessibility_switch">Accessibility Key Interception</string>
-    <string name="accessibility_hint">Intercept function keys (Fn, F1-F12 etc.) via AccessibilityService. Enable this if external keyboard Fn combos don\'t reach the desktop. Requires Accessibility permission granted in system Settings &gt; Accessibility (one-time).</string>
+    <string name="accessibility_hint">Intercept function keys (Fn, F1-F12 etc.) via AccessibilityService and convert tablet-keyboard Back/Browser Back to ESC. Enable this if external keyboard Fn combos or ESC don\'t reach the desktop correctly. Requires Accessibility permission granted in system Settings &gt; Accessibility (one-time).</string>
 
     <!-- Extra keys bar -->
     <string name="extra_keys_mode_label">Extra keys bar mode</string>


### PR DESCRIPTION
有些设备的ESC按键其实是KEYCODE_BACK 或 Browser Back，影响使用Anland的体验，本pr解决此类问题，将按键正确映射