### PR TITLE
修复一些问题，提升用户体验

### DIFF
--- a/AUDIO_INVESTIGATION.md
+++ b/AUDIO_INVESTIGATION.md
@@ -1,0 +1,173 @@
+# Anland Android Audio Investigation
+
+Last updated: 2026-07-28
+
+## Repositories and Git State
+
+- Original clean source: `C:\software\anland-main`
+- Working tracked source: `C:\software\anland-5.15`
+- `C:\software\anland-5.15` was not a git repository initially. It is now tracked locally.
+
+Important commits in `C:\software\anland-5.15`:
+
+- `c182f06` - `Baseline original anland-main`
+  - Created from the untouched `C:\software\anland-main` tree.
+- `ff5b3a8` - `Snapshot current anland-5.15 investigation state`
+  - Preserved the then-current mixed state, including older APK/rootfs/producer experiments.
+- `48dc2e6` - `Limit investigation state to APK audio bridge changes`
+  - Native APK audio bridge rewrite only.
+  - Relative to `c182f06`, this commit only changes:
+    - `consumers/anland_v5/android_consumer/app/src/main/jni/native_audio.c`
+    - `consumers/anland_v5/android_consumer/app/src/main/jni/native_audio.h`
+- `9f0db4e` - `Declare media audio focus for Android consumer`
+  - Adds Android-side media stream/audio-focus declaration in `MainActivity`.
+- `edc283e` - `Record APK audio investigation notes`
+  - Adds this investigation file so the evidence survives context compaction.
+- `135d1ee` - `Harden APK audio callback recovery`
+  - Keeps all follow-up work APK-only.
+  - Aligns playback ring reads/writes/drops to whole PCM frames.
+  - Adds an audio-output-only stall recovery path that reopens AAudio without
+    touching the display reconnect path.
+  - Preserves queued PCM across audio-only reopen when the playback format did
+    not change, so the first post-idle sound is not discarded by recovery.
+  - Makes the capture buffer match the actual input channel count.
+
+Relative to `c182f06`, the current code changes are limited to:
+
+- `consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java`
+- `consumers/anland_v5/android_consumer/app/src/main/jni/native_audio.c`
+- `consumers/anland_v5/android_consumer/app/src/main/jni/native_audio.h`
+
+The current direction is APK-only. Producer/rootfs/KDE backend changes were removed from the current tree after being preserved in git history.
+
+## Observed Symptoms
+
+- Pressing the Linux/Ubuntu volume key only plays the first sound.
+- After that, changing volume again is silent until the app is backgrounded/reopened or the screen orientation changes.
+- Opening Ubuntu's bottom-right volume menu makes repeated volume changes audible.
+- Closing that menu brings the one-shot/no-sound behavior back.
+- Web video playback can have sound the first time, then become silent after a pause.
+- A previous reconnect-based APK attempt made sound recover sometimes, but caused screen flashes because it rebuilt the display path.
+- Repeated volume-key presses after that reconnect attempt sometimes kept sound going briefly, then produced loud burst/noise.
+- Releasing the key after that reconnect attempt could trigger one more visible flash.
+- Opening the Ubuntu volume menu and then holding the volume key did not produce the same burst/noise.
+
+## First-Principles Hypothesis
+
+The audio transport itself can carry repeated audio, because opening Ubuntu's volume menu keeps sound working. That points away from a Linux distribution problem and toward Android-side playback lifecycle/timing.
+
+Original APK-side playback did this:
+
+- Open one AAudio output stream.
+- Poll the audio socket.
+- When a PCM datagram arrives, call `AAudioStream_write()` with a short timeout.
+- When Linux is idle, no audio is written.
+
+Short UI sounds such as volume ticks are very bursty. If Android's output stream or route has gone idle/cold, the first burst can wake the path but later bursts may be dropped or fail to restart cleanly. Ubuntu's volume menu likely keeps the Linux/PipeWire side producing enough continuous activity that the Android stream stays hot.
+
+Display reconnect is the wrong recovery tool:
+
+- It recreates/renegotiates display buffers and native window state.
+- That explains the visible flash.
+- Repeated reconnect or write/reopen cycles can accumulate stale PCM or timing discontinuities, explaining burst/noise.
+
+The APK-side fix should keep Android playback clocked without touching the display connection.
+
+The latest long-press result narrows the APK-side failure mode further:
+
+- The audio path is capable of sustained playback while the Ubuntu volume menu is open.
+- The burst/noise only appears in the reconnect-based recovery path, so display
+  reconnect is not just visually bad; it also perturbs audio timing.
+- A plausible APK-only root cause remains: after idle, Android's AAudio callback
+  or output route can be cold/stalled while Linux sends short PCM bursts. Recovery
+  must be local to the AAudio stream and must keep PCM frame boundaries intact.
+
+## Current APK-Only Implementation
+
+`native_audio.c` now uses a pull model for playback:
+
+- AAudio output is opened with a data callback.
+- The callback continuously feeds Android:
+  - queued Linux PCM when available;
+  - zeroed silence when Linux is idle.
+- The socket thread only receives PCM datagrams and appends them to a small ring buffer.
+- If the ring overflows, old PCM is dropped so stale audio cannot burst later.
+- The ring is reset when the audio fd changes.
+- An AAudio error callback marks the output stream for reopen by the playback thread.
+- Ring capacity, reads, writes, and overflow drops are aligned to full PCM frames.
+  This prevents stale-buffer trimming from splitting a 16-bit sample or stereo
+  frame, which can sound like a loud burst.
+- If PCM is queued but the AAudio callback has not run for about 600 ms, the
+  playback thread reopens only the AAudio output stream. It does not set
+  `need_reconnect` and does not rebuild the display/native-window path.
+- Audio-only reopen preserves queued PCM when the negotiated playback format is
+  unchanged. Full resets still happen on fd changes, stop/destroy, or format
+  changes.
+- The capture thread now allocates its mic buffer using the actual input channel
+  count returned by AAudio instead of assuming mono storage forever.
+
+This models the useful part of "Ubuntu volume menu open": Android sees a continuously running media output stream, but the display pipeline is not reconnected.
+
+`native_audio.h` was updated to document the callback/ring-buffer behavior.
+
+`MainActivity.java` now also declares the Android window as a media-audio client:
+
+- `setVolumeControlStream(AudioManager.STREAM_MUSIC)` keeps hardware/system volume
+  handling tied to the music/media stream while Anland is focused.
+- The activity requests `AUDIOFOCUS_GAIN` with `USAGE_MEDIA`/`CONTENT_TYPE_MUSIC`
+  on resume and abandons it on pause/destroy.
+- This is APK-only and does not reconnect display surfaces.
+
+## Local Verification Limits
+
+This VM cannot fully build or run the APK locally:
+
+- No Java found.
+- No Android SDK/`ANDROID_HOME` found.
+- No usable WSL Linux distribution.
+- No C compiler found (`clang`, `gcc`, and `cl` are unavailable).
+
+Git/source checks completed:
+
+- `git diff --name-status c182f06..HEAD` shows only APK-side code files plus
+  this investigation note:
+  - `AUDIO_INVESTIGATION.md`
+  - `MainActivity.java`
+  - `native_audio.c`
+  - `native_audio.h`
+- Old audio-triggered display reconnect code is not part of the current APK-only tree.
+
+Expected build path:
+
+- Upload/export current `C:\software\anland-5.15` or the generated upload directory to the `FengY233/anland` fork.
+- Let GitHub Actions build the APK.
+
+## Test Expectations
+
+If this APK-side hypothesis is correct:
+
+- Pressing Ubuntu volume keys repeatedly should keep producing ticks without opening Ubuntu's volume menu.
+- No screen flash should occur after stopping volume-key presses.
+- Web video should resume audio after pause more reliably.
+- If PCM arrives faster than Android can play it, old PCM should be dropped instead of delayed into a loud burst.
+
+If it still fails:
+
+- Check `logcat` for tags `AnlandAudio` and `Anland`.
+- Important messages:
+  - `output stream ready`
+  - `output stream error`
+  - `output stream disconnected, reopening`
+  - `output callback stalled with ... queued bytes; reopening audio output only`
+  - `device formats`
+- Next APK-only ideas to investigate:
+  - Try an `AudioTrack` playback backend as an alternative to AAudio.
+  - Add a user-tunable playback ring size/latency if burst underrun or overrun remains.
+  - Add temporary log counters for callback cadence, queued bytes, and AAudio
+    `xrun` count around the first silent post-idle volume tick.
+
+## Do Not Reintroduce
+
+- Do not use display reconnect as audio recovery.
+- Do not modify rootfs/KDE producer as the next step unless the user explicitly reverses the APK-only constraint.
+- Do not upload the old mixed `ff5b3a8` state as the current solution; it is preserved only for history.

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -828,12 +828,28 @@ public class MainActivity extends Activity
     }
 
     /**
+     * Whether a Back key comes from a real keyboard key rather than from Android's
+     * navigation. An external keyboard often reports its physical Esc as Back, and
+     * that key belongs to the desktop, not to the pointer-capture release. The
+     * gesture / three-button navigation Back is a virtual key with no scan code,
+     * so it stays the one way to release the capture.
+     */
+    private boolean isKeyboardBackKey(KeyEvent event) {
+        if (event.getScanCode() == 0)
+            return false;
+        InputDevice device = InputDevice.getDevice(event.getDeviceId());
+        return device != null && !device.isVirtual()
+                && device.getKeyboardType() == InputDevice.KEYBOARD_TYPE_ALPHABETIC;
+    }
+
+    /**
      * Release capture for a non-mouse Android Back key and consume exactly the
      * matching DOWN/UP pair. Shared by the normal Activity and accessibility-key
      * paths so the setting behaves identically with interception enabled.
      */
     private boolean handlePointerCaptureBackKey(KeyEvent event) {
-        if (event.getKeyCode() != KeyEvent.KEYCODE_BACK || isMouseKeyEvent(event))
+        if (event.getKeyCode() != KeyEvent.KEYCODE_BACK || isMouseKeyEvent(event)
+                || isKeyboardBackKey(event))
             return false;
 
         if (event.getAction() == KeyEvent.ACTION_DOWN) {

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -12,6 +12,9 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.hardware.display.DisplayManager;
 import android.content.SharedPreferences;
+import android.media.AudioAttributes;
+import android.media.AudioFocusRequest;
+import android.media.AudioManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
@@ -57,6 +60,8 @@ public class MainActivity extends Activity
     // Latency presets in ms; 0 = engine default. Shared with SettingsActivity.
     static final String KEY_SPEAKER_LATENCY_MS = "speaker_latency_ms";
     static final String KEY_MIC_LATENCY_MS = "mic_latency_ms";
+    // Audio keep-alive toggle. Shared with SettingsActivity.
+    static final String KEY_AUDIO_KEEPALIVE = "audio_keepalive";
     private static final int REQ_RECORD_AUDIO = 1001;
     private static final int REQ_CAMERA = 1002;
     // Camera service fds/threads are created once and persist across reconnects;
@@ -70,6 +75,9 @@ public class MainActivity extends Activity
     static final String EXTRA_WINDOW_NAME = "window_name";
     // This window's own native transport instance (its own consumer_state handle).
     private Native mNative;
+    // Media audio focus for this window (volume keys + playback priority).
+    private AudioManager mAudioManager;
+    private AudioFocusRequest mAudioFocusRequest;
     // Socket path from the launch Intent; overrides the saved pref when non-null.
     private String mSocketOverride = null;
     // Title shown in recents / freeform (setTaskDescription); default "anland".
@@ -369,6 +377,7 @@ public class MainActivity extends Activity
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        setupMediaAudio();
         applyOrientation();
 
         // Apply the launch parameters: socket path (overrides the saved pref) and
@@ -1341,6 +1350,44 @@ public class MainActivity extends Activity
                 dx * scaleX, dy * scaleY);
     }
 
