### PR TITLE
[功能增强] 给触摸板与鼠标增加 "捕获外接指针选项" 

### DIFF
--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -114,11 +114,32 @@ public class MainActivity extends Activity
     // ==================== 触摸板相关设置 ====================
     public static final String KEY_TOUCHPAD_MODE = "touchpad_mode";
     public static final String KEY_MOUSE_ACCEL = "mouse_speed"; // 名称仍为 speed，实际控制加速度强度
+    // Capture an external mouse as a relative pointer so it cannot reach the
+    // Android screen edges while playing.  This is deliberately opt-in: existing
+    // installations keep the old absolute-pointer behaviour until the user enables it.
+    public static final String KEY_POINTER_CAPTURE = "pointer_capture";
 
     // Routing gate: when on, non-mouse touches go to the virtual touchpad.
     private boolean isTouchpadMode = true;
     // Finger-gesture touchpad (relative motion, taps, drag, two-finger scroll).
     private VirtualTouchpad virtualTouchpad;
+
+    // Pointer-capture state.  Android delivers captured mouse events as
+    // SOURCE_MOUSE_RELATIVE directly to the view hierarchy, bypassing
+    // Activity.onGenericMotionEvent/onTouchEvent.  Keep a virtual absolute cursor
+    // for the compositor protocol, which requires both an absolute position and a
+    // relative delta for every motion event.
+    private boolean pointerCaptureEnabled = false;
+    private boolean pointerCaptureSuppressed = false;
+    // Tracks the Back key whose DOWN released pointer capture, so only its matching
+    // UP is swallowed. Device/downTime matching prevents a stale missing UP from
+    // consuming a later, unrelated Back press.
+    private boolean pointerCaptureBackUpPending = false;
+    private boolean pointerCaptureBackWildcard = false;
+    private int pointerCaptureBackDeviceId = 0;
+    private long pointerCaptureBackDownTime = 0L;
+    private float pointerX = Float.NaN;
+    private float pointerY = Float.NaN;
 
     static {
         // Loads the single shared .so backing MainActivity, Native and
@@ -169,6 +190,14 @@ public class MainActivity extends Activity
         }
         if (hasFocus && clipboard != null) {
             clipboard.pushClipboard();
+        }
+        if (mRoot != null) {
+            if (hasFocus)
+                mRoot.post(this::syncPointerCapture);
+            else {
+                clearPointerCaptureBackTracking();
+                releasePointerCapture(false);
+            }
         }
     }
 
@@ -338,9 +367,32 @@ public class MainActivity extends Activity
         getWindow().setDecorFitsSystemWindows(false);
 
         surfaceView = new SurfaceView(this);
+        // Give the content view an explicit focus target. Pointer-captured events
+        // are routed along the focused-view path; the root override below then
+        // intercepts them before the focused child handles them.
+        surfaceView.setFocusable(true);
+        surfaceView.setFocusableInTouchMode(true);
         systemIme = new SystemIME(this, this, mNative);
 
-        FrameLayout root = new FrameLayout(this);
+        // Pointer-captured mouse events are dispatched by ViewRootImpl to the
+        // focused view hierarchy, not to Activity.onGenericMotionEvent(). Intercept
+        // them at the root before they are routed to the hidden IME or any overlay;
+        // this keeps capture working even while the soft keyboard owns focus.
+        FrameLayout root = new FrameLayout(this) {
+            @Override
+            public boolean dispatchCapturedPointerEvent(MotionEvent event) {
+                if (handleCapturedPointerEvent(event))
+                    return true;
+                return super.dispatchCapturedPointerEvent(event);
+            }
+
+            @Override
+            public void dispatchPointerCaptureChanged(boolean hasCapture) {
+                super.dispatchPointerCaptureChanged(hasCapture);
+                if (!hasCapture)
+                    releaseAllMouseButtons();
+            }
+        };
         root.addView(surfaceView, new FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,
             FrameLayout.LayoutParams.MATCH_PARENT));
@@ -397,14 +449,22 @@ public class MainActivity extends Activity
         // the view starts GONE and a GONE view is never measured.
 
         setContentView(root);
+        // Establish a focused descendant after attachment so the DecorView routes
+        // captured-pointer events through our content root even when the extra-keys
+        // bar is hidden.
+        surfaceView.requestFocus();
         surfaceView.getHolder().addCallback(this);
 
         root.setOnApplyWindowInsetsListener((v, insets) -> {
             // When the IME hides by any means (toggle, system back, or the IME's
             // own close button), release the hidden input so its focus state
             // stays in sync — otherwise reopening needs a second press.
-            if (!insets.isVisible(WindowInsets.Type.ime()))
+            if (!insets.isVisible(WindowInsets.Type.ime())) {
+                View focused = getCurrentFocus();
                 systemIme.releaseHiddenInput();
+                if (focused == systemIme.getInputView() || getCurrentFocus() == null)
+                    surfaceView.requestFocus();
+            }
             applyImeInset(insets);
             return v.onApplyWindowInsets(insets);
         });
@@ -417,6 +477,12 @@ public class MainActivity extends Activity
         isTouchpadMode = prefs.getBoolean(KEY_TOUCHPAD_MODE, false);
         virtualTouchpad = new VirtualTouchpad(this, mNative);
         virtualTouchpad.setAccelStrength(prefs.getFloat(KEY_MOUSE_ACCEL, 1.0f));
+        pointerCaptureEnabled = prefs.getBoolean(KEY_POINTER_CAPTURE, false);
+
+        // Requesting capture before the window is attached is a no-op. The post
+        // below covers the initial attach; onWindowFocusChanged() retries after a
+        // focus transition (including returning from Settings).
+        root.post(this::syncPointerCapture);
 
         registerWindow();
     }
@@ -508,6 +574,201 @@ public class MainActivity extends Activity
         surfaceView.setPointerIcon(PointerIcon.getSystemIcon(this, PointerIcon.TYPE_NULL));
     }
 
