### PR TITLE
feat: 添加自定义分辨率的自动拉伸开关

### DIFF
--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -96,6 +96,11 @@ public class MainActivity extends Activity
     private boolean mKeyboardFloating = false;
     // Persistent "tap to open Settings" notification, toggleable in Settings > General.
     private static final String KEY_NOTIFICATION_ENABLED = "settings_notification";
+    private static final String KEY_AUTO_STRETCH = "auto_stretch";
+    private boolean autoStretch = true;
+    private float surfaceOffsetX = 0f;
+    private float surfaceOffsetY = 0f;
+    private float surfaceScale = 1f;
     // System soft-keyboard bridge: hidden input, text forwarding and toggle.
     private SystemIME systemIme;
     private int mImeBottom = 0;   // last IME bottom inset
@@ -579,6 +584,8 @@ public class MainActivity extends Activity
         SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         isTouchpadMode = prefs.getBoolean(KEY_TOUCHPAD_MODE, false);
         virtualTouchpad.setAccelStrength(prefs.getFloat(KEY_MOUSE_ACCEL, 1.0f));
+        autoStretch = prefs.getBoolean(KEY_AUTO_STRETCH, true);
+        relayout();
 
         // The socket pref may have been edited in Settings; keep our dedup key current.
         registerWindow();
@@ -774,12 +781,68 @@ public class MainActivity extends Activity
 
         FrameLayout.LayoutParams lp =
             (FrameLayout.LayoutParams) surfaceView.getLayoutParams();
-        if (lp.bottomMargin != target) {       // skip redundant surface restart
+        
+        if (autoStretch) {
+            lp.width = FrameLayout.LayoutParams.MATCH_PARENT;
+            lp.height = FrameLayout.LayoutParams.MATCH_PARENT;
+            lp.gravity = Gravity.NO_GRAVITY;
+            lp.leftMargin = 0;
+            lp.topMargin = 0;
+            if (lp.bottomMargin != target) {
+                lp.bottomMargin = target;
+                surfaceView.setLayoutParams(lp);
+            }
+        } else {
             lp.bottomMargin = target;
-            surfaceView.setLayoutParams(lp);
+            adjustSurfaceViewLayout(lp);
         }
+        
         if (extraKeysBar != null)
             extraKeysBar.setTranslationY(-mImeBottom);
+    }
+    
+    private void adjustSurfaceViewLayout(FrameLayout.LayoutParams lp) {
+        if (customScreenWidth <= 0 || customScreenHeight <= 0 || mRoot == null) {
+            lp.width = FrameLayout.LayoutParams.MATCH_PARENT;
+            lp.height = FrameLayout.LayoutParams.MATCH_PARENT;
+            lp.gravity = Gravity.NO_GRAVITY;
+            lp.leftMargin = 0;
+            lp.topMargin = 0;
+            surfaceView.setLayoutParams(lp);
+            surfaceOffsetX = 0f;
+            surfaceOffsetY = 0f;
+            surfaceScale = 1f;
+            return;
+        }
+        
+        int parentW = mRoot.getWidth();
+        int parentH = mRoot.getHeight();
+        if (parentW <= 0 || parentH <= 0) {
+            return;
+        }
+        
+        float customRatio = (float) customScreenWidth / customScreenHeight;
+        float screenRatio = (float) parentW / parentH;
+        
+        int surfaceW, surfaceH;
+        if (customRatio > screenRatio) {
+            surfaceW = parentW;
+            surfaceH = (int) (parentW / customRatio);
+        } else {
+            surfaceH = parentH;
+            surfaceW = (int) (parentH * customRatio);
+        }
+        
+        lp.width = surfaceW;
+        lp.height = surfaceH;
+        lp.gravity = Gravity.CENTER;
+        lp.leftMargin = 0;
+        lp.topMargin = 0;
+        surfaceView.setLayoutParams(lp);
+        
+        surfaceOffsetX = (parentW - surfaceW) / 2f;
+        surfaceOffsetY = (parentH - surfaceH) / 2f;
+        surfaceScale = (float) surfaceW / customScreenWidth;
     }
 
     // Show/hide the extra-keys bar and re-apply the layout so the display area