+    /*
+     * Bind hardware/system volume and media audio focus to the MUSIC stream while
+     * this window is focused. Without focus, short Linux UI sounds (volume ticks,
+     * key clicks) can be throttled or silenced by the audio policy; with
+     * STREAM_MUSIC + USAGE_MEDIA the volume keys adjust the media stream and the
+     * AAudio output keeps priority alongside music/video playback.
+     */
+    private void setupMediaAudio() {
+        setVolumeControlStream(AudioManager.STREAM_MUSIC);
+        mAudioManager = getSystemService(AudioManager.class);
+        if (mAudioManager == null)
+            return;
+
+        AudioAttributes attrs = new AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                .build();
+        mAudioFocusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                .setAudioAttributes(attrs)
+                .setWillPauseWhenDucked(false)
+                .setOnAudioFocusChangeListener(change ->
+                        Log.i(TAG, "audio focus change: " + change))
+                .build();
+    }
+
+    private void requestMediaAudioFocus() {
+        if (mAudioManager == null || mAudioFocusRequest == null)
+            return;
+        int result = mAudioManager.requestAudioFocus(mAudioFocusRequest);
+        if (result != AudioManager.AUDIOFOCUS_REQUEST_GRANTED)
+            Log.w(TAG, "media audio focus not granted: " + result);
+    }
+
+    private void abandonMediaAudioFocus() {
+        if (mAudioManager != null && mAudioFocusRequest != null)
+            mAudioManager.abandonAudioFocusRequest(mAudioFocusRequest);
+    }
+
     @Override
     protected void onResume() {
         super.onResume();
@@ -1351,6 +1398,8 @@ public class MainActivity extends Activity
             finish();
             return;
         }
+
+        requestMediaAudioFocus();
 
         // Show settings notification while in foreground, unless disabled in Settings.
         if (getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
@@ -1406,6 +1455,7 @@ public class MainActivity extends Activity
             pushRefreshRate();
             applyMicState();
             applyAudioLatency();
+            applyAudioKeepalive();
         }
 
         // ===== 重新读取触摸板设置 =====