+    /** Keep the window's pointer-capture state in sync with the saved setting. */
+    private void syncPointerCapture() {
+        if (mRoot == null)
+            return;
+
+        boolean shouldCapture = pointerCaptureEnabled
+                && !pointerCaptureSuppressed
+                && mRoot.hasWindowFocus();
+        if (shouldCapture) {
+            if (!mRoot.hasPointerCapture()) {
+                // The request is window-wide.  Calling it on the root is safe even
+                // when the hidden IME currently owns focus; the root override above
+                // intercepts the resulting captured events first.
+                mRoot.requestPointerCapture();
+            }
+        } else if (mRoot.hasPointerCapture()) {
+            mRoot.releasePointerCapture();
+        }
+    }
+
+    /** Release capture, optionally keeping it off until the next mouse click. */
+    private void releasePointerCapture(boolean suppressUntilClick) {
+        if (suppressUntilClick)
+            pointerCaptureSuppressed = true;
+        releaseAllMouseButtons();
+        if (mRoot != null && mRoot.hasPointerCapture())
+            mRoot.releasePointerCapture();
+    }
+
+    private void clearPointerCaptureBackTracking() {
+        pointerCaptureBackUpPending = false;
+        pointerCaptureBackWildcard = false;
+        pointerCaptureBackDeviceId = 0;
+        pointerCaptureBackDownTime = 0L;
+    }
+
+    private void trackPointerCaptureBack(KeyEvent event) {
+        pointerCaptureBackUpPending = true;
+        pointerCaptureBackWildcard = event == null;
+        if (event != null) {
+            pointerCaptureBackDeviceId = event.getDeviceId();
+            pointerCaptureBackDownTime = event.getDownTime();
+        }
+    }
+
+    private boolean matchesTrackedPointerCaptureBack(KeyEvent event) {
+        return pointerCaptureBackUpPending
+                && (pointerCaptureBackWildcard
+                    || (pointerCaptureBackDeviceId == event.getDeviceId()
+                        && pointerCaptureBackDownTime == event.getDownTime()));
+    }
+
+    /**
+     * Release capture for a non-mouse Android Back key and consume exactly the
+     * matching DOWN/UP pair. Shared by the normal Activity and accessibility-key
+     * paths so the setting behaves identically with interception enabled.
+     */
+    private boolean handlePointerCaptureBackKey(KeyEvent event) {
+        if (event.getKeyCode() != KeyEvent.KEYCODE_BACK || isMouseKeyEvent(event))
+            return false;
+
+        if (event.getAction() == KeyEvent.ACTION_DOWN) {
+            if (event.getRepeatCount() > 0)
+                return matchesTrackedPointerCaptureBack(event);
+
+            // A fresh DOWN invalidates any pending state left by an OEM that did
+            // not deliver the previous UP.
+            clearPointerCaptureBackTracking();
+            if (mRoot != null && mRoot.hasPointerCapture()) {
+                releasePointerCapture(true);
+                trackPointerCaptureBack(event);
+                showPointerCaptureReleasedToast();
+                return true;
+            }
+            return false;
+        }
+
+        if (event.getAction() == KeyEvent.ACTION_UP
+                && matchesTrackedPointerCaptureBack(event)) {
+            clearPointerCaptureBackTracking();
+            return true;
+        }
+        return false;
+    }
+
+    private void showPointerCaptureReleasedToast() {
+        android.widget.Toast.makeText(this, R.string.pointer_capture_released,
+                android.widget.Toast.LENGTH_SHORT).show();
+    }
+
+    private void requestPointerCaptureAfterClick() {
+        if (!pointerCaptureEnabled || mRoot == null)
+            return;
+        pointerCaptureSuppressed = false;
+        mRoot.post(this::syncPointerCapture);
+    }
+
+    private int pointerViewWidth() {
+        if (viewWidth > 0)
+            return viewWidth;
+        if (surfaceView != null && surfaceView.getWidth() > 0)
+            return surfaceView.getWidth();
+        return mRoot != null ? mRoot.getWidth() : 0;
+    }
+
+    private int pointerViewHeight() {
+        if (viewHeight > 0)
+            return viewHeight;
+        if (surfaceView != null && surfaceView.getHeight() > 0)
+            return surfaceView.getHeight();
+        return mRoot != null ? mRoot.getHeight() : 0;
+    }
+
+    private void ensurePointerPosition() {
+        int width = pointerViewWidth();
+        int height = pointerViewHeight();
+        if (width <= 0 || height <= 0)
+            return;
+        if (!Float.isFinite(pointerX))
+            pointerX = width / 2f;
+        if (!Float.isFinite(pointerY))
+            pointerY = height / 2f;
+        pointerX = Math.max(0f, Math.min(pointerX, width));
+        pointerY = Math.max(0f, Math.min(pointerY, height));
+    }
+
+    private float pointerScaleX() {
+        return (customScreenWidth > 0 && pointerViewWidth() > 0)
+                ? (float) customScreenWidth / pointerViewWidth() : 1.0f;
+    }
+
+    private float pointerScaleY() {
+        return (customScreenHeight > 0 && pointerViewHeight() > 0)
+                ? (float) customScreenHeight / pointerViewHeight() : 1.0f;
+    }
+
+    /**
+     * Handle a mouse event delivered through View pointer capture.  Captured
+     * mouse coordinates are deltas (getX/getY), not screen coordinates.
+     */
+    private boolean handleCapturedPointerEvent(MotionEvent event) {
+        if (!event.isFromSource(InputDevice.SOURCE_MOUSE_RELATIVE))
+            return false;
+        if (mNative == null)
+            return true;
+
+        int action = event.getActionMasked();
+        if (action == MotionEvent.ACTION_MOVE || action == MotionEvent.ACTION_HOVER_MOVE) {
+            // Relative mouse samples can be batched.  Consume every historical
+            // sample so fast movements do not lose deltas between frames.
+            for (int i = 0; i < event.getHistorySize(); i++) {
+                sendCapturedMouseMotion(event.getHistoricalX(0, i),
+                        event.getHistoricalY(0, i));
+            }
+            sendCapturedMouseMotion(event.getX(), event.getY());
+        }
+
+        if (action == MotionEvent.ACTION_SCROLL) {
+            float vScroll = event.getAxisValue(MotionEvent.AXIS_VSCROLL);
+            float hScroll = event.getAxisValue(MotionEvent.AXIS_HSCROLL);
+            if (vScroll != 0f)
+                mNative.sendMouseScroll(0, -vScroll * 10f);
+            if (hScroll != 0f)
+                mNative.sendMouseScroll(1, hScroll * 10f);
+        }
+
+        // Button state is present on motion, button, and down/up events.  Keeping
+        // this diff in one place also handles mice that report button actions as
+        // ACTION_BUTTON_PRESS/RELEASE instead of ACTION_DOWN/UP.
+        updateMouseButtonState(event.getButtonState());
+        return true;
+    }
+
+    private void sendCapturedMouseMotion(float dx, float dy) {
+        if (!Float.isFinite(dx) || !Float.isFinite(dy)
+                || (dx == 0f && dy == 0f))
+            return;
+        ensurePointerPosition();
+        int width = pointerViewWidth();
+        int height = pointerViewHeight();
+        if (width <= 0 || height <= 0)
+            return;
+
+        pointerX = Math.max(0f, Math.min(pointerX + dx, width));
+        pointerY = Math.max(0f, Math.min(pointerY + dy, height));
+        float scaleX = pointerScaleX();
+        float scaleY = pointerScaleY();
+        // Keep the absolute position clamped, but preserve the raw relative delta
+        // (scaled into the output coordinate space).  This is important for games:
+        // movement continues to be reported even while the virtual cursor is at an
+        // output edge.
+        mNative.sendMouseMotion(pointerX * scaleX, pointerY * scaleY,
+                dx * scaleX, dy * scaleY);
+    }
+
     @Override
     protected void onResume() {
         super.onResume();
@@ -579,6 +840,12 @@ public class MainActivity extends Activity
         SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         isTouchpadMode = prefs.getBoolean(KEY_TOUCHPAD_MODE, false);
         virtualTouchpad.setAccelStrength(prefs.getFloat(KEY_MOUSE_ACCEL, 1.0f));
+        pointerCaptureEnabled = prefs.getBoolean(KEY_POINTER_CAPTURE, false);
+        // A manual Back-key release lasts until the next click or lifecycle
+        // transition. Returning from Settings starts a fresh capture session.
+        pointerCaptureSuppressed = false;
+        if (mRoot != null)
+            mRoot.post(this::syncPointerCapture);
 
         // The socket pref may have been edited in Settings; keep our dedup key current.
         registerWindow();
@@ -590,6 +857,8 @@ public class MainActivity extends Activity
         // Socket-missing bounce: no pipeline exists, so skip teardown (mNative is
         // null) and don't let the jump to Settings trigger any of it.
         if (mForceSettings) return;
+        clearPointerCaptureBackTracking();
+        releasePointerCapture(false);
         NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
         if (nm != null) nm.cancel(NOTIFICATION_ID);
         DisplayManager dm = getSystemService(DisplayManager.class);
@@ -600,6 +869,7 @@ public class MainActivity extends Activity
 
     @Override
     protected void onDestroy() {
+        releasePointerCapture(false);
         if (mRegisteredSocket != null) {
             sWindowsBySocket.remove(mRegisteredSocket, this);
             mRegisteredSocket = null;
@@ -704,6 +974,7 @@ public class MainActivity extends Activity
         Log.i(TAG, "surfaceChanged: " + width + "x" + height);
         viewWidth = width;
         viewHeight = height;
+        ensurePointerPosition();
         surfaceReady = true;
         // Same ordering guarantee as onResume: camera service settled before connect.
         applyCameraState();
@@ -716,11 +987,14 @@ public class MainActivity extends Activity
 
         // ===== 更新屏幕尺寸并重置平滑状态 =====
         virtualTouchpad.onSurfaceChanged();
+        if (mRoot != null)
+            mRoot.post(this::syncPointerCapture);
     }
 
     @Override
     public void surfaceDestroyed(SurfaceHolder holder) {
         surfaceReady = false;
+        releasePointerCapture(false);
         mNative.stop();
     }
 
@@ -889,20 +1163,33 @@ public class MainActivity extends Activity
                 .getString(KEY_EXTRA_KEYS_MODE, "always");
         if ("with_keyboard".equals(mode))
             setExtraKeysBarVisible(visible);
+        if (!visible && surfaceView != null) {
+            surfaceView.requestFocus();
+            if (mRoot != null)
+                mRoot.post(this::syncPointerCapture);
+        }
     }
 
     // ================================================================
-    // 原有 onTouchEvent 仅在最前面插入了一个分支判断，其余原封不动
+    // Route touchscreen gestures and ordinary (non-captured) mouse events.
     // ================================================================
     @Override
     public boolean onTouchEvent(MotionEvent event) {
+        boolean mouseEvent = isMouseEvent(event);
+        if (mouseEvent && event.getActionMasked() == MotionEvent.ACTION_DOWN
+                && pointerCaptureEnabled && mRoot != null
+                && !mRoot.hasPointerCapture()) {
+            // A Back-key release leaves the pointer free long enough for the user
+            // to move/click normally; the next click starts a new capture session.
+            requestPointerCaptureAfterClick();
+        }
+
         // ===== 触摸板模式优先处理（仅针对非鼠标触摸事件） =====
-        if (isTouchpadMode && !isMouseEvent(event)) {
+        if (isTouchpadMode && !mouseEvent) {
             return virtualTouchpad.onTouch(event);
         }
 
-        // 以下为原有代码，一字未改
-        if (isMouseEvent(event)) {
+        if (mouseEvent) {
             int cls = event.getClassification();
             if (cls == CLASSIFICATION_TWO_FINGER_SWIPE)
                 return handleTouchpadScroll(event);
@@ -917,6 +1204,11 @@ public class MainActivity extends Activity
     public boolean onGenericMotionEvent(MotionEvent event) {
         if (isMouseEvent(event)) {
             int action = event.getActionMasked();
+            if (action == MotionEvent.ACTION_BUTTON_PRESS
+                    && pointerCaptureEnabled && mRoot != null
+                    && !mRoot.hasPointerCapture()) {
+                requestPointerCaptureAfterClick();
+            }
             if (action == MotionEvent.ACTION_HOVER_MOVE) {
                         
                 // Масштабирование
@@ -925,6 +1217,9 @@ public class MainActivity extends Activity
                 float scaleY = (customScreenHeight > 0 && viewHeight > 0) ? 
                         (float)customScreenHeight / viewHeight : 1.0f;
         
+                pointerX = event.getX();
+                pointerY = event.getY();
+                ensurePointerPosition();
                 mNative.sendMouseMotion(event.getX()*scaleX, event.getY()*scaleY,
                                       event.getAxisValue(MotionEvent.AXIS_RELATIVE_X),
                                       event.getAxisValue(MotionEvent.AXIS_RELATIVE_Y));
@@ -939,12 +1234,24 @@ public class MainActivity extends Activity
                     mNative.sendMouseScroll(1, hScroll * 10);
                 return true;
             }
+            if (action == MotionEvent.ACTION_BUTTON_PRESS
+                    || action == MotionEvent.ACTION_BUTTON_RELEASE) {
+                updateMouseButtonState(event.getButtonState());
+                return true;
+            }
         }
         return super.onGenericMotionEvent(event);
     }
 
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (handlePointerCaptureBackKey(event))
+            return true;
+        // Mouse Back is already forwarded as BTN_SIDE from the MotionEvent path.
+        // Swallow Android's duplicate KEYCODE_BACK so it neither releases capture
+        // nor toggles the extra-keys bar.
+        if (keyCode == KeyEvent.KEYCODE_BACK && isMouseKeyEvent(event))
+            return true;
         if (event.getRepeatCount() > 0)
             return true;
 
@@ -968,18 +1275,28 @@ public class MainActivity extends Activity
     }
 
     // Some OEM ROMs (notably Xiaomi/HyperOS) dispatch Back via onBackPressed()
-    // instead of onKeyDown().  Without this override the default Activity
-    // onBackPressed() calls finish() — the app just exits.
-    // Keep this empty (same approach as Termux-X11): the actual Back key
-    // handling lives in onKeyDown(); this override simply prevents the
-    // system from finishing the activity via gesture navigation.
+    // instead of onKeyDown(). Release an active pointer capture here; otherwise
+    // keep swallowing Back (same approach as Termux-X11) so the Activity does not
+    // unexpectedly finish via gesture navigation.
     @Override
     public void onBackPressed() {
+        if (mRoot != null && mRoot.hasPointerCapture()) {
+            releasePointerCapture(true);
+            // There is no KeyEvent on this OEM path. Use a wildcard so a trailing
+            // Back UP, if one still arrives, is consumed; a fresh DOWN clears it.
+            trackPointerCaptureBack(null);
+            showPointerCaptureReleasedToast();
+            return;
+        }
     }
 
     // Called from KeyInterceptor (accessibility service) to handle keys that
     // the normal onKeyDown/onKeyUp might miss (e.g. Fn combos).
     public boolean handleAccessibilityKey(KeyEvent event) {
+        if (handlePointerCaptureBackKey(event))
+            return true;
+        if (event.getKeyCode() == KeyEvent.KEYCODE_BACK && isMouseKeyEvent(event))
+            return true;
         if (event.getRepeatCount() > 0)
             return true;
 
@@ -1037,6 +1354,10 @@ public class MainActivity extends Activity
 
     @Override
     public boolean onKeyUp(int keyCode, KeyEvent event) {
+        if (handlePointerCaptureBackKey(event))
+            return true;
+        if (keyCode == KeyEvent.KEYCODE_BACK && isMouseKeyEvent(event))
+            return true;
         forwardKeyToLinux(event);
         return true;
     }
@@ -1055,6 +1376,26 @@ public class MainActivity extends Activity
         {MotionEvent.BUTTON_FORWARD,   0x114}, // BTN_EXTRA
     };
 
+    private void updateMouseButtonState(int currentBS) {
+        for (int[] btn : BUTTON_MAP) {
+            boolean wasDown = (savedBS & btn[0]) != 0;
+            boolean isDown  = (currentBS & btn[0]) != 0;
+            if (wasDown != isDown && mNative != null)
+                mNative.sendMouseButton(btn[1], isDown);
+        }
+        savedBS = currentBS;
+    }
+
+    private void releaseAllMouseButtons() {
+        if (savedBS == 0)
+            return;
+        for (int[] btn : BUTTON_MAP) {
+            if ((savedBS & btn[0]) != 0 && mNative != null)
+                mNative.sendMouseButton(btn[1], false);
+        }
+        savedBS = 0;
+    }
+
     private boolean isMouseEvent(MotionEvent event) {
         int source = event.getSource();
         if ((source & InputDevice.SOURCE_TOUCHSCREEN) == InputDevice.SOURCE_TOUCHSCREEN)
@@ -1064,6 +1405,11 @@ public class MainActivity extends Activity
         int toolType = event.getToolType(event.getActionIndex());
         return toolType == MotionEvent.TOOL_TYPE_MOUSE
             || toolType == MotionEvent.TOOL_TYPE_FINGER;
+    }
+
+    private boolean isMouseKeyEvent(KeyEvent event) {
+        return event.isFromSource(InputDevice.SOURCE_MOUSE)
+                || event.isFromSource(InputDevice.SOURCE_MOUSE_RELATIVE);
     }
 
     private boolean handleMouseEvent(MotionEvent event) {
@@ -1081,16 +1427,14 @@ public class MainActivity extends Activity
             dx = (event.getX() - event.getHistoricalX(0, last))*scaleX;
             dy = (event.getY() - event.getHistoricalY(0, last))*scaleY;
         }
+        if (Float.isFinite(event.getX()) && Float.isFinite(event.getY())) {
+            pointerX = event.getX();
+            pointerY = event.getY();
+            ensurePointerPosition();
+        }
         mNative.sendMouseMotion(event.getX() * scaleX, event.getY() * scaleY, dx, dy);
 
-        int currentBS = event.getButtonState();
-        for (int[] btn : BUTTON_MAP) {
-            boolean wasDown = (savedBS & btn[0]) != 0;
-            boolean isDown  = (currentBS & btn[0]) != 0;
-            if (wasDown != isDown)
-                mNative.sendMouseButton(btn[1], isDown);
-        }
-        savedBS = currentBS;
+        updateMouseButtonState(event.getButtonState());
         return true;
     }
 

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -10,6 +10,7 @@ import android.app.PendingIntent;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
+import android.graphics.Matrix;
 import android.hardware.display.DisplayManager;
 import android.content.SharedPreferences;
 import android.os.Build;
@@ -123,6 +124,10 @@ public class MainActivity extends Activity
     private boolean isTouchpadMode = true;
     // Finger-gesture touchpad (relative motion, taps, drag, two-finger scroll).
     private VirtualTouchpad virtualTouchpad;
+    // Reuses the original VirtualTouchpad gesture state machine for raw
+    // SOURCE_TOUCHPAD events. Its movement output is intentionally ignored;
+    // raw relative axes still go through the capture-specific cursor adapter.
+    private VirtualTouchpad capturedTouchpadRecognizer;
 
     // Pointer-capture state. Android delivers captured mouse/touchpad events
     // directly to the view hierarchy, bypassing
@@ -141,23 +146,15 @@ public class MainActivity extends Activity
     private float pointerX = Float.NaN;
     private float pointerY = Float.NaN;
 
-    // Raw hardware-touchpad gesture state while pointer capture is active.
-    // Android exposes touchpad finger positions and relative axes directly in
-    // this mode, so Anland must provide basic cursor/scroll/tap interpretation.
-    private static final long CAPTURED_TOUCHPAD_TAP_TIMEOUT_MS = 300;
+    // Raw hardware-touchpad coordinate state while pointer capture is active.
+    // Gesture recognition itself is shared with VirtualTouchpad above.
     private float capturedTouchpadAccel = 1.0f;
-    private int capturedTouchpadTouchSlop = 8;
-    private int capturedTouchpadMaxPointers = 0;
-    private float capturedTouchpadTravel = 0f;
-    private boolean capturedTouchpadGestureActive = false;
-    private boolean capturedTouchpadHadButton = false;
-    private boolean capturedTouchpadTwoFingerTapCandidate = false;
-    private long capturedTouchpadTapDownTime = 0L;
     private boolean capturedTouchpadBaselineValid = false;
     private int capturedTouchpadBaselinePointers = 0;
     private float capturedTouchpadLastCentroidX = 0f;
     private float capturedTouchpadLastCentroidY = 0f;
     private final float[] capturedTouchpadResolvedDelta = new float[2];
+    private final Matrix capturedTouchpadTransform = new Matrix();
 
     static {
         // Loads the single shared .so backing MainActivity, Native and
@@ -424,8 +421,6 @@ public class MainActivity extends Activity
         // count / height) comes from the user's JSON config; see buildExtraKeysBar.
         mRoot = root;
         mDensity = getResources().getDisplayMetrics().density;
-        capturedTouchpadTouchSlop = android.view.ViewConfiguration.get(this)
-                .getScaledTouchSlop();
         mKeyboardFloating = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
             .getBoolean(KEY_KEYBOARD_FLOATING, true);
         buildExtraKeysBar();
@@ -498,6 +493,28 @@ public class MainActivity extends Activity
         SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         isTouchpadMode = prefs.getBoolean(KEY_TOUCHPAD_MODE, false);
         virtualTouchpad = new VirtualTouchpad(this, mNative);
+        capturedTouchpadRecognizer = new VirtualTouchpad(this, mNative,
+                new VirtualTouchpad.Output() {
+                    @Override
+                    public void onMotion(float dx, float dy) {
+                        // Cursor motion is handled from AXIS_RELATIVE_X/Y below.
+                        // Keeping this callback empty lets the original class
+                        // remain the single source of truth for tap/drag/scroll
+                        // state without duplicating its movement output.
+                    }
+
+                    @Override
+                    public void onScroll(int axis, float value) {
+                        if (mNative != null)
+                            mNative.sendMouseScroll(axis, value);
+                    }
+
+                    @Override
+                    public void onButton(int button, boolean pressed) {
+                        if (mNative != null)
+                            mNative.sendMouseButton(button, pressed);
+                    }
+                });
         capturedTouchpadAccel = Math.max(0.5f,
                 Math.min(10.0f, prefs.getFloat(KEY_MOUSE_ACCEL, 1.0f)));
         virtualTouchpad.setAccelStrength(capturedTouchpadAccel);
@@ -782,85 +799,78 @@ public class MainActivity extends Activity
     }
 
     /**
-     * Pointer capture exposes a hardware touchpad as raw SOURCE_TOUCHPAD input:
-     * getX/getY are positions on the pad, while AXIS_RELATIVE_X/Y are movement.
-     * Interpret the common gestures locally so the trackpad remains useful while
-     * its Android cursor is locked.
+     * Feed raw capture events through the original VirtualTouchpad recognizer,
+     * while keeping raw relative-axis motion in the capture-specific backend.
      */
     private boolean handleCapturedTouchpadEvent(MotionEvent event) {
         int action = event.getActionMasked();
-        if (event.getButtonState() != 0
+        int pointerCount = event.getPointerCount();
+        boolean hasButton = event.getButtonState() != 0
                 || action == MotionEvent.ACTION_BUTTON_PRESS
-                || action == MotionEvent.ACTION_BUTTON_RELEASE) {
-            capturedTouchpadHadButton = true;
+                || action == MotionEvent.ACTION_BUTTON_RELEASE;
+        boolean canceled = action == MotionEvent.ACTION_CANCEL
+                || ((action == MotionEvent.ACTION_POINTER_UP
+                    || action == MotionEvent.ACTION_UP)
+                    && (event.getFlags() & MotionEvent.FLAG_CANCELED) != 0);
+        int classification = event.getClassification();
+        boolean unsupportedGesture = pointerCount >= 3
+                || classification == CLASSIFICATION_PINCH
+                || classification == CLASSIFICATION_MULTI_FINGER_SWIPE;
+        boolean explicitScroll = (action == MotionEvent.ACTION_MOVE
+                || action == MotionEvent.ACTION_HOVER_MOVE)
+                && hasCapturedTouchpadScrollAxes(event);
+        boolean scrollEvent = action == MotionEvent.ACTION_SCROLL || explicitScroll;
+
+        if (canceled || unsupportedGesture) {
+            if (capturedTouchpadRecognizer != null)
+                capturedTouchpadRecognizer.cancel();
+            capturedTouchpadBaselineValid = false;
+        } else if (scrollEvent) {
+            // Absolute capture normally supplies raw pointer coordinates, but a
+            // few drivers still emit scroll axes. They must cancel a pending tap
+            // before its final ACTION_UP.
+            if (capturedTouchpadRecognizer != null)
+                capturedTouchpadRecognizer.cancel();
+            for (int i = 0; i < event.getHistorySize(); i++)
+                sendCapturedTouchpadScrollAxes(event, i);
+            sendCapturedTouchpadScrollAxes(event, -1);
+            capturedTouchpadBaselineValid = false;
+        } else if (hasButton) {
+            if (capturedTouchpadRecognizer != null)
+                capturedTouchpadRecognizer.cancel();
+        } else if (capturedTouchpadRecognizer != null) {
+            MotionEvent gestureEvent = normalizeCapturedTouchpadEvent(event);
+            try {
+                capturedTouchpadRecognizer.onTouch(gestureEvent);
+            } finally {
+                gestureEvent.recycle();
+            }
         }
 
-        switch (action) {
-            case MotionEvent.ACTION_DOWN:
-                resetCapturedTouchpadGesture();
-                capturedTouchpadGestureActive = true;
-                capturedTouchpadTapDownTime = event.getEventTime();
-                capturedTouchpadMaxPointers = Math.max(1, event.getPointerCount());
-                capturedTouchpadHadButton = event.getButtonState() != 0;
-                capturedTouchpadTwoFingerTapCandidate =
-                        event.getPointerCount() == 2;
-                setCapturedTouchpadBaseline(event, -1);
-                break;
-
-            case MotionEvent.ACTION_POINTER_DOWN:
-                capturedTouchpadMaxPointers = Math.max(capturedTouchpadMaxPointers,
-                        event.getPointerCount());
-                if (event.getPointerCount() == 2) {
-                    // Match VirtualTouchpad: the right-click gesture starts only
-                    // when a real second pointer appears. Ignore any movement made
-                    // by the first finger before the second one touched down.
-                    capturedTouchpadTwoFingerTapCandidate = true;
-                    capturedTouchpadTravel = 0f;
-                } else if (event.getPointerCount() > 2) {
-                    capturedTouchpadTwoFingerTapCandidate = false;
-                }
-                setCapturedTouchpadBaseline(event, -1);
-                break;
-
-            case MotionEvent.ACTION_MOVE:
-            case MotionEvent.ACTION_HOVER_MOVE:
-                capturedTouchpadMaxPointers = Math.max(capturedTouchpadMaxPointers,
-                        event.getPointerCount());
-                for (int i = 0; i < event.getHistorySize(); i++)
-                    processCapturedTouchpadSample(event, i);
-                processCapturedTouchpadSample(event, -1);
-                break;
-
-            case MotionEvent.ACTION_SCROLL:
-                capturedTouchpadTwoFingerTapCandidate = false;
-                capturedTouchpadTravel = capturedTouchpadTouchSlop + 1f;
-                for (int i = 0; i < event.getHistorySize(); i++)
-                    sendCapturedTouchpadScrollAxes(event, i);
-                sendCapturedTouchpadScrollAxes(event, -1);
-                break;
-
-            case MotionEvent.ACTION_POINTER_UP:
-                capturedTouchpadMaxPointers = Math.max(capturedTouchpadMaxPointers,
-                        event.getPointerCount());
-                if ((event.getFlags() & MotionEvent.FLAG_CANCELED) != 0)
-                    capturedTouchpadTwoFingerTapCandidate = false;
-                if (event.getPointerCount() - 1 == 1)
-                    // Match the original VirtualTouchpad state machine: once one
-                    // finger remains, measure the tap timeout from this transition.
-                    capturedTouchpadTapDownTime = event.getEventTime();
-                // The event still contains the leaving pointer. Re-anchor on the
-                // next sample so removing a finger cannot jump the cursor.
-                capturedTouchpadBaselineValid = false;
-                break;
-
-            case MotionEvent.ACTION_UP:
-                maybeSendCapturedTouchpadTap(event);
-                resetCapturedTouchpadGesture();
-                break;
-
-            case MotionEvent.ACTION_CANCEL:
-                resetCapturedTouchpadGesture();
-                break;
+        // A physical button cancels tap recognition, but it must not stop the
+        // relative cursor stream: touchpad click-drag still needs motion.
+        if (!canceled && !unsupportedGesture && !scrollEvent) {
+            switch (action) {
+                case MotionEvent.ACTION_DOWN:
+                    setCapturedTouchpadBaseline(event, -1);
+                    break;
+                case MotionEvent.ACTION_POINTER_DOWN:
+                case MotionEvent.ACTION_POINTER_UP:
+                    // A pointer-count transition must not create a cursor jump.
+                    capturedTouchpadBaselineValid = false;
+                    break;
+                case MotionEvent.ACTION_MOVE:
+                case MotionEvent.ACTION_HOVER_MOVE:
+                    if (pointerCount == 1) {
+                        for (int i = 0; i < event.getHistorySize(); i++)
+                            processCapturedTouchpadMotionSample(event, i);
+                        processCapturedTouchpadMotionSample(event, -1);
+                    }
+                    break;
+                case MotionEvent.ACTION_UP:
+                    capturedTouchpadBaselineValid = false;
+                    break;
+            }
         }
 
         if (action == MotionEvent.ACTION_CANCEL)
@@ -870,83 +880,52 @@ public class MainActivity extends Activity
         return true;
     }
 
-    private void processCapturedTouchpadSample(MotionEvent event, int historyPos) {
-        int pointerCount = event.getPointerCount();
-        if (pointerCount <= 0)
+    private void processCapturedTouchpadMotionSample(MotionEvent event,
+                                                      int historyPos) {
+        if (event.getPointerCount() != 1)
             return;
-
-        // Three/four-finger Android system gestures are intentionally consumed
-        // while captured, but are not translated into desktop pointer movement.
-        if (pointerCount >= 3) {
-            setCapturedTouchpadBaseline(event, historyPos);
-            capturedTouchpadTravel = capturedTouchpadTouchSlop + 1f;
-            capturedTouchpadTwoFingerTapCandidate = false;
-            return;
-        }
-
-        int classification = event.getClassification();
-        if (classification == CLASSIFICATION_PINCH
-                || classification == CLASSIFICATION_MULTI_FINGER_SWIPE) {
-            setCapturedTouchpadBaseline(event, historyPos);
-            capturedTouchpadTravel = capturedTouchpadTouchSlop + 1f;
-            capturedTouchpadTwoFingerTapCandidate = false;
-            return;
-        }
-        boolean twoFingerScroll = !capturedTouchpadHadButton
-                && (pointerCount == 2
-                    || classification == CLASSIFICATION_TWO_FINGER_SWIPE);
-
-        if (twoFingerScroll) {
-            float gestureX = capturedTouchpadAxis(event,
-                    MotionEvent.AXIS_GESTURE_SCROLL_X_DISTANCE, 0, historyPos);
-            float gestureY = capturedTouchpadAxis(event,
-                    MotionEvent.AXIS_GESTURE_SCROLL_Y_DISTANCE, 0, historyPos);
-            if (gestureX != 0f || gestureY != 0f) {
-                capturedTouchpadTravel += (float) Math.hypot(gestureX, gestureY);
-                // A non-zero synthesized scroll axis is already an explicit
-                // gesture, so it can never finish as a tap.
-                if (pointerCount == 2)
-                    capturedTouchpadTwoFingerTapCandidate = false;
-                if (gestureY != 0f)
-                    mNative.sendMouseScroll(0, gestureY);
-                if (gestureX != 0f)
-                    mNative.sendMouseScroll(1, -gestureX);
-                setCapturedTouchpadBaseline(event, historyPos);
-                return;
-            }
-
-            float dx = averageCapturedTouchpadRelativeAxis(event,
-                    MotionEvent.AXIS_RELATIVE_X, historyPos);
-            float dy = averageCapturedTouchpadRelativeAxis(event,
-                    MotionEvent.AXIS_RELATIVE_Y, historyPos);
-            float[] fallback = applyCapturedTouchpadAbsoluteFallback(
-                    event, historyPos, dx, dy);
-            dx = fallback[0];
-            dy = fallback[1];
-            capturedTouchpadTravel += (float) Math.hypot(dx, dy);
-            if (pointerCount == 2
-                    && capturedTouchpadTravel > capturedTouchpadTouchSlop)
-                capturedTouchpadTwoFingerTapCandidate = false;
-            if (dy != 0f)
-                mNative.sendMouseScroll(0, -dy * 0.5f);
-            if (dx != 0f)
-                mNative.sendMouseScroll(1, dx * 0.5f);
-            return;
-        }
-
         float dx = capturedTouchpadAxis(event, MotionEvent.AXIS_RELATIVE_X,
                 0, historyPos);
         float dy = capturedTouchpadAxis(event, MotionEvent.AXIS_RELATIVE_Y,
                 0, historyPos);
         float[] fallback = applyCapturedTouchpadAbsoluteFallback(
                 event, historyPos, dx, dy);
-        dx = fallback[0];
-        dy = fallback[1];
-        capturedTouchpadTravel += (float) Math.hypot(dx, dy);
-        if (capturedTouchpadMaxPointers == 2
-                && capturedTouchpadTravel > capturedTouchpadTouchSlop)
-            capturedTouchpadTwoFingerTapCandidate = false;
-        sendCapturedTouchpadMotion(dx, dy);
+        sendCapturedTouchpadMotion(fallback[0], fallback[1]);
+    }
+
+    /**
+     * Convert device-specific pad coordinates to view pixels for the original
+     * recognizer. SOURCE_CLASS_POSITION ignores MotionEvent transforms on newer
+     * Android releases, so use a temporary touchscreen source on the copy.
+     */
+    private MotionEvent normalizeCapturedTouchpadEvent(MotionEvent event) {
+        MotionEvent copy = MotionEvent.obtain(event);
+        copy.setSource(InputDevice.SOURCE_TOUCHSCREEN);
+
+        int width = pointerViewWidth();
+        int height = pointerViewHeight();
+        InputDevice device = event.getDevice();
+        InputDevice.MotionRange xRange = device == null ? null
+                : device.getMotionRange(MotionEvent.AXIS_X,
+                        InputDevice.SOURCE_TOUCHPAD);
+        InputDevice.MotionRange yRange = device == null ? null
+                : device.getMotionRange(MotionEvent.AXIS_Y,
+                        InputDevice.SOURCE_TOUCHPAD);
+        if (device != null && xRange == null)
+            xRange = device.getMotionRange(MotionEvent.AXIS_X);
+        if (device != null && yRange == null)
+            yRange = device.getMotionRange(MotionEvent.AXIS_Y);
+
+        if (width > 0 && height > 0 && xRange != null && yRange != null
+                && xRange.getRange() > 0f && yRange.getRange() > 0f) {
+            float sx = width / xRange.getRange();
+            float sy = height / yRange.getRange();
+            capturedTouchpadTransform.setScale(sx, sy);
+            capturedTouchpadTransform.postTranslate(-xRange.getMin() * sx,
+                    -yRange.getMin() * sy);
+            copy.transform(capturedTouchpadTransform);
+        }
+        return copy;
     }
 
     /** Use absolute pad coordinates only when a driver omits the relative axes. */
@@ -1002,6 +981,8 @@ public class MainActivity extends Activity
     }
 
     private void sendCapturedTouchpadScrollAxes(MotionEvent event, int historyPos) {
+        if (event.getPointerCount() <= 0)
+            return;
         float vScroll = capturedTouchpadAxis(event, MotionEvent.AXIS_VSCROLL,
                 0, historyPos);
         float hScroll = capturedTouchpadAxis(event, MotionEvent.AXIS_HSCROLL,
@@ -1024,13 +1005,24 @@ public class MainActivity extends Activity
             mNative.sendMouseScroll(1, -gestureX);
     }
 
-    private float averageCapturedTouchpadRelativeAxis(MotionEvent event,
-                                                       int axis, int historyPos) {
-        int pointerCount = event.getPointerCount();
-        float total = 0f;
-        for (int i = 0; i < pointerCount; i++)
-            total += capturedTouchpadAxis(event, axis, i, historyPos);
-        return pointerCount > 0 ? total / pointerCount : 0f;
+    private boolean hasCapturedTouchpadScrollAxes(MotionEvent event) {
+        if (event.getPointerCount() <= 0)
+            return false;
+        for (int i = 0; i < event.getHistorySize(); i++) {
+            if (capturedTouchpadAxis(event, MotionEvent.AXIS_VSCROLL, 0, i) != 0f
+                    || capturedTouchpadAxis(event, MotionEvent.AXIS_HSCROLL, 0, i) != 0f
+                    || capturedTouchpadAxis(event,
+                            MotionEvent.AXIS_GESTURE_SCROLL_X_DISTANCE, 0, i) != 0f
+                    || capturedTouchpadAxis(event,
+                            MotionEvent.AXIS_GESTURE_SCROLL_Y_DISTANCE, 0, i) != 0f)
+                return true;
+        }
+        return capturedTouchpadAxis(event, MotionEvent.AXIS_VSCROLL, 0, -1) != 0f
+                || capturedTouchpadAxis(event, MotionEvent.AXIS_HSCROLL, 0, -1) != 0f
+                || capturedTouchpadAxis(event,
+                        MotionEvent.AXIS_GESTURE_SCROLL_X_DISTANCE, 0, -1) != 0f
+                || capturedTouchpadAxis(event,
+                        MotionEvent.AXIS_GESTURE_SCROLL_Y_DISTANCE, 0, -1) != 0f;
     }
 
     private float capturedTouchpadAxis(MotionEvent event, int axis,
@@ -1066,36 +1058,9 @@ public class MainActivity extends Activity
         capturedTouchpadBaselineValid = capturedTouchpadBaselinePointers > 0;
     }
 
-    private void maybeSendCapturedTouchpadTap(MotionEvent event) {
-        long duration = event.getEventTime() - capturedTouchpadTapDownTime;
-        if (!capturedTouchpadGestureActive || capturedTouchpadHadButton
-                || (event.getFlags() & MotionEvent.FLAG_CANCELED) != 0
-                || duration >= CAPTURED_TOUCHPAD_TAP_TIMEOUT_MS)
-            return;
-
-        int button = 0;
-        if (capturedTouchpadMaxPointers == 2) {
-            if (!capturedTouchpadTwoFingerTapCandidate
-                    || capturedTouchpadTravel > capturedTouchpadTouchSlop)
-                return;
-            button = 0x111;
-        } else if (capturedTouchpadMaxPointers == 1
-                && capturedTouchpadTravel <= capturedTouchpadTouchSlop) {
-            button = 0x110;
-        }
-        if (button != 0) {
-            mNative.sendMouseButton(button, true);
-            mNative.sendMouseButton(button, false);
-        }
-    }
-
     private void resetCapturedTouchpadGesture() {
-        capturedTouchpadMaxPointers = 0;
-        capturedTouchpadTravel = 0f;
-        capturedTouchpadGestureActive = false;
-        capturedTouchpadHadButton = false;
-        capturedTouchpadTwoFingerTapCandidate = false;
-        capturedTouchpadTapDownTime = 0L;
+        if (capturedTouchpadRecognizer != null)
+            capturedTouchpadRecognizer.cancel();
         capturedTouchpadBaselineValid = false;
         capturedTouchpadBaselinePointers = 0;
         capturedTouchpadLastCentroidX = 0f;

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -114,9 +114,9 @@ public class MainActivity extends Activity
     // ==================== 触摸板相关设置 ====================
     public static final String KEY_TOUCHPAD_MODE = "touchpad_mode";
     public static final String KEY_MOUSE_ACCEL = "mouse_speed"; // 名称仍为 speed，实际控制加速度强度
-    // Capture an external mouse as a relative pointer so it cannot reach the
-    // Android screen edges while playing.  This is deliberately opt-in: existing
-    // installations keep the old absolute-pointer behaviour until the user enables it.
+    // Capture an external mouse/touchpad as a relative pointer so it cannot reach
+    // the Android screen edges. This is deliberately opt-in: existing installations
+    // keep the old absolute-pointer behaviour until the user enables it.
     public static final String KEY_POINTER_CAPTURE = "pointer_capture";
 
     // Routing gate: when on, non-mouse touches go to the virtual touchpad.
@@ -124,8 +124,8 @@ public class MainActivity extends Activity
     // Finger-gesture touchpad (relative motion, taps, drag, two-finger scroll).
     private VirtualTouchpad virtualTouchpad;
 
-    // Pointer-capture state.  Android delivers captured mouse events as
-    // SOURCE_MOUSE_RELATIVE directly to the view hierarchy, bypassing
+    // Pointer-capture state. Android delivers captured mouse/touchpad events
+    // directly to the view hierarchy, bypassing
     // Activity.onGenericMotionEvent/onTouchEvent.  Keep a virtual absolute cursor
     // for the compositor protocol, which requires both an absolute position and a
     // relative delta for every motion event.
@@ -140,6 +140,24 @@ public class MainActivity extends Activity
     private long pointerCaptureBackDownTime = 0L;
     private float pointerX = Float.NaN;
     private float pointerY = Float.NaN;
+
+    // Raw hardware-touchpad gesture state while pointer capture is active.
+    // Android exposes touchpad finger positions and relative axes directly in
+    // this mode, so Anland must provide basic cursor/scroll/tap interpretation.
+    private static final long CAPTURED_TOUCHPAD_TAP_TIMEOUT_MS = 300;
+    private float capturedTouchpadAccel = 1.0f;
+    private int capturedTouchpadTouchSlop = 8;
+    private int capturedTouchpadMaxPointers = 0;
+    private float capturedTouchpadTravel = 0f;
+    private boolean capturedTouchpadGestureActive = false;
+    private boolean capturedTouchpadHadButton = false;
+    private boolean capturedTouchpadTwoFingerTapCandidate = false;
+    private long capturedTouchpadTapDownTime = 0L;
+    private boolean capturedTouchpadBaselineValid = false;
+    private int capturedTouchpadBaselinePointers = 0;
+    private float capturedTouchpadLastCentroidX = 0f;
+    private float capturedTouchpadLastCentroidY = 0f;
+    private final float[] capturedTouchpadResolvedDelta = new float[2];
 
     static {
         // Loads the single shared .so backing MainActivity, Native and
@@ -374,7 +392,7 @@ public class MainActivity extends Activity
         surfaceView.setFocusableInTouchMode(true);
         systemIme = new SystemIME(this, this, mNative);
 
-        // Pointer-captured mouse events are dispatched by ViewRootImpl to the
+        // Pointer-captured mouse/touchpad events are dispatched by ViewRootImpl to the
         // focused view hierarchy, not to Activity.onGenericMotionEvent(). Intercept
         // them at the root before they are routed to the hidden IME or any overlay;
         // this keeps capture working even while the soft keyboard owns focus.
@@ -389,8 +407,10 @@ public class MainActivity extends Activity
             @Override
             public void dispatchPointerCaptureChanged(boolean hasCapture) {
                 super.dispatchPointerCaptureChanged(hasCapture);
-                if (!hasCapture)
+                if (!hasCapture) {
                     releaseAllMouseButtons();
+                    resetCapturedTouchpadGesture();
+                }
             }
         };
         root.addView(surfaceView, new FrameLayout.LayoutParams(
@@ -404,6 +424,8 @@ public class MainActivity extends Activity
         // count / height) comes from the user's JSON config; see buildExtraKeysBar.
         mRoot = root;
         mDensity = getResources().getDisplayMetrics().density;
+        capturedTouchpadTouchSlop = android.view.ViewConfiguration.get(this)
+                .getScaledTouchSlop();
         mKeyboardFloating = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
             .getBoolean(KEY_KEYBOARD_FLOATING, true);
         buildExtraKeysBar();
@@ -476,7 +498,9 @@ public class MainActivity extends Activity
         SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         isTouchpadMode = prefs.getBoolean(KEY_TOUCHPAD_MODE, false);
         virtualTouchpad = new VirtualTouchpad(this, mNative);
-        virtualTouchpad.setAccelStrength(prefs.getFloat(KEY_MOUSE_ACCEL, 1.0f));
+        capturedTouchpadAccel = Math.max(0.5f,
+                Math.min(10.0f, prefs.getFloat(KEY_MOUSE_ACCEL, 1.0f)));
+        virtualTouchpad.setAccelStrength(capturedTouchpadAccel);
         pointerCaptureEnabled = prefs.getBoolean(KEY_POINTER_CAPTURE, false);
 
         // Requesting capture before the window is attached is a no-op. The post
@@ -594,11 +618,12 @@ public class MainActivity extends Activity
         }
     }
 
-    /** Release capture, optionally keeping it off until the next mouse click. */
+    /** Release capture, optionally keeping it off until the next pointer click. */
     private void releasePointerCapture(boolean suppressUntilClick) {
         if (suppressUntilClick)
             pointerCaptureSuppressed = true;
         releaseAllMouseButtons();
+        resetCapturedTouchpadGesture();
         if (mRoot != null && mRoot.hasPointerCapture())
             mRoot.releasePointerCapture();
     }
@@ -710,15 +735,21 @@ public class MainActivity extends Activity
                 ? (float) customScreenHeight / pointerViewHeight() : 1.0f;
     }
 
-    /**
-     * Handle a mouse event delivered through View pointer capture.  Captured
-     * mouse coordinates are deltas (getX/getY), not screen coordinates.
-     */
+    /** Handle mouse and hardware-touchpad events delivered through pointer capture. */
     private boolean handleCapturedPointerEvent(MotionEvent event) {
-        if (!event.isFromSource(InputDevice.SOURCE_MOUSE_RELATIVE))
+        // A few OEMs combine source capability bits. Prefer the touchpad path
+        // whenever SOURCE_TOUCHPAD is present so raw multi-pointer events still
+        // reach the gesture state machine.
+        boolean touchpad = event.isFromSource(InputDevice.SOURCE_TOUCHPAD);
+        boolean relativeMouse = !touchpad
+                && event.isFromSource(InputDevice.SOURCE_MOUSE_RELATIVE);
+        if (!relativeMouse && !touchpad)
             return false;
         if (mNative == null)
             return true;
+
+        if (touchpad)
+            return handleCapturedTouchpadEvent(event);
 
         int action = event.getActionMasked();
         if (action == MotionEvent.ACTION_MOVE || action == MotionEvent.ACTION_HOVER_MOVE) {
@@ -743,8 +774,332 @@ public class MainActivity extends Activity
         // Button state is present on motion, button, and down/up events.  Keeping
         // this diff in one place also handles mice that report button actions as
         // ACTION_BUTTON_PRESS/RELEASE instead of ACTION_DOWN/UP.
-        updateMouseButtonState(event.getButtonState());
+        if (action == MotionEvent.ACTION_CANCEL)
+            releaseAllMouseButtons();
+        else
+            updateMouseButtonStateFromEvent(event);
         return true;
+    }
+
+    /**
+     * Pointer capture exposes a hardware touchpad as raw SOURCE_TOUCHPAD input:
+     * getX/getY are positions on the pad, while AXIS_RELATIVE_X/Y are movement.
+     * Interpret the common gestures locally so the trackpad remains useful while
+     * its Android cursor is locked.
+     */
+    private boolean handleCapturedTouchpadEvent(MotionEvent event) {
+        int action = event.getActionMasked();
+        if (event.getButtonState() != 0
+                || action == MotionEvent.ACTION_BUTTON_PRESS
+                || action == MotionEvent.ACTION_BUTTON_RELEASE) {
+            capturedTouchpadHadButton = true;
+        }
+
+        switch (action) {
+            case MotionEvent.ACTION_DOWN:
+                resetCapturedTouchpadGesture();
+                capturedTouchpadGestureActive = true;
+                capturedTouchpadTapDownTime = event.getEventTime();
+                capturedTouchpadMaxPointers = Math.max(1, event.getPointerCount());
+                capturedTouchpadHadButton = event.getButtonState() != 0;
+                capturedTouchpadTwoFingerTapCandidate =
+                        event.getPointerCount() == 2;
+                setCapturedTouchpadBaseline(event, -1);
+                break;
+
+            case MotionEvent.ACTION_POINTER_DOWN:
+                capturedTouchpadMaxPointers = Math.max(capturedTouchpadMaxPointers,
+                        event.getPointerCount());
+                if (event.getPointerCount() == 2) {
+                    // Match VirtualTouchpad: the right-click gesture starts only
+                    // when a real second pointer appears. Ignore any movement made
+                    // by the first finger before the second one touched down.
+                    capturedTouchpadTwoFingerTapCandidate = true;
+                    capturedTouchpadTravel = 0f;
+                } else if (event.getPointerCount() > 2) {
+                    capturedTouchpadTwoFingerTapCandidate = false;
+                }
+                setCapturedTouchpadBaseline(event, -1);
+                break;
+
+            case MotionEvent.ACTION_MOVE:
+            case MotionEvent.ACTION_HOVER_MOVE:
+                capturedTouchpadMaxPointers = Math.max(capturedTouchpadMaxPointers,
+                        event.getPointerCount());
+                for (int i = 0; i < event.getHistorySize(); i++)
+                    processCapturedTouchpadSample(event, i);
+                processCapturedTouchpadSample(event, -1);
+                break;
+
+            case MotionEvent.ACTION_SCROLL:
+                capturedTouchpadTwoFingerTapCandidate = false;
+                capturedTouchpadTravel = capturedTouchpadTouchSlop + 1f;
+                for (int i = 0; i < event.getHistorySize(); i++)
+                    sendCapturedTouchpadScrollAxes(event, i);
+                sendCapturedTouchpadScrollAxes(event, -1);
+                break;
+
+            case MotionEvent.ACTION_POINTER_UP:
+                capturedTouchpadMaxPointers = Math.max(capturedTouchpadMaxPointers,
+                        event.getPointerCount());
+                if ((event.getFlags() & MotionEvent.FLAG_CANCELED) != 0)
+                    capturedTouchpadTwoFingerTapCandidate = false;
+                if (event.getPointerCount() - 1 == 1)
+                    // Match the original VirtualTouchpad state machine: once one
+                    // finger remains, measure the tap timeout from this transition.
+                    capturedTouchpadTapDownTime = event.getEventTime();
+                // The event still contains the leaving pointer. Re-anchor on the
+                // next sample so removing a finger cannot jump the cursor.
+                capturedTouchpadBaselineValid = false;
+                break;
+
+            case MotionEvent.ACTION_UP:
+                maybeSendCapturedTouchpadTap(event);
+                resetCapturedTouchpadGesture();
+                break;
+
+            case MotionEvent.ACTION_CANCEL:
+                resetCapturedTouchpadGesture();
+                break;
+        }
+
+        if (action == MotionEvent.ACTION_CANCEL)
+            releaseAllMouseButtons();
+        else
+            updateMouseButtonStateFromEvent(event);
+        return true;
+    }
+
+    private void processCapturedTouchpadSample(MotionEvent event, int historyPos) {
+        int pointerCount = event.getPointerCount();
+        if (pointerCount <= 0)
+            return;
+
+        // Three/four-finger Android system gestures are intentionally consumed
+        // while captured, but are not translated into desktop pointer movement.
+        if (pointerCount >= 3) {
+            setCapturedTouchpadBaseline(event, historyPos);
+            capturedTouchpadTravel = capturedTouchpadTouchSlop + 1f;
+            capturedTouchpadTwoFingerTapCandidate = false;
+            return;
+        }
+
+        int classification = event.getClassification();
+        if (classification == CLASSIFICATION_PINCH
+                || classification == CLASSIFICATION_MULTI_FINGER_SWIPE) {
+            setCapturedTouchpadBaseline(event, historyPos);
+            capturedTouchpadTravel = capturedTouchpadTouchSlop + 1f;
+            capturedTouchpadTwoFingerTapCandidate = false;
+            return;
+        }
+        boolean twoFingerScroll = !capturedTouchpadHadButton
+                && (pointerCount == 2
+                    || classification == CLASSIFICATION_TWO_FINGER_SWIPE);
+
+        if (twoFingerScroll) {
+            float gestureX = capturedTouchpadAxis(event,
+                    MotionEvent.AXIS_GESTURE_SCROLL_X_DISTANCE, 0, historyPos);
+            float gestureY = capturedTouchpadAxis(event,
+                    MotionEvent.AXIS_GESTURE_SCROLL_Y_DISTANCE, 0, historyPos);
+            if (gestureX != 0f || gestureY != 0f) {
+                capturedTouchpadTravel += (float) Math.hypot(gestureX, gestureY);
+                // A non-zero synthesized scroll axis is already an explicit
+                // gesture, so it can never finish as a tap.
+                if (pointerCount == 2)
+                    capturedTouchpadTwoFingerTapCandidate = false;
+                if (gestureY != 0f)
+                    mNative.sendMouseScroll(0, gestureY);
+                if (gestureX != 0f)
+                    mNative.sendMouseScroll(1, -gestureX);
+                setCapturedTouchpadBaseline(event, historyPos);
+                return;
+            }
+
+            float dx = averageCapturedTouchpadRelativeAxis(event,
+                    MotionEvent.AXIS_RELATIVE_X, historyPos);
+            float dy = averageCapturedTouchpadRelativeAxis(event,
+                    MotionEvent.AXIS_RELATIVE_Y, historyPos);
+            float[] fallback = applyCapturedTouchpadAbsoluteFallback(
+                    event, historyPos, dx, dy);
+            dx = fallback[0];
+            dy = fallback[1];
+            capturedTouchpadTravel += (float) Math.hypot(dx, dy);
+            if (pointerCount == 2
+                    && capturedTouchpadTravel > capturedTouchpadTouchSlop)
+                capturedTouchpadTwoFingerTapCandidate = false;
+            if (dy != 0f)
+                mNative.sendMouseScroll(0, -dy * 0.5f);
+            if (dx != 0f)
+                mNative.sendMouseScroll(1, dx * 0.5f);
+            return;
+        }
+
+        float dx = capturedTouchpadAxis(event, MotionEvent.AXIS_RELATIVE_X,
+                0, historyPos);
+        float dy = capturedTouchpadAxis(event, MotionEvent.AXIS_RELATIVE_Y,
+                0, historyPos);
+        float[] fallback = applyCapturedTouchpadAbsoluteFallback(
+                event, historyPos, dx, dy);
+        dx = fallback[0];
+        dy = fallback[1];
+        capturedTouchpadTravel += (float) Math.hypot(dx, dy);
+        if (capturedTouchpadMaxPointers == 2
+                && capturedTouchpadTravel > capturedTouchpadTouchSlop)
+            capturedTouchpadTwoFingerTapCandidate = false;
+        sendCapturedTouchpadMotion(dx, dy);
+    }
+
+    /** Use absolute pad coordinates only when a driver omits the relative axes. */
+    private float[] applyCapturedTouchpadAbsoluteFallback(MotionEvent event,
+                                                           int historyPos,
+                                                           float dx, float dy) {
+        int pointerCount = event.getPointerCount();
+        float centroidX = capturedTouchpadCentroid(event, historyPos, true);
+        float centroidY = capturedTouchpadCentroid(event, historyPos, false);
+        if (dx == 0f && dy == 0f
+                && capturedTouchpadBaselineValid
+                && capturedTouchpadBaselinePointers == pointerCount) {
+            // AXIS_X/Y are device-dependent touchpad units. Normalize the
+            // low-reliability fallback through the device motion ranges before
+            // treating it as a display-pixel delta.
+            dx = (centroidX - capturedTouchpadLastCentroidX)
+                    * capturedTouchpadCoordinateScale(event, MotionEvent.AXIS_X, true);
+            dy = (centroidY - capturedTouchpadLastCentroidY)
+                    * capturedTouchpadCoordinateScale(event, MotionEvent.AXIS_Y, false);
+        }
+        capturedTouchpadLastCentroidX = centroidX;
+        capturedTouchpadLastCentroidY = centroidY;
+        capturedTouchpadBaselinePointers = pointerCount;
+        capturedTouchpadBaselineValid = true;
+        capturedTouchpadResolvedDelta[0] = dx;
+        capturedTouchpadResolvedDelta[1] = dy;
+        return capturedTouchpadResolvedDelta;
+    }
+
+    private float capturedTouchpadCoordinateScale(MotionEvent event, int axis,
+                                                   boolean xAxis) {
+        InputDevice device = event.getDevice();
+        if (device == null)
+            return 0f;
+        InputDevice.MotionRange range = device.getMotionRange(
+                axis, InputDevice.SOURCE_TOUCHPAD);
+        if (range == null)
+            range = device.getMotionRange(axis);
+        float span = range == null ? 0f : range.getRange();
+        int size = xAxis ? pointerViewWidth() : pointerViewHeight();
+        return span > 0f && size > 0 ? size / span : 0f;
+    }
+
+    private void sendCapturedTouchpadMotion(float dx, float dy) {
+        if (dx == 0f && dy == 0f)
+            return;
+        float distance = (float) Math.hypot(dx, dy);
+        float speed = distance / 10.0f;
+        float scale = 1.0f + (capturedTouchpadAccel - 1.0f)
+                * (speed / (1.0f + speed));
+        scale = Math.max(0.3f, Math.min(10.0f, scale));
+        sendCapturedMouseMotion(dx * scale, dy * scale);
+    }
+
+    private void sendCapturedTouchpadScrollAxes(MotionEvent event, int historyPos) {
+        float vScroll = capturedTouchpadAxis(event, MotionEvent.AXIS_VSCROLL,
+                0, historyPos);
+        float hScroll = capturedTouchpadAxis(event, MotionEvent.AXIS_HSCROLL,
+                0, historyPos);
+        if (vScroll != 0f || hScroll != 0f) {
+            if (vScroll != 0f)
+                mNative.sendMouseScroll(0, -vScroll * 10f);
+            if (hScroll != 0f)
+                mNative.sendMouseScroll(1, hScroll * 10f);
+            return;
+        }
+
+        float gestureX = capturedTouchpadAxis(event,
+                MotionEvent.AXIS_GESTURE_SCROLL_X_DISTANCE, 0, historyPos);
+        float gestureY = capturedTouchpadAxis(event,
+                MotionEvent.AXIS_GESTURE_SCROLL_Y_DISTANCE, 0, historyPos);
+        if (gestureY != 0f)
+            mNative.sendMouseScroll(0, gestureY);
+        if (gestureX != 0f)
+            mNative.sendMouseScroll(1, -gestureX);
+    }
+
+    private float averageCapturedTouchpadRelativeAxis(MotionEvent event,
+                                                       int axis, int historyPos) {
+        int pointerCount = event.getPointerCount();
+        float total = 0f;
+        for (int i = 0; i < pointerCount; i++)
+            total += capturedTouchpadAxis(event, axis, i, historyPos);
+        return pointerCount > 0 ? total / pointerCount : 0f;
+    }
+
+    private float capturedTouchpadAxis(MotionEvent event, int axis,
+                                       int pointerIndex, int historyPos) {
+        return historyPos >= 0
+                ? event.getHistoricalAxisValue(axis, pointerIndex, historyPos)
+                : event.getAxisValue(axis, pointerIndex);
+    }
+
+    private float capturedTouchpadCentroid(MotionEvent event, int historyPos,
+                                           boolean xAxis) {
+        int pointerCount = event.getPointerCount();
+        if (pointerCount <= 0)
+            return 0f;
+        float total = 0f;
+        for (int i = 0; i < pointerCount; i++) {
+            if (historyPos >= 0) {
+                total += xAxis ? event.getHistoricalX(i, historyPos)
+                        : event.getHistoricalY(i, historyPos);
+            } else {
+                total += xAxis ? event.getX(i) : event.getY(i);
+            }
+        }
+        return total / pointerCount;
+    }
+
+    private void setCapturedTouchpadBaseline(MotionEvent event, int historyPos) {
+        capturedTouchpadLastCentroidX = capturedTouchpadCentroid(
+                event, historyPos, true);
+        capturedTouchpadLastCentroidY = capturedTouchpadCentroid(
+                event, historyPos, false);
+        capturedTouchpadBaselinePointers = event.getPointerCount();
+        capturedTouchpadBaselineValid = capturedTouchpadBaselinePointers > 0;
+    }
+
+    private void maybeSendCapturedTouchpadTap(MotionEvent event) {
+        long duration = event.getEventTime() - capturedTouchpadTapDownTime;
+        if (!capturedTouchpadGestureActive || capturedTouchpadHadButton
+                || (event.getFlags() & MotionEvent.FLAG_CANCELED) != 0
+                || duration >= CAPTURED_TOUCHPAD_TAP_TIMEOUT_MS)
+            return;
+
+        int button = 0;
+        if (capturedTouchpadMaxPointers == 2) {
+            if (!capturedTouchpadTwoFingerTapCandidate
+                    || capturedTouchpadTravel > capturedTouchpadTouchSlop)
+                return;
+            button = 0x111;
+        } else if (capturedTouchpadMaxPointers == 1
+                && capturedTouchpadTravel <= capturedTouchpadTouchSlop) {
+            button = 0x110;
+        }
+        if (button != 0) {
+            mNative.sendMouseButton(button, true);
+            mNative.sendMouseButton(button, false);
+        }
+    }
+
+    private void resetCapturedTouchpadGesture() {
+        capturedTouchpadMaxPointers = 0;
+        capturedTouchpadTravel = 0f;
+        capturedTouchpadGestureActive = false;
+        capturedTouchpadHadButton = false;
+        capturedTouchpadTwoFingerTapCandidate = false;
+        capturedTouchpadTapDownTime = 0L;
+        capturedTouchpadBaselineValid = false;
+        capturedTouchpadBaselinePointers = 0;
+        capturedTouchpadLastCentroidX = 0f;
+        capturedTouchpadLastCentroidY = 0f;
     }
 
     private void sendCapturedMouseMotion(float dx, float dy) {
@@ -839,7 +1194,9 @@ public class MainActivity extends Activity
         // ===== 重新读取触摸板设置 =====
         SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         isTouchpadMode = prefs.getBoolean(KEY_TOUCHPAD_MODE, false);
-        virtualTouchpad.setAccelStrength(prefs.getFloat(KEY_MOUSE_ACCEL, 1.0f));
+        capturedTouchpadAccel = Math.max(0.5f,
+                Math.min(10.0f, prefs.getFloat(KEY_MOUSE_ACCEL, 1.0f)));
+        virtualTouchpad.setAccelStrength(capturedTouchpadAccel);
         pointerCaptureEnabled = prefs.getBoolean(KEY_POINTER_CAPTURE, false);
         // A manual Back-key release lasts until the next click or lifecycle
         // transition. Returning from Settings starts a fresh capture session.
@@ -1236,7 +1593,7 @@ public class MainActivity extends Activity
             }
             if (action == MotionEvent.ACTION_BUTTON_PRESS
                     || action == MotionEvent.ACTION_BUTTON_RELEASE) {
-                updateMouseButtonState(event.getButtonState());
+                updateMouseButtonStateFromEvent(event);
                 return true;
             }
         }
@@ -1386,6 +1743,18 @@ public class MainActivity extends Activity
         savedBS = currentBS;
     }
 
+    // ACTION_BUTTON_RELEASE may report a stale buttonState on some touchpad
+    // drivers. Use the explicit action button as a correction when available.
+    private void updateMouseButtonStateFromEvent(MotionEvent event) {
+        int buttonState = event.getButtonState();
+        int action = event.getActionMasked();
+        if (action == MotionEvent.ACTION_BUTTON_PRESS)
+            buttonState |= event.getActionButton();
+        else if (action == MotionEvent.ACTION_BUTTON_RELEASE)
+            buttonState &= ~event.getActionButton();
+        updateMouseButtonState(buttonState);
+    }
+
     private void releaseAllMouseButtons() {
         if (savedBS == 0)
             return;
@@ -1434,7 +1803,7 @@ public class MainActivity extends Activity
         }
         mNative.sendMouseMotion(event.getX() * scaleX, event.getY() * scaleY, dx, dy);
 
-        updateMouseButtonState(event.getButtonState());
+        updateMouseButtonStateFromEvent(event);
         return true;
     }
 

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
@@ -67,6 +67,7 @@ public class SettingsActivity extends Activity {
     // ===== 新增：触摸板 Key =====
     private static final String KEY_TOUCHPAD_MODE = "touchpad_mode";
     private static final String KEY_MOUSE_ACCEL = "mouse_speed";
+    private static final String KEY_POINTER_CAPTURE = "pointer_capture";
 
     // Latency presets: target buffer in ms (0 = auto). The user-visible labels live
     // in the R.array.latency_labels string-array, parallel to this array.
@@ -595,6 +596,25 @@ public class SettingsActivity extends Activity {
         touchpadHint.setTextColor(Color.GRAY);
         touchpadHint.setPadding(0, dp(4), 0, dp(12));
         root.addView(touchpadHint);
+
+        // External mouse pointer capture.  This is opt-in because it changes
+        // Android's mouse event mode from absolute coordinates to relative motion.
+        Switch pointerCaptureSwitch = new Switch(this);
+        pointerCaptureSwitch.setText(R.string.pointer_capture_switch);
+        pointerCaptureSwitch.setTextSize(14);
+        pointerCaptureSwitch.setPadding(0, dp(8), 0, 0);
+        pointerCaptureSwitch.setChecked(prefs.getBoolean(KEY_POINTER_CAPTURE, false));
+        pointerCaptureSwitch.setOnCheckedChangeListener((v, checked) ->
+                getSharedPreferences(PREFS_NAME, MODE_PRIVATE).edit()
+                        .putBoolean(KEY_POINTER_CAPTURE, checked).apply());
+        root.addView(pointerCaptureSwitch);
+
+        TextView pointerCaptureHint = new TextView(this);
+        pointerCaptureHint.setText(R.string.pointer_capture_hint);
+        pointerCaptureHint.setTextSize(12);
+        pointerCaptureHint.setTextColor(Color.GRAY);
+        pointerCaptureHint.setPadding(0, dp(4), 0, dp(12));
+        root.addView(pointerCaptureHint);
 
         // 鼠标加速度（灵敏度）—— 范围 0.5 ~ 10.0
         LinearLayout accelLayout = new LinearLayout(this);

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/VirtualTouchpad.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/VirtualTouchpad.java
@@ -18,6 +18,18 @@ import android.view.WindowManager;
  */
 public final class VirtualTouchpad {
 
+    /**
+     * Optional output used by the pointer-capture adapter.  The original
+     * touchpad path keeps writing directly to Native; a capture instance can
+     * reuse the same gesture state machine while supplying its own movement
+     * and coordinate backend.
+     */
+    interface Output {
+        void onMotion(float dx, float dy);
+        void onScroll(int axis, float value);
+        void onButton(int button, boolean pressed);
+    }
+
     // 状态机
     private static final int STATE_IDLE = 0;
     private static final int STATE_ONE_FINGER = 1;
@@ -65,10 +77,21 @@ public final class VirtualTouchpad {
 
     private final Context context;
     private final Native mNative;
+    private final Output output;
+    // The original on-screen touchpad emits an explicit double-click sequence.
+    // Captured hardware taps already arrive as separate clicks, so emitting a
+    // second synthetic pair would turn two taps into three clicks.
+    private final boolean synthesizeDoubleTap;
 
     VirtualTouchpad(Context context, Native n) {
+        this(context, n, null);
+    }
+
+    VirtualTouchpad(Context context, Native n, Output output) {
         this.context = context;
         this.mNative = n;
+        this.output = output;
+        this.synthesizeDoubleTap = output == null;
         touchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
         updateScreenSize();
         mouseX = screenWidth / 2f;
@@ -86,6 +109,46 @@ public final class VirtualTouchpad {
         mouseX = clamp(mouseX, 0, screenWidth);
         mouseY = clamp(mouseY, 0, screenHeight);
         resetSmoothing();
+    }
+
+    /** Cancel an in-progress gesture when the capture window loses focus. */
+    void cancel() {
+        if (isDraggingActive)
+            sendButton(0x110, false);
+        resetTouchpadState();
+        resetSmoothing();
+        lastTapTime = 0L;
+        lastTapX = 0f;
+        lastTapY = 0f;
+    }
+
+    private void sendButton(int button, boolean pressed) {
+        if (output != null)
+            output.onButton(button, pressed);
+        else if (mNative != null)
+            mNative.sendMouseButton(button, pressed);
+    }
+
+    private void sendScroll(int axis, float value) {
+        if (output != null)
+            output.onScroll(axis, value);
+        else if (mNative != null)
+            mNative.sendMouseScroll(axis, value);
+    }
+
+    /**
+     * Send a relative movement to an adapter, or preserve the original
+     * absolute-cursor behavior for the normal virtual touchpad.
+     */
+    private void sendMotion(float dx, float dy) {
+        if (output != null) {
+            output.onMotion(dx, dy);
+            return;
+        }
+        mouseX = clamp(mouseX + dx, 0, screenWidth);
+        mouseY = clamp(mouseY + dy, 0, screenHeight);
+        if (mNative != null)
+            mNative.sendMouseMotion(mouseX, mouseY, 0f, 0f);
     }
 
     // ==================== 触摸板手势及辅助方法 ====================
@@ -115,7 +178,7 @@ public final class VirtualTouchpad {
                 isSingleTapCandidate = false;
                 isLongPressPossible = false;
                 if (currentState == STATE_DRAGGING) {
-                    mNative.sendMouseButton(0x110, false);
+                    sendButton(0x110, false);
                     isDraggingActive = false;
                 }
                 if (pointerCount == 2) {
@@ -139,6 +202,12 @@ public final class VirtualTouchpad {
                     if (dist > touchSlop) {
                         isLongPressPossible = false;
                         isSingleTapCandidate = false;
+                        // The original state machine intentionally preserves
+                        // this flag through POINTER_UP. In capture mode, clear
+                        // it once the remaining finger actually moves so a
+                        // scroll/drag cannot finish as a right-click.
+                        if (output != null)
+                            isTwoFingerTapCandidate = false;
                     }
 
                     if (isLongPressPossible && !hasLongPressed &&
@@ -146,10 +215,13 @@ public final class VirtualTouchpad {
                         hasLongPressed = true;
                         currentState = STATE_DRAGGING;
                         isDraggingActive = true;
-                        mNative.sendMouseButton(0x110, true);
+                        sendButton(0x110, true);
                         mouseX = clamp(mouseX, 0, screenWidth);
                         mouseY = clamp(mouseY, 0, screenHeight);
-                        mNative.sendMouseMotion(mouseX, mouseY, 0f, 0f);
+                        if (output != null)
+                            output.onMotion(0f, 0f);
+                        else if (mNative != null)
+                            mNative.sendMouseMotion(mouseX, mouseY, 0f, 0f);
                         resetSmoothing();
                         break;
                     }
@@ -171,9 +243,7 @@ public final class VirtualTouchpad {
 
                         float moveX = smoothDx * dynamicScale;
                         float moveY = smoothDy * dynamicScale;
-                        mouseX = clamp(mouseX + moveX, 0, screenWidth);
-                        mouseY = clamp(mouseY + moveY, 0, screenHeight);
-                        mNative.sendMouseMotion(mouseX, mouseY, 0f, 0f);
+                        sendMotion(moveX, moveY);
                     }
 
                     lastX1 = x;
@@ -191,10 +261,10 @@ public final class VirtualTouchpad {
                         if (Math.abs(avgDx) > 1 || Math.abs(avgDy) > 1) {
                             isTwoFingerTapCandidate = false;
                             if (Math.abs(avgDy) > Math.abs(avgDx) * 0.5) {
-                                mNative.sendMouseScroll(0, -avgDy * 0.5f);
+                                sendScroll(0, -avgDy * 0.5f);
                             }
                             if (Math.abs(avgDx) > Math.abs(avgDy) * 0.5) {
-                                mNative.sendMouseScroll(1, avgDx * 0.5f);
+                                sendScroll(1, avgDx * 0.5f);
                             }
                             lastX1 = x1;
                             lastY1 = y1;
@@ -228,7 +298,7 @@ public final class VirtualTouchpad {
                 boolean isQuickTap = duration < 300;
 
                 if (isDraggingActive) {
-                    mNative.sendMouseButton(0x110, false);
+                    sendButton(0x110, false);
                     isDraggingActive = false;
                     resetTouchpadState();
                     resetSmoothing();
@@ -236,8 +306,8 @@ public final class VirtualTouchpad {
                 }
 
                 if (isTwoFingerTapCandidate && isQuickTap) {
-                    mNative.sendMouseButton(0x111, true);
-                    mNative.sendMouseButton(0x111, false);
+                    sendButton(0x111, true);
+                    sendButton(0x111, false);
                     resetTouchpadState();
                     resetSmoothing();
                     return true;
@@ -246,17 +316,18 @@ public final class VirtualTouchpad {
                 if (currentState == STATE_ONE_FINGER && isSingleTapCandidate && isQuickTap) {
                     long gap = event.getEventTime() - lastTapTime;
                     float dist = (float) Math.hypot(lastX1 - lastTapX, lastY1 - lastTapY);
-                    if (gap < 300 && dist < touchSlop && !isDoubleTapPending) {
+                    if (synthesizeDoubleTap && gap < 300 && dist < touchSlop
+                            && !isDoubleTapPending) {
                         isDoubleTapPending = true;
-                        mNative.sendMouseButton(0x110, true);
-                        mNative.sendMouseButton(0x110, false);
-                        mNative.sendMouseButton(0x110, true);
-                        mNative.sendMouseButton(0x110, false);
+                        sendButton(0x110, true);
+                        sendButton(0x110, false);
+                        sendButton(0x110, true);
+                        sendButton(0x110, false);
                         isDoubleTapPending = false;
                         lastTapTime = 0;
                     } else {
-                        mNative.sendMouseButton(0x110, true);
-                        mNative.sendMouseButton(0x110, false);
+                        sendButton(0x110, true);
+                        sendButton(0x110, false);
                         lastTapTime = event.getEventTime();
                         lastTapX = lastX1;
                         lastTapY = lastY1;
@@ -272,7 +343,7 @@ public final class VirtualTouchpad {
             }
             case MotionEvent.ACTION_CANCEL: {
                 if (isDraggingActive) {
-                    mNative.sendMouseButton(0x110, false);
+                    sendButton(0x110, false);
                     isDraggingActive = false;
                 }
                 resetTouchpadState();

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values-zh-rTW/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values-zh-rTW/strings.xml
@@ -17,7 +17,7 @@
     <string name="cat_keyboard_title">鍵盤與按鍵</string>
     <string name="cat_keyboard_subtitle">按鍵綁定、無障礙與擴充按鍵列</string>
     <string name="cat_touchpad_title">觸控板與滑鼠</string>
-    <string name="cat_touchpad_subtitle">觸控板模式與指標靈敏度</string>
+    <string name="cat_touchpad_subtitle">觸控板模式、指標擷取與靈敏度</string>
     <string name="cat_connection_subtitle">socket、root、麥克風、相機與音訊延遲</string>
     <string name="cat_resolution_subtitle">輸出解析度與預設</string>
     <string name="cat_general_title">一般</string>
@@ -67,7 +67,10 @@
     <!-- Touchpad -->
     <string name="touchpad_mode_switch">觸控板模式（相對移動）</string>
     <string name="touchpad_hint">開啟：手指滑動移動滑鼠游標（相對）。關閉：觸控直接對應到螢幕（絕對）。</string>
-    <string name="mouse_sensitivity_label">滑鼠靈敏度（加速度）</string>
+    <string name="pointer_capture_switch">擷取外接滑鼠指標（遊戲模式）</string>
+    <string name="pointer_capture_hint">開啟後會將外接滑鼠鎖定在桌面畫面內並使用相對移動，移到螢幕頂部或底部不會呼出 Android 狀態列或導覽列。按 Android 返回鍵可暫時釋放，點擊桌面畫面重新擷取；觸控不受影響。</string>
+    <string name="pointer_capture_released">滑鼠已釋放。點擊桌面畫面即可重新擷取。</string>
+    <string name="mouse_sensitivity_label">觸控板指標靈敏度（加速度）</string>
     <string name="mouse_accel_value">%1$.1f 倍</string>
 
     <!-- Connection -->

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values-zh-rTW/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values-zh-rTW/strings.xml
@@ -67,9 +67,9 @@
     <!-- Touchpad -->
     <string name="touchpad_mode_switch">觸控板模式（相對移動）</string>
     <string name="touchpad_hint">開啟：手指滑動移動滑鼠游標（相對）。關閉：觸控直接對應到螢幕（絕對）。</string>
-    <string name="pointer_capture_switch">擷取外接滑鼠指標（遊戲模式）</string>
-    <string name="pointer_capture_hint">開啟後會將外接滑鼠鎖定在桌面畫面內並使用相對移動，移到螢幕頂部或底部不會呼出 Android 狀態列或導覽列。按 Android 返回鍵可暫時釋放，點擊桌面畫面重新擷取；觸控不受影響。</string>
-    <string name="pointer_capture_released">滑鼠已釋放。點擊桌面畫面即可重新擷取。</string>
+    <string name="pointer_capture_switch">擷取外接指標</string>
+    <string name="pointer_capture_hint">開啟後會將外接滑鼠或觸控板鎖定在桌面畫面內並使用相對移動，移到螢幕頂部或底部不會呼出 Android 狀態列或導覽列。按 Android 返回鍵可暫時釋放，點擊桌面畫面重新擷取；螢幕觸控不受影響。</string>
+    <string name="pointer_capture_released">外接指標已釋放。點擊桌面畫面即可重新擷取。</string>
     <string name="mouse_sensitivity_label">觸控板指標靈敏度（加速度）</string>
     <string name="mouse_accel_value">%1$.1f 倍</string>
 

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
@@ -67,9 +67,9 @@
     <!-- Touchpad -->
     <string name="touchpad_mode_switch">触摸板模式（相对移动）</string>
     <string name="touchpad_hint">开启：手指滑动移动鼠标光标（相对）。关闭：触摸直接映射到屏幕（绝对）。</string>
-    <string name="pointer_capture_switch">捕获外接鼠标指针（游戏模式）</string>
-    <string name="pointer_capture_hint">开启后将外接鼠标锁定在桌面画面内并使用相对移动，移到屏幕顶部或底部不会呼出 Android 状态栏或导航栏。按 Android 返回键可暂时释放，点击桌面画面重新捕获；触摸不受影响。</string>
-    <string name="pointer_capture_released">鼠标已释放。点击桌面画面可重新捕获。</string>
+    <string name="pointer_capture_switch">捕获外接指针</string>
+    <string name="pointer_capture_hint">开启后将外接鼠标或触摸板锁定在桌面画面内并使用相对移动，移到屏幕顶部或底部不会呼出 Android 状态栏或导航栏。按 Android 返回键可暂时释放，点击桌面画面重新捕获；屏幕触摸不受影响。</string>
+    <string name="pointer_capture_released">外接指针已释放。点击桌面画面可重新捕获。</string>
     <string name="mouse_sensitivity_label">触摸板指针灵敏度（加速度）</string>
     <string name="mouse_accel_value">%1$.1f 倍</string>
 

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
@@ -17,7 +17,7 @@
     <string name="cat_keyboard_title">键盘与按键</string>
     <string name="cat_keyboard_subtitle">按键绑定、无障碍与扩展按键栏</string>
     <string name="cat_touchpad_title">触摸板与鼠标</string>
-    <string name="cat_touchpad_subtitle">触摸板模式与指针灵敏度</string>
+    <string name="cat_touchpad_subtitle">触摸板模式、指针捕获与灵敏度</string>
     <string name="cat_connection_subtitle">套接字、root、麦克风、摄像头与音频延迟</string>
     <string name="cat_resolution_subtitle">输出分辨率与预设</string>
     <string name="cat_general_title">通用</string>
@@ -67,7 +67,10 @@
     <!-- Touchpad -->
     <string name="touchpad_mode_switch">触摸板模式（相对移动）</string>
     <string name="touchpad_hint">开启：手指滑动移动鼠标光标（相对）。关闭：触摸直接映射到屏幕（绝对）。</string>
-    <string name="mouse_sensitivity_label">鼠标灵敏度（加速度）</string>
+    <string name="pointer_capture_switch">捕获外接鼠标指针（游戏模式）</string>
+    <string name="pointer_capture_hint">开启后将外接鼠标锁定在桌面画面内并使用相对移动，移到屏幕顶部或底部不会呼出 Android 状态栏或导航栏。按 Android 返回键可暂时释放，点击桌面画面重新捕获；触摸不受影响。</string>
+    <string name="pointer_capture_released">鼠标已释放。点击桌面画面可重新捕获。</string>
+    <string name="mouse_sensitivity_label">触摸板指针灵敏度（加速度）</string>
     <string name="mouse_accel_value">%1$.1f 倍</string>
 
     <!-- Connection -->

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
@@ -17,7 +17,7 @@
     <string name="cat_keyboard_title">Keyboard &amp; Keys</string>
     <string name="cat_keyboard_subtitle">Key binding, accessibility &amp; extra keys bar</string>
     <string name="cat_touchpad_title">Touchpad &amp; Mouse</string>
-    <string name="cat_touchpad_subtitle">Touchpad mode &amp; pointer sensitivity</string>
+    <string name="cat_touchpad_subtitle">Touchpad mode, pointer capture &amp; sensitivity</string>
     <string name="cat_connection_subtitle">Socket, root, mic, camera &amp; audio latency</string>
     <string name="cat_resolution_subtitle">Output resolution &amp; presets</string>
     <string name="cat_general_title">General</string>
@@ -67,7 +67,10 @@
     <!-- Touchpad -->
     <string name="touchpad_mode_switch">Touchpad Mode (relative movement)</string>
     <string name="touchpad_hint">ON: finger slides move mouse cursor (relative). OFF: touch maps directly to screen (absolute).</string>
-    <string name="mouse_sensitivity_label">Mouse Sensitivity (Acceleration)</string>
+    <string name="pointer_capture_switch">Capture external mouse pointer (game mode)</string>
+    <string name="pointer_capture_hint">Locks an external mouse to the desktop view and uses relative movement, so reaching the top or bottom edge will not reveal Android system bars. Use Android Back to release temporarily; click the desktop view to capture again. Touch input is unaffected.</string>
+    <string name="pointer_capture_released">Mouse released. Click the desktop view to capture it again.</string>
+    <string name="mouse_sensitivity_label">Touchpad Pointer Sensitivity (Acceleration)</string>
     <string name="mouse_accel_value">%1$.1fx</string>
 
     <!-- Connection -->

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
@@ -67,9 +67,9 @@
     <!-- Touchpad -->
     <string name="touchpad_mode_switch">Touchpad Mode (relative movement)</string>
     <string name="touchpad_hint">ON: finger slides move mouse cursor (relative). OFF: touch maps directly to screen (absolute).</string>
-    <string name="pointer_capture_switch">Capture external mouse pointer (game mode)</string>
-    <string name="pointer_capture_hint">Locks an external mouse to the desktop view and uses relative movement, so reaching the top or bottom edge will not reveal Android system bars. Use Android Back to release temporarily; click the desktop view to capture again. Touch input is unaffected.</string>
-    <string name="pointer_capture_released">Mouse released. Click the desktop view to capture it again.</string>
+    <string name="pointer_capture_switch">Capture external pointer</string>
+    <string name="pointer_capture_hint">Locks an external mouse or touchpad to the desktop view and uses relative movement, so reaching the top or bottom edge will not reveal Android system bars. Use Android Back to release temporarily; click the desktop view to capture again. Screen touch input is unaffected.</string>
+    <string name="pointer_capture_released">External pointer released. Click the desktop view to capture it again.</string>
     <string name="mouse_sensitivity_label">Touchpad Pointer Sensitivity (Acceleration)</string>
     <string name="mouse_accel_value">%1$.1fx</string>
 


### PR DESCRIPTION
捕获外接指针: 开启后，将外接鼠标或触摸板锁定在桌面画面内进行相对移动

已经在我的设备上测试成功（一加平板 2Pro)