@@ -918,14 +981,20 @@ public class MainActivity extends Activity
         if (isMouseEvent(event)) {
             int action = event.getActionMasked();
             if (action == MotionEvent.ACTION_HOVER_MOVE) {
-                        
-                // Масштабирование
-                float scaleX = (customScreenWidth > 0 && viewWidth > 0) ? 
-                        (float)customScreenWidth / viewWidth : 1.0f;
-                float scaleY = (customScreenHeight > 0 && viewHeight > 0) ? 
-                        (float)customScreenHeight / viewHeight : 1.0f;
+                float nativeX, nativeY;
+                if (autoStretch) {
+                    float scaleX = (customScreenWidth > 0 && viewWidth > 0) ? 
+                            (float)customScreenWidth / viewWidth : 1.0f;
+                    float scaleY = (customScreenHeight > 0 && viewHeight > 0) ? 
+                            (float)customScreenHeight / viewHeight : 1.0f;
+                    nativeX = event.getX() * scaleX;
+                    nativeY = event.getY() * scaleY;
+                } else {
+                    nativeX = (event.getX() - surfaceOffsetX) / surfaceScale;
+                    nativeY = (event.getY() - surfaceOffsetY) / surfaceScale;
+                }
         
-                mNative.sendMouseMotion(event.getX()*scaleX, event.getY()*scaleY,
+                mNative.sendMouseMotion(nativeX, nativeY,
                                       event.getAxisValue(MotionEvent.AXIS_RELATIVE_X),
                                       event.getAxisValue(MotionEvent.AXIS_RELATIVE_Y));
                 return true;
@@ -1070,18 +1139,29 @@ public class MainActivity extends Activity
         float dx = 0f;
         float dy = 0f;
         
-        // Масштабирование
-        float scaleX = (customScreenWidth > 0 && viewWidth > 0) ? 
-                   (float)customScreenWidth / viewWidth : 1.0f;
-        float scaleY = (customScreenHeight > 0 && viewHeight > 0) ? 
-                   (float)customScreenHeight / viewHeight : 1.0f;
-        
-        if (event.getHistorySize() > 0) {
-            int last = event.getHistorySize() - 1;
-            dx = (event.getX() - event.getHistoricalX(0, last))*scaleX;
-            dy = (event.getY() - event.getHistoricalY(0, last))*scaleY;
+        float nativeX, nativeY;
+        if (autoStretch) {
+            float scaleX = (customScreenWidth > 0 && viewWidth > 0) ? 
+                       (float)customScreenWidth / viewWidth : 1.0f;
+            float scaleY = (customScreenHeight > 0 && viewHeight > 0) ? 
+                       (float)customScreenHeight / viewHeight : 1.0f;
+            nativeX = event.getX() * scaleX;
+            nativeY = event.getY() * scaleY;
+            if (event.getHistorySize() > 0) {
+                int last = event.getHistorySize() - 1;
+                dx = (event.getX() - event.getHistoricalX(0, last))*scaleX;
+                dy = (event.getY() - event.getHistoricalY(0, last))*scaleY;
+            }
+        } else {
+            nativeX = (event.getX() - surfaceOffsetX) / surfaceScale;
+            nativeY = (event.getY() - surfaceOffsetY) / surfaceScale;
+            if (event.getHistorySize() > 0) {
+                int last = event.getHistorySize() - 1;
+                dx = (event.getX() - event.getHistoricalX(0, last)) / surfaceScale;
+                dy = (event.getY() - event.getHistoricalY(0, last)) / surfaceScale;
+            }
         }
-        mNative.sendMouseMotion(event.getX() * scaleX, event.getY() * scaleY, dx, dy);
+        mNative.sendMouseMotion(nativeX, nativeY, dx, dy);
 
         int currentBS = event.getButtonState();
         for (int[] btn : BUTTON_MAP) {
@@ -1112,52 +1192,62 @@ public class MainActivity extends Activity
         int pointerIdx = event.getActionIndex();
         int pointerId = event.getPointerId(pointerIdx);
     
-        // Масштабирование
-        float scaleX = (customScreenWidth > 0 && viewWidth > 0) ? 
-                       (float)customScreenWidth / viewWidth : 1.0f;
-        float scaleY = (customScreenHeight > 0 && viewHeight > 0) ? 
-                       (float)customScreenHeight / viewHeight : 1.0f;
-    
         switch (action) {
             case MotionEvent.ACTION_DOWN:
             case MotionEvent.ACTION_POINTER_DOWN:
-                mNative.sendTouch(0, 
-                    event.getX(pointerIdx) * scaleX, 
-                    event.getY(pointerIdx) * scaleY, 
-                    pointerId);
+                float[] downCoords = convertToNativeCoords(event.getX(pointerIdx), event.getY(pointerIdx));
+                mNative.sendTouch(0, downCoords[0], downCoords[1], pointerId);
                 mNative.sendTouchFrame();
                 return true;
             
             case MotionEvent.ACTION_UP:
             case MotionEvent.ACTION_POINTER_UP:
-                mNative.sendTouch(1, 
-                    event.getX(pointerIdx) * scaleX, 
-                    event.getY(pointerIdx) * scaleY, 
-                    pointerId);
+                float[] upCoords = convertToNativeCoords(event.getX(pointerIdx), event.getY(pointerIdx));
+                mNative.sendTouch(1, upCoords[0], upCoords[1], pointerId);
                 mNative.sendTouchFrame();
                 return true;
             
             case MotionEvent.ACTION_MOVE:
                 for (int i = 0; i < event.getPointerCount(); i++) {
-                    mNative.sendTouch(2, 
-                        event.getX(i) * scaleX, 
-                        event.getY(i) * scaleY, 
-                        event.getPointerId(i));
+                    float[] moveCoords = convertToNativeCoords(event.getX(i), event.getY(i));
+                    mNative.sendTouch(2, moveCoords[0], moveCoords[1], event.getPointerId(i));
                 }
                 mNative.sendTouchFrame();
                 return true;
             
             case MotionEvent.ACTION_CANCEL:
                 for (int i = 0; i < event.getPointerCount(); i++) {
-                    mNative.sendTouch(1, 
-                        event.getX(i) * scaleX, 
-                        event.getY(i) * scaleY, 
-                        event.getPointerId(i));
+                    float[] cancelCoords = convertToNativeCoords(event.getX(i), event.getY(i));
+                    mNative.sendTouch(1, cancelCoords[0], cancelCoords[1], event.getPointerId(i));
                 }
                 mNative.sendTouchFrame();
                 return true;
         }
         return false;
+    }
+    
+    private float[] convertToNativeCoords(float x, float y) {
+        if (autoStretch) {
+            float scaleX = (customScreenWidth > 0 && viewWidth > 0) ? 
+                           (float)customScreenWidth / viewWidth : 1.0f;
+            float scaleY = (customScreenHeight > 0 && viewHeight > 0) ? 
+                           (float)customScreenHeight / viewHeight : 1.0f;
+            return new float[]{x * scaleX, y * scaleY};
+        } else {
+            return new float[]{(x - surfaceOffsetX) / surfaceScale, (y - surfaceOffsetY) / surfaceScale};
+        }
+    }
+    
+    private float[] convertMouseToNative(float x, float y) {
+        if (autoStretch) {
+            float scaleX = (customScreenWidth > 0 && viewWidth > 0) ? 
+                           (float)customScreenWidth / viewWidth : 1.0f;
+            float scaleY = (customScreenHeight > 0 && viewHeight > 0) ? 
+                           (float)customScreenHeight / viewHeight : 1.0f;
+            return new float[]{x * scaleX, y * scaleY};
+        } else {
+            return new float[]{x / surfaceScale, y / surfaceScale};
+        }
     }
 
 }

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
@@ -842,6 +842,22 @@ public class SettingsActivity extends Activity {
     hint.setTextColor(Color.GRAY);
     hint.setPadding(0, dp(4), 0, 0);
     root.addView(hint);
+
+    Switch autoStretchSwitch = new Switch(this);
+    autoStretchSwitch.setText(R.string.auto_stretch_switch);
+    autoStretchSwitch.setTextSize(14);
+    autoStretchSwitch.setPadding(0, dp(16), 0, 0);
+    autoStretchSwitch.setChecked(prefs.getBoolean("auto_stretch", true));
+    autoStretchSwitch.setOnCheckedChangeListener((v, checked) ->
+        prefs.edit().putBoolean("auto_stretch", checked).apply());
+    root.addView(autoStretchSwitch);
+
+    TextView autoStretchHint = new TextView(this);
+    autoStretchHint.setText(R.string.auto_stretch_hint);
+    autoStretchHint.setTextSize(12);
+    autoStretchHint.setTextColor(Color.GRAY);
+    autoStretchHint.setPadding(0, dp(4), 0, 0);
+    root.addView(autoStretchHint);
     }
 
     // Maps a res_preset_labels index to {width, height}, or null for the index-0

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
@@ -90,6 +90,8 @@
     <string name="width_hint">宽度（例如 1920）</string>
     <string name="height_hint">高度（例如 1080）</string>
     <string name="resolution_hint">选择预设或手动输入数值。填 0 表示原生分辨率。\"Screen ×\" 会按本设备面板（横向）缩放。下次连接时生效。</string>
+    <string name="auto_stretch_switch">自动拉伸显示</string>
+    <string name="auto_stretch_hint">开启时，显示内容会填满屏幕（必要时拉伸）。关闭时，显示内容保持自定义分辨率的宽高比，四周留黑边（信箱模式）。输入坐标会自动映射。</string>
 
     <!-- Settings notification -->
     <string name="notification_switch">显示设置通知</string>

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
@@ -90,6 +90,8 @@
     <string name="width_hint">Width (e.g. 1920)</string>
     <string name="height_hint">Height (e.g. 1080)</string>
     <string name="resolution_hint">Pick a preset or enter values manually. Leave 0 for native resolution. \"Screen ×\" scales this device\'s panel (landscape). Takes effect on next connect.</string>
+    <string name="auto_stretch_switch">Auto-stretch display</string>
+    <string name="auto_stretch_hint">When ON, the display fills the screen (stretched if needed). When OFF, the display maintains the custom resolution aspect ratio with black bars (letterboxing). Input coordinates are automatically mapped.</string>
 
     <!-- Settings notification -->
     <string name="notification_switch">Show settings notification</string>


### PR DESCRIPTION
## 概述

在分辨率设置页面添加了一个开关，用于控制显示内容是否自动拉伸以填满屏幕，或者保持自定义分辨率的宽高比并显示黑边（Letterboxing）。

## 问题

当使用与设备屏幕宽高比不同的自定义分辨率时，显示内容会被拉伸以填满屏幕，导致画面变形。用户无法选择保持原始宽高比。

## 解决方案

- 在设置 > 显示分辨率页面添加了「自动拉伸显示」开关
- **开启**（默认）：显示内容填满整个屏幕，必要时进行拉伸
- **关闭**：显示内容保持自定义分辨率的宽高比，四周显示黑边
- 触摸、鼠标、触摸板的输入坐标会自动映射到实际显示区域，确保点击准确

## 修改的文件

- `consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java`
  - 添加了 `autoStretch` 设置及相关变量
  - 修改 `relayout()` 根据设置调整 SurfaceView 布局
  - 添加 `adjustSurfaceViewLayout()` 计算黑边尺寸
  - 修改输入事件处理方法以正确映射坐标
- `consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java`
  - 在分辨率设置页面添加开关按钮
- `consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml`
  - 添加英文文案
- `consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml`
  - 添加中文翻译