@@ -1439,10 +1489,12 @@ public class MainActivity extends Activity
         if (dm != null)
             dm.unregisterDisplayListener(displayListener);
         mNative.stop();
+        abandonMediaAudioFocus();
     }
 
     @Override
     protected void onDestroy() {
+        abandonMediaAudioFocus();
         releasePointerCapture(false);
         if (mRegisteredSocket != null) {
             sWindowsBySocket.remove(mRegisteredSocket, this);
@@ -1497,6 +1549,11 @@ public class MainActivity extends Activity
         int speakerMs = prefs.getInt(KEY_SPEAKER_LATENCY_MS, 0);
         int micMs = prefs.getInt(KEY_MIC_LATENCY_MS, 0);
         mNative.setAudioLatency(speakerMs, micMs);
+    }
+
+    private void applyAudioKeepalive() {
+        SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+        mNative.setAudioKeepalive(prefs.getBoolean(KEY_AUDIO_KEEPALIVE, false));
     }
 
     private void applyMicState() {
@@ -1558,6 +1615,7 @@ public class MainActivity extends Activity
         pushRefreshRate();
         applyMicState();
         applyAudioLatency();
+        applyAudioKeepalive();
 
         // ===== 更新屏幕尺寸并重置平滑状态 =====
         updateTouchpadBounds(null);

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/Native.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/Native.java
@@ -51,6 +51,7 @@ public final class Native {
     public void sendTextInput(byte[] data) { nativeSendTextInput(handle, data); }
     public void setMicEnabled(boolean enabled) { nativeSetMicEnabled(handle, enabled); }
     public void setAudioLatency(int speakerMs, int micMs) { nativeSetAudioLatency(handle, speakerMs, micMs); }
+    public void setAudioKeepalive(boolean enabled) { nativeSetAudioKeepalive(handle, enabled); }
 
     // ---- native handle lifecycle + handle-taking entry points ----
 
@@ -82,4 +83,5 @@ public final class Native {
     private static native void nativeSendTextInput(long handle, byte[] data);
     private static native void nativeSetMicEnabled(long handle, boolean enabled);
     private static native void nativeSetAudioLatency(long handle, int speakerMs, int micMs);
+    private static native void nativeSetAudioKeepalive(long handle, boolean enabled);
 }

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
@@ -46,6 +46,7 @@ public class SettingsActivity extends Activity {
     private static final String KEY_USE_ROOT = "use_root";
     private static final String KEY_MIC_ENABLED = "mic_enabled";
     private static final String KEY_CAMERA_ENABLED = "camera_enabled";
+    private static final String KEY_AUDIO_KEEPALIVE = "audio_keepalive";
     private static final String KEY_SPEAKER_LATENCY_MS = "speaker_latency_ms";
     private static final String KEY_MIC_LATENCY_MS = "mic_latency_ms";
     private static final String KEY_ACCESSIBILITY_ENABLED = "accessibility_key_intercept";
@@ -859,6 +860,27 @@ public class SettingsActivity extends Activity {
         cameraHint.setTextColor(Color.GRAY);
         cameraHint.setPadding(0, dp(4), 0, 0);
         root.addView(cameraHint);
+
+        // Audio keep-alive: keep the AAudio output stream running (fed near-silent
+        // keepalive) so short Linux UI sounds (volume ticks, key clicks) always play
+        // immediately. Off by default so the audio path can sleep when the desktop is
+        // silent and save standby power.
+        Switch keepaliveSwitch = new Switch(this);
+        keepaliveSwitch.setText(R.string.audio_keepalive_switch);
+        keepaliveSwitch.setTextSize(14);
+        keepaliveSwitch.setPadding(0, dp(16), 0, 0);
+        keepaliveSwitch.setChecked(prefs.getBoolean(KEY_AUDIO_KEEPALIVE, false));
+        keepaliveSwitch.setOnCheckedChangeListener((v, checked) ->
+            getSharedPreferences(PREFS_NAME, MODE_PRIVATE).edit()
+                .putBoolean(KEY_AUDIO_KEEPALIVE, checked).apply());
+        root.addView(keepaliveSwitch);
+
+        TextView keepaliveHint = new TextView(this);
+        keepaliveHint.setText(R.string.audio_keepalive_hint);
+        keepaliveHint.setTextSize(12);
+        keepaliveHint.setTextColor(Color.GRAY);
+        keepaliveHint.setPadding(0, dp(4), 0, 0);
+        root.addView(keepaliveHint);
 
         // Audio latency presets, separately for the speaker (playback) and microphone
         // (capture) paths. The chosen buffer is forwarded to the producer's PipeWire

--- a/consumers/anland_v5/android_consumer/app/src/main/jni/native_audio.c
+++ b/consumers/anland_v5/android_consumer/app/src/main/jni/native_audio.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <poll.h>
+#include <time.h>
 #include <unistd.h>
 
 #define TAG "AnlandAudio"
@@ -25,6 +26,17 @@
 #define WANT_CAP_CHANNELS  1
 #define MAX_DGRAM          (64 * 1024)
 #define MIC_MAX_FRAMES     1024   /* upper bound on frames per mic read */
+#define PLAY_POLL_MS       100
+#define PLAY_RING_MS       160
+#define PLAY_RING_MIN      (32 * 1024)
+#define PLAY_RING_MAX      (256 * 1024)
+#define PLAY_KEEPALIVE_AMPLITUDE 1
+#define PLAY_WAKE_FADE_MS  8
+/* Keep the output stream running while the desktop is producing audio (short
+ * UI sounds restart it instantly), but stop it once silence has lasted this
+ * long so the audio path can idle instead of holding the codec/HAL on forever
+ * (idle power). A fresh PCM datagram restarts it via ensure_play_stream_started(). */
+#define PLAY_IDLE_STOP_MS  1500
 
 struct audio_bridge {
     volatile bool running;
@@ -49,14 +61,31 @@ struct audio_bridge {
     /* Latency presets in ms (0 = engine default), set from the settings UI. */
     volatile int play_latency_ms;
     volatile int cap_latency_ms;
-    volatile bool resend_formats;   /* a preset changed -> re-announce on the live fd */
+    volatile bool resend_formats;   /* a preset/device change -> re-announce */
 
-    /* Output stream died (error callback fired, or a write returned an error) ->
-     * the play thread closes and reopens it. AAudio disconnects a low-latency
-     * stream on route changes, HAL fast-track teardown after the desktop goes
-     * silent, or audio-policy preemption; without this flag the dead stream is
-     * never recovered and all audio stays silent until the Activity is recreated. */
-    volatile bool play_rebuild;
+    /* User "audio keep-alive" toggle. On: keep the output stream running (fed
+     * near-silent keepalive) for maximum burst reliability, at a little standby
+     * power. Off (default): the play thread idle-stops the stream after silence
+     * so the audio path can sleep. */
+    volatile bool keepalive_enabled;
+
+    /*
+     * Playback is pull-driven by an AAudio data callback. The socket thread only
+     * appends incoming PCM to this ring; the callback feeds an inaudible keepalive
+     * on underrun.
+     * That keeps Android's audio mixer awake across short Linux sound effects
+     * without reconnecting the display pipeline.
+     */
+    pthread_mutex_t play_lock;
+    uint8_t *play_ring;
+    size_t play_ring_size;
+    size_t play_ring_head;
+    size_t play_ring_tail;
+    size_t play_ring_fill;
+    volatile bool play_error;
+    bool play_idle;
+    int play_keepalive_phase;
+    int play_wake_fade_frames;
 
     uint8_t rx[MAX_DGRAM];
 };
@@ -67,25 +96,231 @@ static int current_fd(struct audio_bridge *b)
     return ctx ? get_audio_fd(ctx) : -1;
 }
 
-/* ---- AAudio stream helpers ---- */
-
-/* AAudio invokes this from its own thread the moment the output stream becomes
- * unusable: an audio route changed (headset/BT plugged or unplugged), the HAL tore
- * down the low-latency fast track after the desktop went silent and the stream
- * underran, audio focus/policy preempted us, etc. The stream object is now dead --
- * writes into it silently produce no sound -- so just signal the play thread to
- * close and reopen it. (Never call AAudio on the stream from in here.) */
-static void play_error_cb(AAudioStream *stream, void *userData, aaudio_result_t error)
+static uint64_t now_ms(void)
 {
-    struct audio_bridge *b = userData;
-    (void)stream;
-    LOGE("playback stream error: %s -- scheduling rebuild",
-         AAudio_convertResultToText(error));
-    b->play_rebuild = true;
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000 + (uint64_t)ts.tv_nsec / 1000000;
 }
 
-static AAudioStream *open_stream(aaudio_direction_t dir, int channels,
-                                 AAudioStream_errorCallback error_cb, void *user_data)
+/* ---- playback ring helpers ---- */
+
+static size_t align_down(size_t n, size_t align)
+{
+    return align > 0 ? n - (n % align) : n;
+}
+
+static size_t align_up(size_t n, size_t align)
+{
+    if (align == 0)
+        return n;
+    size_t rem = n % align;
+    return rem == 0 ? n : n + align - rem;
+}
+
+static size_t play_frame_bytes(struct audio_bridge *b)
+{
+    int channels = b && b->play_channels > 0 ? b->play_channels : WANT_PLAY_CHANNELS;
+    return (size_t)channels * sizeof(int16_t);
+}
+
+static size_t playback_ring_bytes(int rate, int channels)
+{
+    if (rate <= 0)
+        rate = 48000;
+    if (channels <= 0)
+        channels = WANT_PLAY_CHANNELS;
+
+    size_t frame_bytes = (size_t)channels * sizeof(int16_t);
+    size_t bytes = (size_t)rate * (size_t)channels * sizeof(int16_t) * PLAY_RING_MS / 1000;
+    if (bytes < PLAY_RING_MIN)
+        bytes = PLAY_RING_MIN;
+    if (bytes > PLAY_RING_MAX)
+        bytes = PLAY_RING_MAX;
+    bytes = align_down(bytes, frame_bytes);
+    if (bytes < frame_bytes)
+        bytes = frame_bytes;
+    return bytes;
+}
+
+static void play_ring_reset_locked(struct audio_bridge *b)
+{
+    b->play_ring_head = 0;
+    b->play_ring_tail = 0;
+    b->play_ring_fill = 0;
+}
+
+static bool play_ring_resize_locked(struct audio_bridge *b, size_t size, bool reset)
+{
+    if (b->play_ring && b->play_ring_size == size) {
+        if (reset)
+            play_ring_reset_locked(b);
+        return true;
+    }
+
+    uint8_t *ring = malloc(size);
+    if (!ring)
+        return false;
+
+    free(b->play_ring);
+    b->play_ring = ring;
+    b->play_ring_size = size;
+    play_ring_reset_locked(b);
+    return true;
+}
+
+static size_t play_ring_read_locked(struct audio_bridge *b, uint8_t *dst, size_t n)
+{
+    if (!b->play_ring || b->play_ring_fill == 0)
+        return 0;
+
+    n = align_down(n, play_frame_bytes(b));
+    size_t got = n < b->play_ring_fill ? n : b->play_ring_fill;
+    got = align_down(got, play_frame_bytes(b));
+    if (got == 0)
+        return 0;
+
+    size_t first = b->play_ring_size - b->play_ring_tail;
+    if (first > got)
+        first = got;
+
+    memcpy(dst, b->play_ring + b->play_ring_tail, first);
+    memcpy(dst + first, b->play_ring, got - first);
+    b->play_ring_tail = (b->play_ring_tail + got) % b->play_ring_size;
+    b->play_ring_fill -= got;
+    return got;
+}
+
+static void play_ring_write_locked(struct audio_bridge *b, const uint8_t *src, size_t n)
+{
+    if (!b->play_ring || b->play_ring_size == 0 || n == 0)
+        return;
+
+    size_t frame_bytes = play_frame_bytes(b);
+    n = align_down(n, frame_bytes);
+    if (n == 0)
+        return;
+
+    if (n > b->play_ring_size) {
+        src += n - b->play_ring_size;
+        n = b->play_ring_size;
+    }
+
+    if (b->play_ring_fill + n > b->play_ring_size) {
+        size_t drop = b->play_ring_fill + n - b->play_ring_size;
+        drop = align_up(drop, frame_bytes);
+        if (drop > b->play_ring_fill)
+            drop = b->play_ring_fill;
+        b->play_ring_tail = (b->play_ring_tail + drop) % b->play_ring_size;
+        b->play_ring_fill -= drop;
+    }
+
+    size_t first = b->play_ring_size - b->play_ring_head;
+    if (first > n)
+        first = n;
+
+    memcpy(b->play_ring + b->play_ring_head, src, first);
+    memcpy(b->play_ring, src + first, n - first);
+    b->play_ring_head = (b->play_ring_head + n) % b->play_ring_size;
+    b->play_ring_fill += n;
+}
+
+static void queue_playback_bytes(struct audio_bridge *b, const uint8_t *data, size_t bytes)
+{
+    if (!b || !data || bytes == 0)
+        return;
+
+    pthread_mutex_lock(&b->play_lock);
+    play_ring_write_locked(b, data, bytes);
+    pthread_mutex_unlock(&b->play_lock);
+}
+
+static int play_wake_fade_frame_count(struct audio_bridge *b)
+{
+    int rate = b && b->play_rate > 0 ? b->play_rate : 48000;
+    int frames = rate * PLAY_WAKE_FADE_MS / 1000;
+    return frames > 0 ? frames : 1;
+}
+
+static void fill_keepalive_frames(struct audio_bridge *b, int16_t *dst,
+                                  int32_t frames, int channels)
+{
+    if (frames <= 0 || channels <= 0)
+        return;
+
+    for (int32_t f = 0; f < frames; ++f) {
+        int16_t v = b->play_keepalive_phase ? PLAY_KEEPALIVE_AMPLITUDE
+                                            : -PLAY_KEEPALIVE_AMPLITUDE;
+        b->play_keepalive_phase ^= 1;
+        for (int ch = 0; ch < channels; ++ch)
+            *dst++ = v;
+    }
+}
+
+static void apply_wake_fade(struct audio_bridge *b, int16_t *samples,
+                            int32_t frames, int channels)
+{
+    if (frames <= 0 || channels <= 0 || b->play_wake_fade_frames <= 0)
+        return;
+
+    int total = play_wake_fade_frame_count(b);
+    for (int32_t f = 0; f < frames && b->play_wake_fade_frames > 0; ++f) {
+        int gain = total - b->play_wake_fade_frames + 1;
+        for (int ch = 0; ch < channels; ++ch) {
+            int32_t s = samples[f * channels + ch];
+            samples[f * channels + ch] = (int16_t)((s * gain) / total);
+        }
+        b->play_wake_fade_frames--;
+    }
+}
+
+static aaudio_data_callback_result_t play_data_cb(
+    AAudioStream *stream, void *userdata, void *audio_data, int32_t num_frames)
+{
+    (void)stream;
+    struct audio_bridge *b = userdata;
+    uint8_t *dst = audio_data;
+    int16_t *samples = audio_data;
+    int channels = b->play_channels > 0 ? b->play_channels : WANT_PLAY_CHANNELS;
+    size_t need = (size_t)num_frames * (size_t)channels * sizeof(int16_t);
+    size_t got = 0;
+    int32_t got_frames = 0;
+
+    if (pthread_mutex_trylock(&b->play_lock) == 0) {
+        got = play_ring_read_locked(b, dst, need);
+        pthread_mutex_unlock(&b->play_lock);
+    }
+
+    got_frames = (int32_t)(got / ((size_t)channels * sizeof(int16_t)));
+    if (got_frames > 0) {
+        if (b->play_idle)
+            b->play_wake_fade_frames = play_wake_fade_frame_count(b);
+        b->play_idle = false;
+        apply_wake_fade(b, samples, got_frames, channels);
+    }
+
+    if (got < need) {
+        int32_t keepalive_frames = num_frames - got_frames;
+        fill_keepalive_frames(b, (int16_t *)(dst + got), keepalive_frames, channels);
+        b->play_idle = true;
+    }
+    return AAUDIO_CALLBACK_RESULT_CONTINUE;
+}
+
+static void play_error_cb(AAudioStream *stream, void *userdata, aaudio_result_t error)
+{
+    (void)stream;
+    struct audio_bridge *b = userdata;
+    if (b) {
+        b->play_error = true;
+        LOGE("output stream error: %s", AAudio_convertResultToText(error));
+    }
+}
+
+/* ---- AAudio stream helpers ---- */
+
+static AAudioStream *open_stream(struct audio_bridge *bridge,
+                                 aaudio_direction_t dir, int channels)
 {
     AAudioStreamBuilder *bld = NULL;
     if (AAudio_createStreamBuilder(&bld) != AAUDIO_OK || !bld)
@@ -96,10 +331,18 @@ static AAudioStream *open_stream(aaudio_direction_t dir, int channels,
     AAudioStreamBuilder_setSampleRate(bld, AAUDIO_UNSPECIFIED);
     AAudioStreamBuilder_setChannelCount(bld, channels);
     AAudioStreamBuilder_setFormat(bld, AAUDIO_FORMAT_PCM_I16);
-    AAudioStreamBuilder_setPerformanceMode(bld, AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
     AAudioStreamBuilder_setSharingMode(bld, AAUDIO_SHARING_MODE_SHARED);
-    if (error_cb)
-        AAudioStreamBuilder_setErrorCallback(bld, error_cb, user_data);
+
+    if (dir == AAUDIO_DIRECTION_OUTPUT) {
+        AAudioStreamBuilder_setUsage(bld, AAUDIO_USAGE_MEDIA);
+        AAudioStreamBuilder_setContentType(bld, AAUDIO_CONTENT_TYPE_MUSIC);
+        AAudioStreamBuilder_setPerformanceMode(bld, AAUDIO_PERFORMANCE_MODE_NONE);
+        AAudioStreamBuilder_setDataCallback(bld, play_data_cb, bridge);
+        AAudioStreamBuilder_setErrorCallback(bld, play_error_cb, bridge);
+    } else {
+        AAudioStreamBuilder_setInputPreset(bld, AAUDIO_INPUT_PRESET_VOICE_RECOGNITION);
+        AAudioStreamBuilder_setPerformanceMode(bld, AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
+    }
 
     AAudioStream *stream = NULL;
     aaudio_result_t r = AAudioStreamBuilder_openStream(bld, &stream);
@@ -111,6 +354,116 @@ static AAudioStream *open_stream(aaudio_direction_t dir, int channels,
         return NULL;
     }
     return stream;
+}
+
+static void close_play_stream(struct audio_bridge *b, bool reset_ring)
+{
+    if (!b || !b->play)
+        return;
+    AAudioStream_requestStop(b->play);
+    AAudioStream_close(b->play);
+    b->play = NULL;
+    b->play_error = false;
+
+    if (reset_ring) {
+        pthread_mutex_lock(&b->play_lock);
+        play_ring_reset_locked(b);
+        pthread_mutex_unlock(&b->play_lock);
+    }
+}
+
+static bool open_play_stream(struct audio_bridge *b, bool reset_ring)
+{
+    int old_rate = b->play_rate;
+    int old_channels = b->play_channels;
+    close_play_stream(b, reset_ring);
+
+    if (b->play_rate <= 0)
+        b->play_rate = 48000;
+    if (b->play_channels <= 0)
+        b->play_channels = WANT_PLAY_CHANNELS;
+
+    b->play = open_stream(b, AAUDIO_DIRECTION_OUTPUT, WANT_PLAY_CHANNELS);
+    if (!b->play)
+        return false;
+
+    int rate = AAudioStream_getSampleRate(b->play);
+    int channels = AAudioStream_getChannelCount(b->play);
+    if (rate > 0)
+        b->play_rate = rate;
+    if (channels > 0)
+        b->play_channels = channels;
+
+    pthread_mutex_lock(&b->play_lock);
+    bool format_changed = old_rate != b->play_rate || old_channels != b->play_channels;
+    bool ring_ok = play_ring_resize_locked(
+        b, playback_ring_bytes(b->play_rate, b->play_channels),
+        reset_ring || format_changed);
+    pthread_mutex_unlock(&b->play_lock);
+    if (!ring_ok) {
+        LOGE("allocate playback ring failed");
+        close_play_stream(b, true);
+        return false;
+    }
+
+    b->play_idle = true;
+    b->play_keepalive_phase = 0;
+    b->play_wake_fade_frames = 0;
+
+    aaudio_result_t r = AAudioStream_requestStart(b->play);
+    if (r != AAUDIO_OK) {
+        LOGE("start output stream failed: %s", AAudio_convertResultToText(r));
+        close_play_stream(b, true);
+        return false;
+    }
+
+    b->play_error = false;
+    b->resend_formats = true;
+    LOGI("output stream ready: %d Hz x%d ring=%zu",
+         b->play_rate, b->play_channels, b->play_ring_size);
+    return true;
+}
+
+static bool ensure_play_stream_started(struct audio_bridge *b)
+{
+    if (!b->play || b->play_error)
+        return open_play_stream(b, false);
+
+    aaudio_stream_state_t state = AAudioStream_getState(b->play);
+    if (state == AAUDIO_STREAM_STATE_STARTED || state == AAUDIO_STREAM_STATE_STARTING)
+        return true;
+
+    if (state == AAUDIO_STREAM_STATE_DISCONNECTED) {
+        LOGE("output stream disconnected, reopening");
+        return open_play_stream(b, false);
+    }
+
+    aaudio_result_t r = AAudioStream_requestStart(b->play);
+    if (r == AAUDIO_OK)
+        return true;
+
+    LOGE("restart output stream from %s failed: %s",
+         AAudio_convertStreamStateToText(state),
+         AAudio_convertResultToText(r));
+
+    if (r == AAUDIO_ERROR_DISCONNECTED || r == AAUDIO_ERROR_INVALID_STATE)
+        return open_play_stream(b, false);
+
+    return false;
+}
+
+static void queue_playback_frames(struct audio_bridge *b, const uint8_t *data,
+                                  int32_t frames, int packet_channels)
+{
+    if (!ensure_play_stream_started(b))
+        return;
+
+    int channels = b->play_channels > 0 ? b->play_channels : WANT_PLAY_CHANNELS;
+    if (channels != packet_channels)
+        return;
+
+    size_t bytes = (size_t)frames * (size_t)packet_channels * sizeof(int16_t);
+    queue_playback_bytes(b, data, bytes);
 }
 
 /* Convert a latency preset (ms) to a frame count at the given rate. 0 ms -> 0 (let
@@ -144,64 +497,53 @@ static void send_format(int fd, uint32_t role, uint32_t rate, uint32_t channels,
 
 /* ---- playback: socket -> speaker ---- */
 
-/* Close any dead output stream and open a fresh one, reading back the device-
- * chosen rate/channels. Used for the initial open (audio_start) and for runtime
- * recovery (the play thread, once the error callback or a failed write flags the
- * stream as dead). A new stream may pick a different device format, so callers
- * arrange to re-announce it to the producer. Returns true on success. */
-static bool reopen_play_stream(struct audio_bridge *b)
-{
-    if (b->play) {
-        AAudioStream_requestStop(b->play);
-        AAudioStream_close(b->play);
-        b->play = NULL;
-    }
-    b->play = open_stream(AAUDIO_DIRECTION_OUTPUT, WANT_PLAY_CHANNELS,
-                          play_error_cb, b);
-    if (!b->play)
-        return false;
-    b->play_rate = AAudioStream_getSampleRate(b->play);
-    b->play_channels = AAudioStream_getChannelCount(b->play);
-    AAudioStream_requestStart(b->play);
-    LOGI("playback stream opened: %d Hz x%d", b->play_rate, b->play_channels);
-    return true;
-}
-
 static void *play_thread_func(void *arg)
 {
     struct audio_bridge *b = arg;
     LOGI("playback thread started");
 
     bool had_fd = false;   /* drives a one-shot format handshake per connection */
+    int last_fd = -1;
+    /* Last time real PCM was queued; the idle-stop logic below uses it to let the
+     * audio path sleep once the desktop has been silent for a while. */
+    uint64_t last_pcm_ms = now_ms();
 
     while (b->running) {
-        /* The output stream is opened once (audio_start) and normally kept for the
-         * bridge's lifetime. AAudio can disconnect it at any time -- a route change,
-         * the HAL tearing down the low-latency fast track once the desktop goes
-         * silent and the stream underruns, or an audio-policy preemption. A
-         * disconnected stream is dead: writes silently produce no sound. Reopen it
-         * here instead of losing all audio until the Activity is recreated. */
-        if (b->play_rebuild || !b->play) {
-            b->play_rebuild = false;
-            if (!reopen_play_stream(b)) {
-                usleep(200000);   /* open failed (device busy?): retry shortly */
-                continue;
-            }
-            had_fd = false;        /* new stream -> re-announce its format upstream */
-            b->resend_formats = true;
+        if (b->play_error)
+            open_play_stream(b, false);
+
+        /* Power: with the keepalive callback the output stream never naturally
+         * idles, so once the desktop has been silent for PLAY_IDLE_STOP_MS we stop
+         * it ourselves. The next PCM arrival restarts it in queue_playback_frames()
+         * via ensure_play_stream_started(). requestStop is a no-op unless the stream
+         * is actually running, so this is cheap even when already stopped.
+         * Skipped when the user enabled "audio keep-alive" (keep the stream hot). */
+        if (!b->keepalive_enabled && b->play
+                && now_ms() - last_pcm_ms > PLAY_IDLE_STOP_MS) {
+            aaudio_stream_state_t st = AAudioStream_getState(b->play);
+            if (st == AAUDIO_STREAM_STATE_STARTED || st == AAUDIO_STREAM_STATE_STARTING)
+                AAudioStream_requestStop(b->play);
         }
 
         int fd = current_fd(b);
-        if (fd < 0) {
+        if (fd != last_fd) {
+            pthread_mutex_lock(&b->play_lock);
+            play_ring_reset_locked(b);
+            pthread_mutex_unlock(&b->play_lock);
             had_fd = false;
+            last_fd = fd;
+        }
+
+        if (fd < 0) {
             usleep(20000);
             continue;
         }
 
         /* Hand the producer the real device formats + latency presets for both
          * directions: once when the socket comes up (just left fallback), and again
-         * whenever a preset changes so it re-sizes its PipeWire nodes live. */
+         * whenever a preset/device change needs to re-size its PipeWire nodes live. */
         if (!had_fd || b->resend_formats) {
+            ensure_play_stream_started(b);
             b->resend_formats = false;
             send_format(fd, AUDIO_ROLE_PLAYBACK, b->play_rate, b->play_channels,
                         ms_to_frames(b->play_latency_ms, b->play_rate));
@@ -211,9 +553,17 @@ static void *play_thread_func(void *arg)
         }
 
         struct pollfd pfd = { .fd = fd, .events = POLLIN };
-        if (poll(&pfd, 1, 200) <= 0)
+        int poll_result = poll(&pfd, 1, PLAY_POLL_MS);
+        if (poll_result == 0)
+            continue;
+        if (poll_result < 0)
             continue;
         if (pfd.revents & (POLLHUP | POLLERR)) {
+            pthread_mutex_lock(&b->play_lock);
+            play_ring_reset_locked(b);
+            pthread_mutex_unlock(&b->play_lock);
+            had_fd = false;
+            last_fd = -1;
             usleep(20000);
             continue;
         }
@@ -224,26 +574,20 @@ static void *play_thread_func(void *arg)
 
         struct audio_msg h;
         memcpy(&h, b->rx, sizeof(h));
-        if (h.type != AUDIO_MSG_PCM || !b->play)
+        if (h.type != AUDIO_MSG_PCM)
             continue;   /* the producer only sends PCM back; formats flow upstream */
 
         size_t avail = (size_t)n - sizeof(struct audio_msg);
         size_t bytes = h.size < avail ? h.size : avail;
-        int32_t frames = (int32_t)(bytes / (sizeof(int16_t) * b->play_channels));
+        int play_channels = b->play_channels > 0 ? b->play_channels : WANT_PLAY_CHANNELS;
+        size_t frame_bytes = sizeof(int16_t) * (size_t)play_channels;
+        bytes -= bytes % frame_bytes;
+        int32_t frames = (int32_t)(bytes / frame_bytes);
         if (frames <= 0)
             continue;
 
-        /* Blocking write with a short timeout: on underrun/overrun AAudio paces us;
-         * we never stall the loop longer than the timeout. A negative result means
-         * the stream disconnected/errored under us -- flag it for reopen on the next
-         * iteration so we don't keep writing into a dead stream. */
-        aaudio_result_t wr = AAudioStream_write(b->play, b->rx + sizeof(struct audio_msg),
-                                                frames, 20 * 1000 * 1000L);
-        if (wr < 0) {
-            LOGE("playback write failed: %s -- rebuilding stream",
-                 AAudio_convertResultToText(wr));
-            b->play_rebuild = true;
-        }
+        queue_playback_frames(b, b->rx + sizeof(struct audio_msg), frames, play_channels);
+        last_pcm_ms = now_ms();
     }
 
     LOGI("playback thread stopped");
@@ -258,7 +602,12 @@ static void *cap_thread_func(void *arg)
     LOGI("capture thread started");
 
     bool started = false;
-    int16_t buf[MIC_MAX_FRAMES * WANT_CAP_CHANNELS];
+    int cap_channels = b->cap_channels > 0 ? b->cap_channels : WANT_CAP_CHANNELS;
+    int16_t *buf = malloc((size_t)MIC_MAX_FRAMES * (size_t)cap_channels * sizeof(*buf));
+    if (!buf) {
+        LOGE("allocate capture buffer failed");
+        return NULL;
+    }
     /* ~10 ms per read at the device rate, capped to the buffer. */
     int32_t mic_frames = b->cap_rate / 100;
     if (mic_frames <= 0)
@@ -292,7 +641,7 @@ static void *cap_thread_func(void *arg)
         if (got <= 0)
             continue;
 
-        uint32_t bytes = (uint32_t)got * sizeof(int16_t) * b->cap_channels;
+        uint32_t bytes = (uint32_t)got * sizeof(int16_t) * (uint32_t)cap_channels;
         struct audio_msg h = { .type = AUDIO_MSG_PCM, .size = bytes };
         struct iovec iov[2] = {
             { .iov_base = &h, .iov_len = sizeof(h) },
@@ -304,6 +653,7 @@ static void *cap_thread_func(void *arg)
 
     if (started && b->rec)
         AAudioStream_requestStop(b->rec);
+    free(buf);
     LOGI("capture thread stopped");
     return NULL;
 }
@@ -312,7 +662,11 @@ static void *cap_thread_func(void *arg)
 
 audio_bridge *audio_create(void)
 {
-    return calloc(1, sizeof(struct audio_bridge));
+    audio_bridge *b = calloc(1, sizeof(struct audio_bridge));
+    if (!b)
+        return NULL;
+    pthread_mutex_init(&b->play_lock, NULL);
+    return b;
 }
 
 void audio_destroy(audio_bridge *b)
@@ -320,6 +674,8 @@ void audio_destroy(audio_bridge *b)
     if (!b)
         return;
     audio_stop(b);
+    pthread_mutex_destroy(&b->play_lock);
+    free(b->play_ring);
     free(b);
 }
 
@@ -328,19 +684,19 @@ void audio_start(audio_bridge *b)
     if (!b || b->running)
         return;
 
-    /* Open the output stream and read back the rate/channels the device actually
-     * chose -- this is the real playback capability we negotiate with the producer.
-     * If the open fails here (device not ready yet) the play thread keeps retrying
-     * reopen_play_stream() until it succeeds. */
+    /* Keep the output stream running and silence-fed. Short Linux UI sounds then
+     * arrive into a hot Android mixer instead of waking a cold one-shot stream. */
     b->play_rate = 48000;
     b->play_channels = WANT_PLAY_CHANNELS;
-    reopen_play_stream(b);
+    b->resend_formats = true;
+    b->play_error = false;
+    open_play_stream(b, true);
 
     /* Open the input stream even before the mic is enabled; it is started/stopped
      * by the capture thread. May be NULL if RECORD_AUDIO is not granted. */
     b->cap_rate = 48000;
     b->cap_channels = WANT_CAP_CHANNELS;
-    b->rec = open_stream(AAUDIO_DIRECTION_INPUT, WANT_CAP_CHANNELS, NULL, NULL);
+    b->rec = open_stream(b, AAUDIO_DIRECTION_INPUT, WANT_CAP_CHANNELS);
     if (b->rec) {
         b->cap_rate = AAudioStream_getSampleRate(b->rec);
         b->cap_channels = AAudioStream_getChannelCount(b->rec);
@@ -362,16 +718,18 @@ void audio_stop(audio_bridge *b)
     pthread_join(b->play_thread, NULL);
     pthread_join(b->cap_thread, NULL);
 
-    if (b->play) {
-        AAudioStream_requestStop(b->play);
-        AAudioStream_close(b->play);
-        b->play = NULL;
-    }
+    close_play_stream(b, true);
     if (b->rec) {
         AAudioStream_requestStop(b->rec);
         AAudioStream_close(b->rec);
         b->rec = NULL;
     }
+    pthread_mutex_lock(&b->play_lock);
+    free(b->play_ring);
+    b->play_ring = NULL;
+    b->play_ring_size = 0;
+    play_ring_reset_locked(b);
+    pthread_mutex_unlock(&b->play_lock);
     b->ctx = NULL;
     LOGI("audio bridge stopped");
 }
@@ -398,4 +756,12 @@ void audio_set_latency(audio_bridge *b, int speaker_ms, int mic_ms)
     b->cap_latency_ms = mic_ms;
     b->resend_formats = true;   /* picked up by the playback thread on the live fd */
     LOGI("latency preset: speaker=%dms mic=%dms", speaker_ms, mic_ms);
+}
+
+void audio_set_keepalive(audio_bridge *b, int enabled)
+{
+    if (!b)
+        return;
+    b->keepalive_enabled = enabled != 0;
+    LOGI("audio keep-alive %s", b->keepalive_enabled ? "enabled" : "disabled");
 }

--- a/consumers/anland_v5/android_consumer/app/src/main/jni/native_audio.h
+++ b/consumers/anland_v5/android_consumer/app/src/main/jni/native_audio.h
@@ -12,10 +12,13 @@
  *                datagrams to the socket (the producer exposes them as a Linux
  *                recording source). Only active while the mic is enabled.
  *
- * The AAudio streams are opened once and stay open across reconnects; the active
- * display_ctx (and thus the live audio fd) is swapped via audio_set_ctx(). While
- * detached the playback stream simply has nothing to play and the capture stream's
- * PCM is dropped. The audio fd is owned by the display library -- never closed here.
+ * The playback AAudio stream stays open and is driven by an AAudio callback. The
+ * socket thread appends PCM into a small ring buffer; the callback outputs an
+ * inaudible keepalive when Linux is idle. This keeps Android's mixer awake across
+ * short UI sounds without reconnecting the display pipeline. The capture stream is
+ * opened once and only started while the mic is enabled. The active display_ctx
+ * (and thus the live audio fd) is swapped via audio_set_ctx(). The audio fd is
+ * owned by the display library -- never closed here.
  *
  * The bridge is per-instance: each consumer window owns its own audio_bridge (its
  * own AAudio playback + capture streams, connected to its own producer). Multiple
@@ -45,5 +48,10 @@ void audio_set_mic_enabled(audio_bridge *b, int enabled);
  * producer, which applies it as the PipeWire node.latency. Takes effect immediately
  * (the formats are re-announced on the live connection). */
 void audio_set_latency(audio_bridge *b, int speaker_ms, int mic_ms);
+
+/* Keep the AAudio output stream hot with a near-silent keepalive (bursty UI sounds
+ * always play immediately), or let it idle-stop after silence to save standby power.
+ * Default is disabled. Takes effect on the playback thread's next loop pass. */
+void audio_set_keepalive(audio_bridge *b, int enabled);
 
 #endif

--- a/consumers/anland_v5/android_consumer/app/src/main/jni/native_consumer.c
+++ b/consumers/anland_v5/android_consumer/app/src/main/jni/native_consumer.c
@@ -1094,3 +1094,13 @@ Java_com_anland_consumer_Native_nativeSetAudioLatency(
         return;
     audio_set_latency(s->audio, speakerMs, micMs);
 }
+
+JNIEXPORT void JNICALL
+Java_com_anland_consumer_Native_nativeSetAudioKeepalive(
+    JNIEnv *env, jclass clazz, jlong handle, jboolean enabled)
+{
+    struct consumer_state *s = STATE(handle);
+    if (!s)
+        return;
+    audio_set_keepalive(s->audio, enabled == JNI_TRUE);
+}

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values-zh-rTW/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values-zh-rTW/strings.xml
@@ -84,6 +84,8 @@
     <string name="mic_hint">桌面音訊始終透過本裝置的喇叭播放。啟用此項還會把麥克風反向發送到桌面。下次連線時生效（請重新開啟應用程式）。</string>
     <string name="camera_switch">將相機轉發到桌面</string>
     <string name="camera_hint">允許桌面將本裝置的相機作為視訊來源開啟。僅在桌面正在錄製時相機才會開啟。下次返回應用程式時生效；首次使用會請求相機權限。</string>
+    <string name="audio_keepalive_switch">音訊保活</string>
+    <string name="audio_keepalive_hint">保持音訊輸出串流持續活躍，讓 Linux 的短促系統音（音量提示、按鍵音）始終即時播放；會略增待機耗電。關閉時桌面靜默約 1.5 秒後音訊路徑自動休眠，下次出聲時自動喚醒。開啟後若聽感延遲不合預期，可能需要配合調整下方的「音訊延遲」預設。</string>
     <string name="audio_latency_title">音訊延遲</string>
     <string name="latency_speaker_label">喇叭（桌面 → 手機）</string>
     <string name="latency_mic_label">麥克風（手機 → 桌面）</string>

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
@@ -96,6 +96,8 @@
     <string name="mic_hint">桌面音频始终通过本设备的扬声器播放。启用此项还会把麦克风反向发送到桌面。下次连接时生效（请重新打开应用）。</string>
     <string name="camera_switch">将摄像头转发到桌面</string>
     <string name="camera_hint">允许桌面将本设备的摄像头作为视频源打开。仅在桌面正在录制时摄像头才会开启。下次返回应用时生效；首次使用会请求摄像头权限。</string>
+    <string name="audio_keepalive_switch">音频保活</string>
+    <string name="audio_keepalive_hint">保持音频输出流持续活跃，让 Linux 的短促系统音（音量提示、按键音）始终即时播放；会略增待机功耗。关闭时桌面静默约1.5秒后音频通路自动休眠，下次出声时自动唤醒。开启后若听感延迟不合预期，可能需要配合调整下方的「音频延迟」预设。</string>
     <string name="audio_latency_title">音频延迟</string>
     <string name="latency_speaker_label">扬声器（桌面 → 手机）</string>
     <string name="latency_mic_label">麦克风（手机 → 桌面）</string>

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
@@ -96,6 +96,8 @@
     <string name="mic_hint">Desktop audio always plays through this device\'s speaker. Enabling this also sends the mic the other way. Takes effect on next connect (reopen the app).</string>
     <string name="camera_switch">Forward camera to desktop</string>
     <string name="camera_hint">Lets the desktop open this device\'s camera(s) as a video source. The camera only turns on while the desktop is actively recording. Takes effect on next return to the app; first use prompts for the camera permission.</string>
+    <string name="audio_keepalive_switch">Audio keep-alive</string>
+    <string name="audio_keepalive_hint">Keep the audio output stream running so short Linux sounds (volume ticks, key clicks) always play instantly. Costs a little standby power. Off: the audio path sleeps after ~1.5 s of desktop silence and wakes for the next sound. If the audible latency does not match your preference, you may need to tune the Audio latency presets below.</string>
     <string name="audio_latency_title">Audio latency</string>
     <string name="latency_speaker_label">Speaker (desktop → phone)</string>
     <string name="latency_mic_label">Microphone (phone → desktop)</string>


### PR DESCRIPTION
1. bug修复，修复使用键盘ESC触发捕获外部指针退出捕获，固定为安卓返回键

2. 移植  @FengY233 音频修复(AAudio 拉模型保活)并新增"音频保活"开关,默认关闭
音频修复参考自 https://github.com/FengY233/anland/commits/main/
(FengY233) 的提交:

- native_audio.c/h: AAudio 播放改为数据回调拉取模型,空闲喂近无声
  保活信号;帧对齐环形缓冲防爆音;音频卡死只重开 AAudio 流、不重建
  显示链路。修复音量键只响一声、网页视频暂停后失声的问题。
- MainActivity.java: 绑定 STREAM_MUSIC,申请/释放媒体音频焦点。
- AUDIO_INVESTIGATION.md: 附带调研文档作为参考。

本地增强:

- 空闲停机:桌面静默约 1.5s 后自动 requestStop 输出流,音频通路
  休眠省电;下一个 PCM 到达自动重启播放(唤醒淡入防爆音)。
- 新增"音频保活"设置开关(默认关闭