### PR TITLE
添加沉浸模式(实验性)，并修复蓝牙鼠标无法应用灵敏度的bug

### DIFF
--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/ImmersiveMode.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/ImmersiveMode.java
@@ -1,0 +1,887 @@
+package com.anland.consumer;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Looper;
+import android.os.SystemClock;
+import android.util.Log;
+import android.view.InputDevice;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.Surface;
+import android.widget.Toast;
+
+import java.util.Arrays;
+
+/**
+ * Immersive mode: the whole device is handed over to the Linux desktop.
+ *
+ * A root helper takes an exclusive grab (EVIOCGRAB) on the touchscreen, the
+ * keyboard and any pointer, so Android stops seeing them entirely — no gesture
+ * navigation, no notification shade, no accidental Home. This class turns the
+ * raw evdev stream that comes back into the input the app already knows how to
+ * forward, so nothing about the desktop side changes:
+ *
+ * <ul>
+ *   <li>a grabbed touchscreen is replayed as an ordinary {@link MotionEvent} and
+ *       routed exactly like a real touch — through {@link Touchpad} when
+ *       touchpad (relative) mode is on, straight to the remote when it is off,
+ *       which is why the two features compose;</li>
+ *   <li>a grabbed physical touchpad gets its own {@link Touchpad}, so the same
+ *       gestures, thresholds and pointer sensitivity apply as when Android
+ *       captures the pad itself;</li>
+ *   <li>a grabbed mouse drives the shared cursor through the host's relative
+ *       motion path, which is where the sensitivity setting is applied;</li>
+ *   <li>keys are already evdev scan codes on the wire, so they pass straight
+ *       through.</li>
+ * </ul>
+ *
+ * The session is bound to one key, chosen in Settings. Pressing it enters and
+ * pressing it again leaves — the helper watches for that key itself, so the way
+ * out never depends on this process being healthy. The Settings switch is only a
+ * safety gate: with it off the key does nothing at all, and a session never
+ * survives a pause, a focus change or a lost surface.
+ */
+final class ImmersiveMode implements InputGrab.Listener {
+    private static final String TAG = "Anland";
+    private static final String PREFS_NAME = "anland_settings";
+
+    static final String KEY_ENABLED  = "immersive_enabled";
+    static final String KEY_KEYCODE  = "immersive_keycode";
+    /** Raw evdev scan code of the bound key: what the helper actually compares. */
+    static final String KEY_SCANCODE = "immersive_scancode";
+
+    // evdev event types / codes (linux/input-event-codes.h).
+    private static final int EV_SYN = 0x00, EV_KEY = 0x01, EV_REL = 0x02, EV_ABS = 0x03;
+    private static final int SYN_REPORT = 0, SYN_DROPPED = 3;
+    private static final int ABS_X = 0x00, ABS_Y = 0x01;
+    private static final int ABS_MT_SLOT = 0x2f;
+    private static final int ABS_MT_POSITION_X = 0x35, ABS_MT_POSITION_Y = 0x36;
+    private static final int ABS_MT_TRACKING_ID = 0x39;
+    private static final int REL_X = 0x00, REL_Y = 0x01, REL_HWHEEL = 0x06;
+    private static final int REL_WHEEL = 0x08;
+    private static final int REL_WHEEL_HI_RES = 0x0b, REL_HWHEEL_HI_RES = 0x0c;
+    private static final int BTN_FIRST = 0x110, BTN_LAST = 0x117;   // BTN_LEFT..BTN_TASK
+    private static final int BTN_LEFT = 0x110;
+    private static final int BTN_TOOL_FIRST = 0x140, BTN_TOOL_LAST = 0x14f;
+    private static final int BTN_TOUCH = 0x14a;
+    private static final int KEY_CODE_LIMIT = 0x300;
+    /** One wheel detent, matching the ±1 AXIS_VSCROLL the captured-mouse path sees. */
+    private static final float WHEEL_STEP = 10f;
+    private static final float HI_RES_PER_DETENT = 120f;
+
+    /** MotionEvent tops out at 16 pointers, and so does every panel worth caring about. */
+    private static final int MAX_SLOTS = 16;
+    /** Matches IGRAB_MAX_DEVICES in jni/input_grab.h. */
+    private static final int MAX_DEVICES = 32;
+
+    /** Everything this class needs from the activity that owns the pipeline. */
+    interface Host {
+        Context context();
+        /** Size of the area touches are mapped into, in view pixels. */
+        int outputWidth();
+        int outputHeight();
+        /** Its top-left corner, which is not the origin when the display is letterboxed. */
+        float outputOriginX();
+        float outputOriginY();
+        /** The panel's current refresh rate, for the session's telemetry line. */
+        float displayRefreshHz();
+        /** Cached {@link android.view.Display#getRotation()}. */
+        int displayRotation();
+        /**
+         * A grabbed touchscreen frame, already in view pixels: routed exactly
+         * like a real touch, so touchpad mode keeps working.
+         */
+        void onGrabbedTouch(MotionEvent ev);
+        /** A {@link Touchpad} wired to the host's cursor, for a grabbed physical pad. */
+        Touchpad newGrabbedPad();
+        /** Relative cursor motion in view pixels, with the sensitivity setting applied. */
+        void movePointerRelative(float dx, float dy);
+        void sendKey(int action, int evdev);
+        void sendMouseButton(int button, boolean pressed);
+        void sendMouseScroll(int axis, float value);
+        /** Session started or ended; the host re-syncs pointer capture. */
+        void onImmersiveChanged(boolean active);
+    }
+
+    /** Per-device translation state. */
+    private static final class Dev {
+        int devIdx;
+        int cls;
+        boolean grabbed;
+        boolean multitouch;
+        /** One button under the whole pad, so BTN_LEFT alone just means "clicked". */
+        boolean clickpad;
+        int minX, maxX, minY, maxY;
+        Touchpad pad;                       // CLASS_TOUCHPAD only, and never for twins
+
+        /**
+         * This pad is a twin: another CLASS_TOUCHPAD already covered these exact
+         * ranges. Some docks expose one physical pad through two nodes (pogo +
+         * HID), so this one may be the same pad a second time.
+         */
+        boolean twin;
+        /**
+         * A twin that provably delivers the same contacts as its primary: both
+         * emitted real contact frames, so one of them is a duplicate path for
+         * the same pad. Whichever keeps working is the same pad to the user.
+         */
+        boolean dup;
+        /**
+         * Frames with at least one real contact, for the twin decision. Only
+         * frames that actually produced a contact count — a chip that reports
+         * BTN_TOUCH without any MT data must never tip the decision.
+         */
+        int contactFrames;
+
+        // Multi-touch protocol B: one contact per slot, alive while its tracking
+        // id is >= 0. The slot index doubles as the MotionEvent pointer id, which
+        // keeps ids stable for as long as the finger stays down.
+        final int[] trackingId = new int[MAX_SLOTS];
+        final float[] x = new float[MAX_SLOTS];
+        final float[] y = new float[MAX_SLOTS];
+        int curSlot = 0;
+        boolean sawTrackingId = false;
+
+        // Single-touch fallback for panels with no MT axes (BTN_TOUCH + ABS_X/Y).
+        // stValid is set by actual ABS_X/Y data, never by the BTN_TOUCH hint
+        // alone: a multitouch chip that only reports "someone is touching" must
+        // not produce a phantom contact at stale coordinates.
+        boolean stTouch = false;
+        boolean stValid = false;
+        float stX, stY;
+
+        /** Contacts currently reported to the host, in pointer-index order. */
+        final int[] active = new int[MAX_SLOTS];
+        int activeCount = 0;
+        long downTime = 0;
+        boolean absDirty = false;
+
+        // Relative axes, accumulated over a frame and emitted on SYN_REPORT.
+        float relX, relY;
+        float wheel, hwheel;
+        boolean sawHiRes = false;
+
+        /** Clickpad press latch: release exactly the button that was pressed. */
+        int latchedButton = 0;
+
+        Dev() {
+            Arrays.fill(trackingId, -1);
+        }
+    }
+
+    private final Host host;
+    private final Context ctx;
+    private final InputGrab grab;
+    private final Dev[] devs = new Dev[MAX_DEVICES];
+
+    /** Held keys and buttons, so a session can never leave one stuck on the desktop. */
+    private final boolean[] keyDown = new boolean[KEY_CODE_LIMIT];
+
+    // Scratch for MotionEvent synthesis; obtain() copies these out immediately,
+    // so one set is reused for every event.
+    private final MotionEvent.PointerProperties[] props =
+            new MotionEvent.PointerProperties[MAX_SLOTS];
+    private final MotionEvent.PointerCoords[] coords =
+            new MotionEvent.PointerCoords[MAX_SLOTS];
+    private final int[] desiredSlots = new int[MAX_SLOTS];
+    private final int[] probeSlots = new int[MAX_SLOTS];
+    private final float[] mapped = new float[2];
+
+    private boolean active = false;
+    private boolean starting = false;
+    /** The user asked to leave, so the closing toast is theirs to see. */
+    private boolean userExitPending = false;
+
+    // Session telemetry: events per second, per-device event counts and the
+    // panel's current rate, logged once a second while a session runs. It is the
+    // fastest way to tell a bursty device (a duplicated touchpad streaming the
+    // same contacts twice) from a healthy stream on a slow panel.
+    private final android.os.Handler stats = new android.os.Handler(Looper.getMainLooper());
+    private long statsLastAt = 0L;
+    private int statsEvents = 0;
+    private final int[] statsPerDev = new int[MAX_DEVICES];
+    private final Runnable statsTick = new Runnable() {
+        @Override
+        public void run() {
+            if (!active && !starting)
+                return;
+            long now = SystemClock.elapsedRealtime();
+            if (statsLastAt != 0L && now - statsLastAt >= 900) {
+                long dt = now - statsLastAt;
+                StringBuilder sb = new StringBuilder("immersive stats: ")
+                        .append((int) (statsEvents * 1000f / dt)).append(" ev/s, display ")
+                        .append(host.displayRefreshHz()).append(" Hz, devs:");
+                for (int i = 0; i < devs.length; i++) {
+                    Dev d = devs[i];
+                    if (d == null)
+                        continue;
+                    sb.append(' ').append(i).append(':').append(d.cls);
+                    if (d.clickpad)
+                        sb.append("(cp)");
+                    if (d.twin)
+                        sb.append(d.dup ? "(dup)" : "(twin)");
+                    sb.append('=').append(statsPerDev[i]);
+                }
+                Log.i(TAG, sb.toString());
+                statsEvents = 0;
+                java.util.Arrays.fill(statsPerDev, 0);
+                statsLastAt = now;
+            } else if (statsLastAt == 0L) {
+                statsLastAt = now;
+            }
+            stats.postDelayed(this, 500);
+        }
+    };
+
+    ImmersiveMode(Host host) {
+        this.host = host;
+        this.ctx = host.context();
+        this.grab = new InputGrab(ctx, this);
+        for (int i = 0; i < MAX_SLOTS; i++) {
+            props[i] = new MotionEvent.PointerProperties();
+            props[i].toolType = MotionEvent.TOOL_TYPE_FINGER;
+            coords[i] = new MotionEvent.PointerCoords();
+        }
+    }
+
+    boolean isActive() {
+        return active || starting;
+    }
+
+    // ---- settings --------------------------------------------------------
+
+    private SharedPreferences prefs() {
+        return ctx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+    }
+
+    private boolean isEnabled() {
+        return prefs().getBoolean(KEY_ENABLED, false);
+    }
+
+    /**
+     * Evdev code of the bound key. Recorded straight from the KeyEvent at bind
+     * time because {@link KeyCodeMapper} has no entry for the volume keys — the
+     * obvious thing to bind on a tablet — and the helper compares evdev codes,
+     * not Android key codes.
+     */
+    private int boundScanCode() {
+        SharedPreferences p = prefs();
+        int scan = p.getInt(KEY_SCANCODE, -1);
+        if (scan > 0)
+            return scan;
+        int keycode = p.getInt(KEY_KEYCODE, -1);
+        return keycode == -1 ? -1 : KeyCodeMapper.getScanCode(keycode);
+    }
+
+    /**
+     * Consume the bound key. Called from both key paths — the accessibility
+     * service eats keys before the window when interception is on, so neither
+     * path alone sees every press.
+     *
+     * @return true when the event was the toggle key and must go no further.
+     */
+    boolean handleKey(KeyEvent event) {
+        if (!isEnabled())
+            return false;
+        SharedPreferences p = prefs();
+        int scan = p.getInt(KEY_SCANCODE, -1);
+        int keycode = p.getInt(KEY_KEYCODE, -1);
+        if (scan <= 0 && keycode == -1)
+            return false;
+        boolean match = (scan > 0 && event.getScanCode() == scan)
+                || (keycode != -1 && event.getKeyCode() == keycode);
+        if (!match)
+            return false;
+        // A key with no evdev code is one the root helper could never recognise,
+        // and the helper is what ends a session no matter what happens to this
+        // process. Rather than swallow the key to no purpose, leave it alone;
+        // Settings flags such a binding where the user can see it.
+        if (boundScanCode() <= 0)
+            return false;
+
+        if (event.getAction() == KeyEvent.ACTION_DOWN && event.getRepeatCount() == 0)
+            toggle();
+        // Swallow the release too, so the key never reaches the desktop or the
+        // soft-keyboard toggle bound to the same code.
+        return true;
+    }
+
+    private void toggle() {
+        if (active || starting) {
+            userExitPending = true;
+            stop();
+        } else {
+            start();
+        }
+    }
+
+    private void start() {
+        int scan = boundScanCode();
+        if (scan <= 0) {
+            // Without an evdev code the helper cannot recognise the key that ends
+            // the session, and it refuses to grab anything blind.
+            toast(ctx.getString(R.string.immersive_no_scancode));
+            return;
+        }
+        starting = true;
+        userExitPending = false;
+        if (!grab.start(scan)) {
+            starting = false;
+            toast(ctx.getString(R.string.immersive_failed));
+            return;
+        }
+        statsLastAt = 0L;
+        statsEvents = 0;
+        java.util.Arrays.fill(statsPerDev, 0);
+        stats.postDelayed(statsTick, 500);
+        // Announced up front, and with the way out, because once the grab lands
+        // the on-screen UI is unreachable by design.
+        toast(ctx.getString(R.string.immersive_entering,
+                KeyCodeMapper.keyName(ctx, prefs().getInt(KEY_KEYCODE, -1), scan)));
+        host.onImmersiveChanged(true);
+    }
+
+    /** End the session. Safe to call at any time, including when not running. */
+    void stop() {
+        if (!active && !starting)
+            return;
+        grab.stop();
+    }
+
+    // ---- InputGrab.Listener (all on the main thread) ---------------------
+
+    @Override
+    public void onDevice(int dev, int cls, int minX, int maxX, int minY, int maxY,
+                         int flags) {
+        if (dev < 0 || dev >= devs.length)
+            return;
+        Dev d = new Dev();
+        d.devIdx = dev;
+        d.cls = cls;
+        d.grabbed = (flags & InputGrab.DEV_GRABBED) != 0;
+        d.multitouch = (flags & InputGrab.DEV_MULTITOUCH) != 0;
+        d.clickpad = (flags & InputGrab.DEV_CLICKPAD) != 0;
+        d.minX = minX;
+        d.maxX = maxX;
+        d.minY = minY;
+        d.maxY = maxY;
+        if (cls == InputGrab.CLASS_TOUCHPAD && maxX > minX && maxY > minY) {
+            // Same ranges as an earlier pad: one physical pad behind two nodes.
+            // Both get a Touchpad: until the duplicate decision, a pad's frames
+            // must be interpreted as a pad, never as screen touches.
+            for (Dev other : devs) {
+                if (other != null && other.pad != null
+                        && other.minX == minX && other.maxX == maxX
+                        && other.minY == minY && other.maxY == maxY) {
+                    d.twin = true;
+                    break;
+                }
+            }
+            d.pad = host.newGrabbedPad();
+            d.pad.setInputBounds(minX, minY, maxX - minX, maxY - minY);
+        }
+        devs[dev] = d;
+    }
+
+    @Override
+    public void onReady(int grabbedCount) {
+        starting = false;
+        active = true;
+        Log.i(TAG, "immersive mode active (" + grabbedCount + " grabbed devices)");
+        host.onImmersiveChanged(true);
+    }
+
+    @Override
+    public void onEnded(int reason) {
+        boolean wasRunning = active || starting;
+        active = false;
+        starting = false;
+        stats.removeCallbacks(statsTick);
+        releaseEverything(true);
+        Arrays.fill(devs, null);
+        host.onImmersiveChanged(false);
+        if (!wasRunning)
+            return;
+
+        switch (reason) {
+            case InputGrab.REASON_TOGGLE:
+                toast(ctx.getString(R.string.immersive_exited));
+                break;
+            case InputGrab.REASON_STOPPED:
+                // Lifecycle teardown (pause / focus loss / surface gone) is not
+                // worth a toast; a key-driven exit is.
+                if (userExitPending)
+                    toast(ctx.getString(R.string.immersive_exited));
+                break;
+            case InputGrab.REASON_NO_ROOT:
+                toast(ctx.getString(R.string.immersive_failed));
+                break;
+            case InputGrab.REASON_HELPER_ERR:
+                toast(ctx.getString(R.string.immersive_no_devices));
+                break;
+            default:
+                toast(ctx.getString(R.string.immersive_interrupted));
+                break;
+        }
+        userExitPending = false;
+    }
+
+    @Override
+    public void onEvents(int[] batch, int count) {
+        if (!active && !starting)
+            return;
+        statsEvents += count / 4;
+        for (int i = 0; i + 3 < count; i += 4) {
+            int dev = batch[i];
+            if (dev >= 0 && dev < statsPerDev.length)
+                statsPerDev[dev]++;
+            handleEvent(dev, batch[i + 1], batch[i + 2], batch[i + 3]);
+        }
+    }
+
+    // ---- evdev translation ----------------------------------------------
+
+    private void handleEvent(int devIdx, int type, int code, int value) {
+        if (devIdx == InputGrab.DEV_ALL) {
+            // The helper had to drop records. Anything we still believe is held
+            // may already be up, so let go of all of it rather than strand a key
+            // or a contact on the desktop.
+            if (type == EV_SYN && code == SYN_DROPPED)
+                releaseEverything(false);
+            return;
+        }
+        if (devIdx < 0 || devIdx >= devs.length)
+            return;
+        Dev d = devs[devIdx];
+        if (d == null)
+            return;
+
+        switch (type) {
+            case EV_SYN:
+                if (code == SYN_REPORT)
+                    endFrame(d);
+                else if (code == SYN_DROPPED)
+                    releaseEverything(false);
+                break;
+            case EV_KEY:
+                handleKeyEvent(d, code, value);
+                break;
+            case EV_REL:
+                handleRelEvent(d, code, value);
+                break;
+            case EV_ABS:
+                handleAbsEvent(d, code, value);
+                break;
+            default:
+                break;   // EV_MSC scan codes, EV_LED, EV_SW: nothing to forward
+        }
+    }
+
+    private void handleKeyEvent(Dev d, int code, int value) {
+        if (value == 2)
+            return;   // auto-repeat: the compositor makes its own from the keymap
+        boolean pressed = value != 0;
+
+        if (code == BTN_TOUCH) {
+            // Only meaningful for the single-touch fallback; protocol B devices
+            // track contacts by slot instead.
+            d.stTouch = pressed;
+            d.absDirty = true;
+            return;
+        }
+        if (code >= BTN_FIRST && code <= BTN_LAST) {
+            handlePointerButton(d, code, pressed);
+            return;
+        }
+        if (code >= BTN_TOOL_FIRST && code <= BTN_TOOL_LAST)
+            return;   // BTN_TOOL_*: contact-shape hints, not real keys
+
+        if (code < 0 || code >= KEY_CODE_LIMIT)
+            return;
+        if (keyDown[code] == pressed)
+            return;   // a repeated state means a record was dropped, not a new press
+        keyDown[code] = pressed;
+        host.sendKey(pressed ? 0 : 1, code);
+    }
+
+    /**
+     * Mouse and clickpad buttons. A single-button clickpad reports every press as
+     * BTN_LEFT, so the pressing finger's position decides left vs right — the
+     * same rule the Android-captured pad uses — and the choice is latched, so a
+     * finger drifting across the midline cannot strand a held button.
+     */
+    private void handlePointerButton(Dev d, int code, boolean pressed) {
+        int button = code;
+        if (d.pad != null && d.clickpad && code == BTN_LEFT) {
+            if (pressed) {
+                syncPadOutput(d);
+                MotionEvent probe = buildPadProbe(d);
+                if (probe != null) {
+                    button = d.pad.clickpadButton(probe);
+                    probe.recycle();
+                }
+                d.latchedButton = button;
+                // A physical press is not a gesture; drop whatever was in flight.
+                d.pad.cancel();
+            } else if (d.latchedButton != 0) {
+                button = d.latchedButton;
+                d.latchedButton = 0;
+            }
+        }
+        if (button < 0 || button >= KEY_CODE_LIMIT)
+            return;
+        if (keyDown[button] == pressed)
+            return;
+        keyDown[button] = pressed;
+        host.sendMouseButton(button, pressed);
+    }
+
+    /** A throwaway event holding the pad's current contacts, for clickpadButton(). */
+    private MotionEvent buildPadProbe(Dev d) {
+        int n = gatherContacts(d, probeSlots);
+        if (n <= 0)
+            return null;
+        return buildMotionEvent(d, MotionEvent.ACTION_MOVE, -1, probeSlots, n,
+                SystemClock.uptimeMillis());
+    }
+
+    private void handleRelEvent(Dev d, int code, int value) {
+        switch (code) {
+            case REL_X: d.relX += value; break;
+            case REL_Y: d.relY += value; break;
+            case REL_WHEEL_HI_RES:
+                d.sawHiRes = true;
+                d.wheel += value / HI_RES_PER_DETENT;
+                break;
+            case REL_HWHEEL_HI_RES:
+                d.sawHiRes = true;
+                d.hwheel += value / HI_RES_PER_DETENT;
+                break;
+            // Drivers that report hi-res send the legacy axis as well; taking
+            // both would scroll twice as far.
+            case REL_WHEEL:
+                if (!d.sawHiRes) d.wheel += value;
+                break;
+            case REL_HWHEEL:
+                if (!d.sawHiRes) d.hwheel += value;
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void handleAbsEvent(Dev d, int code, int value) {
+        if (d.cls != InputGrab.CLASS_TOUCHSCREEN && d.cls != InputGrab.CLASS_TOUCHPAD)
+            return;   // a gamepad's sticks are not contacts
+        switch (code) {
+            case ABS_MT_SLOT:
+                d.curSlot = (value >= 0 && value < MAX_SLOTS) ? value : MAX_SLOTS - 1;
+                break;
+            case ABS_MT_TRACKING_ID:
+                d.sawTrackingId = true;
+                d.trackingId[d.curSlot] = value;
+                d.absDirty = true;
+                break;
+            case ABS_MT_POSITION_X:
+                d.x[d.curSlot] = value;
+                d.absDirty = true;
+                break;
+            case ABS_MT_POSITION_Y:
+                d.y[d.curSlot] = value;
+                d.absDirty = true;
+                break;
+            case ABS_X:
+                d.stX = value;
+                d.stValid = true;
+                d.absDirty = true;
+                break;
+            case ABS_Y:
+                d.stY = value;
+                d.stValid = true;
+                d.absDirty = true;
+                break;
+            default:
+                break;
+        }
+    }
+
+    /** SYN_REPORT: the frame is complete, so turn it into app input. */
+    private void endFrame(Dev d) {
+        if (d.relX != 0f || d.relY != 0f) {
+            host.movePointerRelative(d.relX, d.relY);
+            d.relX = 0f;
+            d.relY = 0f;
+        }
+        if (d.wheel != 0f) {
+            host.sendMouseScroll(0, -d.wheel * WHEEL_STEP);
+            d.wheel = 0f;
+        }
+        if (d.hwheel != 0f) {
+            host.sendMouseScroll(1, d.hwheel * WHEEL_STEP);
+            d.hwheel = 0f;
+        }
+        if (d.absDirty) {
+            d.absDirty = false;
+            resolveTwin(d);
+            if (!d.dup)
+                dispatchContacts(d);
+        }
+    }
+
+    /**
+     * Once two identical-range pads have both provably delivered real contact
+     * frames, they are two paths for one physical pad. The pad with more real
+     * frames is the one actually carrying the stream, so it survives; a tie
+     * keeps the lower dev id. A twin that never produces real contacts (a dead
+     * duplicate node, or one that only reports BTN_TOUCH) never triggers this
+     * and never gets dropped. An already-deduped peer is skipped, so a third
+     * identical node can still resolve against a live one.
+     */
+    private void resolveTwin(Dev d) {
+        if (!d.twin || d.dup || d.contactFrames <= 0)
+            return;
+        for (Dev other : devs) {
+            if (other == null || other == d || other.cls != InputGrab.CLASS_TOUCHPAD
+                    || other.minX != d.minX || other.maxX != d.maxX
+                    || other.minY != d.minY || other.maxY != d.maxY)
+                continue;
+            if (other.contactFrames <= 0 || other.dup)
+                continue;
+            // Both deliver real contacts: keep the busier one.
+            if (d.contactFrames > other.contactFrames
+                    || (d.contactFrames == other.contactFrames && d.devIdx < other.devIdx)) {
+                other.dup = true;
+                Log.i(TAG, "touchpad " + other.devIdx + " (" + other.contactFrames
+                        + " frames) duplicates " + d.devIdx + " (" + d.contactFrames
+                        + "); ignoring its events");
+            } else {
+                d.dup = true;
+                Log.i(TAG, "touchpad " + d.devIdx + " (" + d.contactFrames
+                        + " frames) duplicates " + other.devIdx + " (" + other.contactFrames
+                        + "); ignoring its events");
+            }
+            break;
+        }
+    }
+
+    /**
+     * Slots holding a live contact, in ascending order (== pointer index order).
+     *
+     * Protocol B devices are tracked by slot; their BTN_TOUCH is only a "someone
+     * is touching" hint and produces no contact on its own — a chip that reports
+     * the hint without MT data (a dock's pass-through) must not turn into a
+     * phantom contact at stale coordinates. The single-touch fallback needs
+     * real ABS_X/Y data; the hint alone is never enough, regardless of what the
+     * device's capability flags claim.
+     */
+    private int gatherContacts(Dev d, int[] out) {
+        int n = 0;
+        if (d.sawTrackingId) {
+            for (int s = 0; s < MAX_SLOTS; s++) {
+                if (d.trackingId[s] >= 0)
+                    out[n++] = s;
+            }
+        } else if (d.stTouch && d.stValid) {
+            // Device without usable MT data: one contact, wherever the last
+            // position was.
+            d.x[0] = d.stX;
+            d.y[0] = d.stY;
+            out[n++] = 0;
+        }
+        return n;
+    }
+
+    /**
+     * Turn the new contact set into the MotionEvent sequence a real touchscreen
+     * would have produced: releases first, then a move for whatever stayed down,
+     * then the new contacts. That is the order Android's own input reader uses,
+     * and it is what keeps the pointer indices valid inside each event.
+     */
+    private void dispatchContacts(Dev d) {
+        int nDesired = gatherContacts(d, desiredSlots);
+        if (nDesired > 0)
+            d.contactFrames++;
+        long now = SystemClock.uptimeMillis();
+
+        // 1. contacts that lifted, one event each, highest index first so the
+        //    removal below never disturbs an index still to be visited.
+        for (int i = d.activeCount - 1; i >= 0; i--) {
+            if (contains(desiredSlots, nDesired, d.active[i]))
+                continue;
+            int action = d.activeCount == 1
+                    ? MotionEvent.ACTION_UP : MotionEvent.ACTION_POINTER_UP;
+            emit(d, action, i, d.active, d.activeCount, now);
+            System.arraycopy(d.active, i + 1, d.active, i, d.activeCount - i - 1);
+            d.activeCount--;
+        }
+
+        // 2. everything still down, moving together
+        if (d.activeCount > 0)
+            emit(d, MotionEvent.ACTION_MOVE, -1, d.active, d.activeCount, now);
+
+        // 3. contacts that appeared
+        for (int i = 0; i < nDesired; i++) {
+            int slot = desiredSlots[i];
+            if (contains(d.active, d.activeCount, slot))
+                continue;
+            if (d.activeCount >= MAX_SLOTS)
+                break;
+            int insert = d.activeCount++;
+            d.active[insert] = slot;
+            if (d.activeCount == 1) {
+                d.downTime = now;
+                emit(d, MotionEvent.ACTION_DOWN, -1, d.active, 1, now);
+            } else {
+                emit(d, MotionEvent.ACTION_POINTER_DOWN, insert, d.active,
+                        d.activeCount, now);
+            }
+        }
+    }
+
+    private static boolean contains(int[] arr, int len, int value) {
+        for (int i = 0; i < len; i++) {
+            if (arr[i] == value)
+                return true;
+        }
+        return false;
+    }
+
+    private void emit(Dev d, int action, int actionIndex, int[] slots, int count,
+                      long eventTime) {
+        if (d.dup)
+            return;
+        MotionEvent ev = buildMotionEvent(d, action, actionIndex, slots, count,
+                eventTime);
+        if (ev == null)
+            return;
+        try {
+            if (d.pad != null) {
+                syncPadOutput(d);
+                d.pad.onTouch(ev);
+            } else {
+                host.onGrabbedTouch(ev);
+            }
+        } finally {
+            ev.recycle();
+        }
+    }
+
+    private void syncPadOutput(Dev d) {
+        if (d.pad != null)
+            d.pad.setOutputSize(host.outputWidth(), host.outputHeight());
+    }
+
+    private MotionEvent buildMotionEvent(Dev d, int action, int actionIndex,
+                                         int[] slots, int count, long eventTime) {
+        if (count <= 0 || count > MAX_SLOTS)
+            return null;
+        for (int i = 0; i < count; i++) {
+            int slot = slots[i];
+            props[i].id = slot;
+            props[i].toolType = MotionEvent.TOOL_TYPE_FINGER;
+            mapContact(d, slot);
+            coords[i].clear();
+            coords[i].x = mapped[0];
+            coords[i].y = mapped[1];
+            coords[i].pressure = 1f;
+            coords[i].size = 1f;
+        }
+        int act = action;
+        if (actionIndex >= 0 && (action == MotionEvent.ACTION_POINTER_DOWN
+                || action == MotionEvent.ACTION_POINTER_UP))
+            act |= actionIndex << MotionEvent.ACTION_POINTER_INDEX_SHIFT;
+        // obtain() reads exactly `count` entries, so the full-size scratch arrays
+        // can be handed over as they are. The source is deliberately
+        // SOURCE_TOUCHSCREEN even for a pad: Touchpad normalises pad coordinates
+        // with MotionEvent.transform(), which newer Android releases ignore for
+        // SOURCE_CLASS_POSITION events.
+        return MotionEvent.obtain(d.downTime, eventTime, act, count, props, coords,
+                0, 0, 1f, 1f, 0, 0, InputDevice.SOURCE_TOUCHSCREEN, 0);
+    }
+
+    /**
+     * Raw panel coordinates to the space the consumer expects.
+     *
+     * A touchscreen reports in its own fixed, panel-native frame, which does not
+     * turn with the display, so the rotation has to be undone here before scaling
+     * into view pixels. A pad has no such relationship to the screen: its
+     * coordinates stay as they are and {@link Touchpad#setInputBounds} does the
+     * normalising.
+     */
+    private void mapContact(Dev d, int slot) {
+        float rawX = d.x[slot];
+        float rawY = d.y[slot];
+        if (d.cls != InputGrab.CLASS_TOUCHSCREEN
+                || d.maxX <= d.minX || d.maxY <= d.minY) {
+            mapped[0] = rawX;
+            mapped[1] = rawY;
+            return;
+        }
+        float u = clamp01((rawX - d.minX) / (float) (d.maxX - d.minX));
+        float v = clamp01((rawY - d.minY) / (float) (d.maxY - d.minY));
+        float ou, ov;
+        switch (host.displayRotation()) {
+            case Surface.ROTATION_90:  ou = v;       ov = 1f - u; break;
+            case Surface.ROTATION_180: ou = 1f - u;  ov = 1f - v; break;
+            case Surface.ROTATION_270: ou = 1f - v;  ov = u;      break;
+            default:                   ou = u;       ov = v;      break;
+        }
+        mapped[0] = host.outputOriginX() + ou * host.outputWidth();
+        mapped[1] = host.outputOriginY() + ov * host.outputHeight();
+    }
+
+    private static float clamp01(float f) {
+        if (!(f > 0f))
+            return 0f;   // also catches NaN
+        return f > 1f ? 1f : f;
+    }
+
+    // ---- teardown --------------------------------------------------------
+
+    /**
+     * Let go of everything this session put down: contacts, mouse buttons and
+     * keys. A missed release would otherwise stay stuck on the desktop with no
+     * input left to clear it.
+     *
+     * @param forgetContacts true when the session is over. On a mid-session
+     *        resync the per-slot tracking state is kept instead, because a finger
+     *        still on the glass will not have its tracking id announced again —
+     *        keeping it lets the next frame bring the contact back as a fresh
+     *        press rather than losing it until the user lifts.
+     */
+    private void releaseEverything(boolean forgetContacts) {
+        long now = SystemClock.uptimeMillis();
+        for (Dev d : devs) {
+            if (d == null)
+                continue;
+            if (d.activeCount > 0) {
+                emit(d, MotionEvent.ACTION_CANCEL, -1, d.active, d.activeCount, now);
+                d.activeCount = 0;
+            }
+            if (forgetContacts) {
+                Arrays.fill(d.trackingId, -1);
+                d.stTouch = false;
+                d.stValid = false;
+            }
+            d.absDirty = false;
+            d.relX = d.relY = d.wheel = d.hwheel = 0f;
+            d.latchedButton = 0;
+            if (d.pad != null)
+                d.pad.cancel();
+        }
+        for (int code = 0; code < keyDown.length; code++) {
+            if (!keyDown[code])
+                continue;
+            keyDown[code] = false;
+            if (code >= BTN_FIRST && code <= BTN_LAST)
+                host.sendMouseButton(code, false);
+            else
+                host.sendKey(1, code);
+        }
+    }
+
+    private void toast(String text) {
+        Toast.makeText(ctx, text, Toast.LENGTH_SHORT).show();
+    }
+}

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/ImmersiveMode.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/ImmersiveMode.java
@@ -377,6 +377,9 @@ final class ImmersiveMode implements InputGrab.Listener {
 
     /** End the session. Safe to call at any time, including when not running. */
     void stop() {
+        // The receiver is registered against the activity. Remove it before the
+        // helper's asynchronous teardown can outlive that activity.
+        unregisterScreenOff();
         if (!active && !starting)
             return;
         grab.stop();
@@ -388,10 +391,11 @@ final class ImmersiveMode implements InputGrab.Listener {
      * When the screen locks, Android's keyguard is about to take over the
      * display — and the keyguard cannot be swiped while the touchscreen is
      * grabbed. The session must hand the input back the moment the screen goes
-     * dark, so the power key (never grabbed, see input_grab.c) can unlock again.
+     * dark, so Android's dedicated power path (kept ungrabbed by input_grab.c)
+     * can unlock again.
      * The receiver exists only for the duration of a session: registered in
-     * {@link #start}, dropped in {@link #onEnded}, which fires exactly once per
-     * successful start.
+     * {@link #start}, dropped synchronously in {@link #stop}; {@link #onEnded}
+     * repeats that idempotent cleanup for helper-initiated exits.
      */
     private final BroadcastReceiver screenOffReceiver = new BroadcastReceiver() {
         @Override

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/ImmersiveMode.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/ImmersiveMode.java
@@ -1,7 +1,11 @@
 package com.anland.consumer;
 
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Looper;
 import android.os.SystemClock;
 import android.util.Log;
@@ -40,7 +44,9 @@ import java.util.Arrays;
  * pressing it again leaves — the helper watches for that key itself, so the way
  * out never depends on this process being healthy. The Settings switch is only a
  * safety gate: with it off the key does nothing at all, and a session never
- * survives a pause, a focus change or a lost surface.
+ * survives a pause, a focus change, a lost surface or a locked screen — the
+ * keyguard needs the touchscreen, so the grab ends the moment the screen turns
+ * off (see {@link #registerScreenOff}).
  */
 final class ImmersiveMode implements InputGrab.Listener {
     private static final String TAG = "Anland";
@@ -357,6 +363,7 @@ final class ImmersiveMode implements InputGrab.Listener {
             toast(ctx.getString(R.string.immersive_failed));
             return;
         }
+        registerScreenOff();
         statsLastAt = 0L;
         statsEvents = 0;
         java.util.Arrays.fill(statsPerDev, 0);
@@ -373,6 +380,52 @@ final class ImmersiveMode implements InputGrab.Listener {
         if (!active && !starting)
             return;
         grab.stop();
+    }
+
+    // ---- screen-off safety ------------------------------------------------
+
+    /**
+     * When the screen locks, Android's keyguard is about to take over the
+     * display — and the keyguard cannot be swiped while the touchscreen is
+     * grabbed. The session must hand the input back the moment the screen goes
+     * dark, so the power key (never grabbed, see input_grab.c) can unlock again.
+     * The receiver exists only for the duration of a session: registered in
+     * {@link #start}, dropped in {@link #onEnded}, which fires exactly once per
+     * successful start.
+     */
+    private final BroadcastReceiver screenOffReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (Intent.ACTION_SCREEN_OFF.equals(intent.getAction())) {
+                Log.i(TAG, "screen off; leaving immersive mode");
+                stop();
+            }
+        }
+    };
+    private boolean screenOffRegistered = false;
+
+    private void registerScreenOff() {
+        if (screenOffRegistered)
+            return;
+        IntentFilter filter = new IntentFilter(Intent.ACTION_SCREEN_OFF);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+            ctx.registerReceiver(screenOffReceiver, filter,
+                    Context.RECEIVER_NOT_EXPORTED);
+        else
+            ctx.registerReceiver(screenOffReceiver, filter);
+        screenOffRegistered = true;
+    }
+
+    private void unregisterScreenOff() {
+        if (!screenOffRegistered)
+            return;
+        screenOffRegistered = false;
+        try {
+            ctx.unregisterReceiver(screenOffReceiver);
+        } catch (IllegalArgumentException ignored) {
+            // The activity auto-unregisters its receivers on destroy; a session
+            // end delivered after that has nothing left to unregister.
+        }
     }
 
     // ---- InputGrab.Listener (all on the main thread) ---------------------
@@ -423,6 +476,7 @@ final class ImmersiveMode implements InputGrab.Listener {
         boolean wasRunning = active || starting;
         if (wasRunning && reason == InputGrab.REASON_TOGGLE)
             suppressToggleTail();
+        unregisterScreenOff();
         active = false;
         starting = false;
         stats.removeCallbacks(statsTick);

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/ImmersiveMode.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/ImmersiveMode.java
@@ -192,6 +192,9 @@ final class ImmersiveMode implements InputGrab.Listener {
     private boolean starting = false;
     /** The user asked to leave, so the closing toast is theirs to see. */
     private boolean userExitPending = false;
+    private boolean suppressToggleUntilUp = false;
+    private long suppressToggleDeadlineMs = 0L;
+    private static final long TOGGLE_SUPPRESS_MS = 2000L;
 
     // Session telemetry: events per second, per-device event counts and the
     // panel's current rate, logged once a second while a session runs. It is the
@@ -274,6 +277,26 @@ final class ImmersiveMode implements InputGrab.Listener {
         return keycode == -1 ? -1 : KeyCodeMapper.getScanCode(keycode);
     }
 
+    private void suppressToggleTail() {
+        suppressToggleUntilUp = true;
+        suppressToggleDeadlineMs = SystemClock.uptimeMillis() + TOGGLE_SUPPRESS_MS;
+    }
+
+    private boolean consumeSuppressedToggle(KeyEvent event) {
+        if (!suppressToggleUntilUp)
+            return false;
+        if (SystemClock.uptimeMillis() > suppressToggleDeadlineMs) {
+            suppressToggleUntilUp = false;
+            suppressToggleDeadlineMs = 0L;
+            return false;
+        }
+        if (event.getAction() == KeyEvent.ACTION_UP) {
+            suppressToggleUntilUp = false;
+            suppressToggleDeadlineMs = 0L;
+        }
+        return true;
+    }
+
     /**
      * Consume the bound key. Called from both key paths — the accessibility
      * service eats keys before the window when interception is on, so neither
@@ -299,6 +322,8 @@ final class ImmersiveMode implements InputGrab.Listener {
         // Settings flags such a binding where the user can see it.
         if (boundScanCode() <= 0)
             return false;
+        if (consumeSuppressedToggle(event))
+            return true;
 
         if (event.getAction() == KeyEvent.ACTION_DOWN && event.getRepeatCount() == 0)
             toggle();
@@ -310,6 +335,7 @@ final class ImmersiveMode implements InputGrab.Listener {
     private void toggle() {
         if (active || starting) {
             userExitPending = true;
+            suppressToggleTail();
             stop();
         } else {
             start();
@@ -395,6 +421,8 @@ final class ImmersiveMode implements InputGrab.Listener {
     @Override
     public void onEnded(int reason) {
         boolean wasRunning = active || starting;
+        if (wasRunning && reason == InputGrab.REASON_TOGGLE)
+            suppressToggleTail();
         active = false;
         starting = false;
         stats.removeCallbacks(statsTick);

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/InputGrab.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/InputGrab.java
@@ -1,0 +1,520 @@
+package com.anland.consumer;
+
+import android.content.Context;
+import android.net.Credentials;
+import android.net.LocalServerSocket;
+import android.net.LocalSocket;
+import android.net.LocalSocketAddress;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
+import android.util.Log;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Transport for immersive mode: runs the bundled {@code libinputgrab.so} helper as
+ * root and turns its record stream into callbacks on the main thread.
+ *
+ * The app cannot open {@code /dev/input} itself (untrusted_app is denied
+ * {@code input_device:chr_file}), so the helper does it in the root context and
+ * streams the raw evdev events back. This is the same bridge shape
+ * {@code fd_helper.c} uses for the daemon connection, except the app is the one
+ * listening and the payload is events rather than a file descriptor.
+ *
+ * Because the helper holds an exclusive grab on the touchscreen while it runs,
+ * every failure mode here has to end with that grab released:
+ * <ul>
+ *   <li>closing the socket makes the helper see EOF and ungrab — and the kernel
+ *       closes it for us even if this process is killed outright;</li>
+ *   <li>the heartbeat below is written only while the <em>main thread</em> is
+ *       still running, so an ANR — not just a crash — also frees the input;</li>
+ *   <li>the helper watches the toggle key itself, which is what rescues a
+ *       session whose app went away without either of the above working;</li>
+ *   <li>and if the helper is somehow still alive shortly after {@link #stop}, it
+ *       is killed by the token this session put in its argv.</li>
+ * </ul>
+ */
+final class InputGrab {
+    private static final String TAG = "AnlandGrab";
+
+    /** Wire record size; see jni/input_grab.h. */
+    private static final int REC_SIZE = 32;
+    /** Byte offset of aux[0] inside a record. */
+    private static final int AUX0 = 12;
+
+    // rtype
+    private static final int REC_HELLO  = 1;
+    private static final int REC_DEVICE = 2;
+    private static final int REC_READY  = 3;
+    private static final int REC_EVENT  = 4;
+    private static final int REC_BYE    = 5;
+
+    // DEVICE.etype (device class)
+    static final int CLASS_TOUCHSCREEN = 1;
+    static final int CLASS_TOUCHPAD    = 2;
+    static final int CLASS_MOUSE       = 3;
+    static final int CLASS_KEYBOARD    = 4;
+
+    // DEVICE.aux[4] flags
+    static final int DEV_GRABBED    = 1;
+    static final int DEV_MULTITOUCH = 2;
+    static final int DEV_CLICKPAD   = 4;
+
+    /** Broadcast device id used by the helper's "records were dropped" marker. */
+    static final int DEV_ALL = 0xFFFF;
+
+    // Session end reasons. 1..4 mirror the helper's IGRAB_BYE_*; the rest are local.
+    static final int REASON_TOGGLE     = 1;  // toggle key pressed on a grabbed device
+    static final int REASON_PEER_GONE  = 2;
+    static final int REASON_STALLED    = 3;
+    static final int REASON_HELPER_ERR = 4;  // helper found nothing it could grab
+    static final int REASON_NO_ROOT    = 5;  // helper never connected (su denied/missing)
+    static final int REASON_IO         = 6;  // stream broke
+    static final int REASON_STOPPED    = 7;  // stop() was called
+
+    /** How long to wait for the helper to connect; a first-time su prompt is slow. */
+    private static final int CONNECT_TIMEOUT_MS = 20000;
+    private static final int HEARTBEAT_INTERVAL_MS = 1000;
+    /** The main thread must have run this recently for a heartbeat to be sent. */
+    private static final int MAIN_ALIVE_WINDOW_MS = 2500;
+    private static final int MAIN_BEACON_INTERVAL_MS = 500;
+    /** Grace period for the helper to notice a closed socket before we kill it. */
+    private static final int KILL_FALLBACK_MS = 1500;
+
+    interface Listener {
+        /** One opened device, before {@link #onReady}. Ranges are raw ABS units. */
+        void onDevice(int dev, int cls, int minX, int maxX, int minY, int maxY, int flags);
+        /** Device list complete; from here on only events arrive. */
+        void onReady(int grabbedCount);
+        /**
+         * A batch of evdev events as flat {dev, type, code, value} quadruples.
+         * Batched per SYN_REPORT so a multi-touch frame is applied in one piece.
+         */
+        void onEvents(int[] batch, int count);
+        /** The session ended, for any reason, exactly once per {@link #start}. */
+        void onEnded(int reason);
+    }
+
+    private final Context context;
+    private final Listener listener;
+    private final Handler main = new Handler(Looper.getMainLooper());
+
+    private LocalSocket binder;          // owns the listening fd; closed via `server`
+    private volatile LocalServerSocket server;
+    private volatile LocalSocket client;
+    private Thread heartbeat;
+
+    private volatile boolean running = false;
+    private volatile boolean stopping = false;
+    /**
+     * Token of a session whose helper is known to be gone, so the last-resort
+     * kill is skipped. Per-token rather than a flag: a delayed kill from the
+     * previous session must never target the one that replaced it.
+     */
+    private volatile String finishedToken = null;
+    private volatile long lastMainAlive = 0L;
+    private boolean endReported = false;
+    private volatile String killToken;
+
+    InputGrab(Context context, Listener listener) {
+        this.context = context.getApplicationContext();
+        this.listener = listener;
+    }
+
+    boolean isRunning() {
+        return running;
+    }
+
+    /**
+     * Launch a session. Returns false only when the listening socket could not be
+     * created; every later failure arrives through {@link Listener#onEnded}.
+     *
+     * @param toggleScanCode evdev code of the key that ends the session. The helper
+     *                       refuses to grab anything without it.
+     */
+    boolean start(int toggleScanCode) {
+        if (running)
+            return true;
+        if (toggleScanCode <= 0)
+            return false;
+
+        killToken = Long.toHexString(SystemClock.elapsedRealtimeNanos())
+                + Integer.toHexString(System.identityHashCode(this));
+        final String token = killToken;
+        final String socketName = "anland.igrab." + token;
+
+        try {
+            binder = new LocalSocket(LocalSocket.SOCKET_STREAM);
+            // Abstract namespace (LocalServerSocket's own default): no file to
+            // create, chmod or leave behind, and root needs one SELinux
+            // permission fewer than for a socket in the app's cache dir. The name
+            // carries a random token and the peer's uid is checked on accept, so
+            // another app cannot slip into the event stream.
+            binder.bind(new LocalSocketAddress(socketName,
+                    LocalSocketAddress.Namespace.ABSTRACT));
+            server = new LocalServerSocket(binder.getFileDescriptor());
+        } catch (IOException e) {
+            Log.e(TAG, "cannot listen on " + socketName, e);
+            closeAll();
+            return false;
+        }
+
+        running = true;
+        stopping = false;
+        finishedToken = null;
+        endReported = false;
+        lastMainAlive = SystemClock.uptimeMillis();
+        main.postDelayed(mainBeacon, MAIN_BEACON_INTERVAL_MS);
+
+        final String helper = context.getApplicationInfo().nativeLibraryDir
+                + "/libinputgrab.so";
+        Thread worker = new Thread(() -> run(helper, socketName, toggleScanCode, token),
+                "anland-inputgrab");
+        worker.setDaemon(true);
+        worker.start();
+        return true;
+    }
+
+    /** End the session. Idempotent; {@link Listener#onEnded} still fires once. */
+    void stop() {
+        if (!running)
+            return;
+        stopping = true;
+        final String token = killToken;
+        // Closing the socket is the release that matters: the helper's poll()
+        // sees EOF and ungrabs. Everything else here is a backstop.
+        closeAll();
+        main.postDelayed(() -> killHelper(token), KILL_FALLBACK_MS);
+    }
+
+    // ---- main-thread liveness beacon -------------------------------------
+
+    // Re-posts itself while a session is live. The heartbeat writer only sends
+    // when this ran recently, so a wedged main thread stops the heartbeat and the
+    // helper hands the input back without needing anything from us.
+    private final Runnable mainBeacon = new Runnable() {
+        @Override
+        public void run() {
+            if (!running)
+                return;
+            lastMainAlive = SystemClock.uptimeMillis();
+            main.postDelayed(this, MAIN_BEACON_INTERVAL_MS);
+        }
+    };
+
+    // ---- worker ----------------------------------------------------------
+
+    private void run(String helperPath, String socketName, int toggleScanCode,
+                     String token) {
+        int reason = REASON_NO_ROOT;
+        Process p = null;
+        try {
+            // The token is inert to the helper (it stops parsing after argv[2]);
+            // it exists so this session can find its own process again later.
+            String cmd = helperPath + " " + socketName + " " + toggleScanCode
+                    + " igrabtoken=" + token + " >/dev/null 2>&1";
+            try {
+                p = new ProcessBuilder("su", "-c", cmd)
+                        .redirectErrorStream(true).start();
+            } catch (IOException e) {
+                // `su` is missing or refused outright: nothing was launched, so
+                // nothing can be holding a grab and no kill is needed.
+                Log.w(TAG, "su failed: " + e);
+                finishedToken = token;
+                return;
+            }
+            drain(p);
+
+            LocalSocket sock = acceptHelper();
+            if (sock == null) {
+                // Nothing was ever grabbed: a helper that starts late finds the
+                // abstract name gone, fails to connect and exits before it
+                // touches any device.
+                finishedToken = token;
+                return;
+            }
+            client = sock;
+            if (stopping)
+                return;
+            startHeartbeat(sock);
+            reason = readLoop(sock, token);
+        } catch (IOException e) {
+            // The stream broke with the helper possibly still grabbing; the kill
+            // in the finally block is what covers that.
+            Log.w(TAG, "immersive stream ended: " + e);
+            reason = REASON_IO;
+        } catch (Throwable t) {
+            Log.e(TAG, "immersive session crashed", t);
+            reason = REASON_IO;
+        } finally {
+            final int r = stopping ? REASON_STOPPED : reason;
+            closeAll();
+            killHelper(token);
+            if (p != null)
+                p.destroy();
+            main.post(() -> finish(r));
+        }
+    }
+
+    /** Discard the su pipe so a chatty `su` can never block on a full one. */
+    private void drain(final Process p) {
+        Thread t = new Thread(() -> {
+            byte[] scratch = new byte[256];
+            try (InputStream in = p.getInputStream()) {
+                while (in.read(scratch) >= 0) {
+                    // discarded on purpose: the helper logs through liblog
+                }
+            } catch (IOException ignored) {
+            }
+        }, "anland-inputgrab-drain");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    /**
+     * Wait for the helper's connection, verifying it really is root: the abstract
+     * name is reachable process-wide, so an unprivileged peer is refused rather
+     * than handed the device's entire input stream.
+     */
+    private LocalSocket acceptHelper() {
+        final LocalServerSocket srv = server;
+        if (srv == null)
+            return null;
+        // LocalServerSocket has no accept timeout; close it from a timer instead.
+        // Closing an fd on Android signals threads blocked on it, so the pending
+        // accept() returns. Guarded on identity so a timer left over from an
+        // earlier session cannot close this one's listener.
+        main.postDelayed(() -> {
+            if (server == srv && client == null)
+                closeServer();
+        }, CONNECT_TIMEOUT_MS);
+        try {
+            LocalSocket sock = srv.accept();
+            Credentials cred = sock.getPeerCredentials();
+            if (cred == null || cred.getUid() != 0) {
+                Log.e(TAG, "rejecting non-root peer uid="
+                        + (cred == null ? -1 : cred.getUid()));
+                sock.close();
+                return null;
+            }
+            // One peer only. Dropping the listener also releases the abstract
+            // name, so nothing else can connect for the rest of the session.
+            closeServer();
+            return sock;
+        } catch (IOException e) {
+            if (!stopping)
+                Log.w(TAG, "helper did not connect: " + e);
+            return null;
+        }
+    }
+
+    private void startHeartbeat(final LocalSocket sock) {
+        Thread hb = new Thread(() -> {
+            try {
+                OutputStream out = sock.getOutputStream();
+                byte[] beat = {(byte) 0xA5};
+                while (running && !stopping) {
+                    Thread.sleep(HEARTBEAT_INTERVAL_MS);
+                    if (SystemClock.uptimeMillis() - lastMainAlive
+                            > MAIN_ALIVE_WINDOW_MS) {
+                        // Withholding the beat is the point: a main thread that
+                        // stopped running cannot end the session, so let the
+                        // helper time out and release the devices itself.
+                        Log.w(TAG, "main thread stalled; withholding heartbeat");
+                        continue;
+                    }
+                    out.write(beat);
+                    out.flush();
+                }
+            } catch (InterruptedException ignored) {
+            } catch (IOException e) {
+                // Socket already gone; the read loop reports the end.
+            }
+        }, "anland-inputgrab-hb");
+        heartbeat = hb;
+        hb.setDaemon(true);
+        hb.start();
+    }
+
+    /**
+     * Parse the fixed-size record stream. Records carry no length field precisely
+     * so that the helper can drop them under back-pressure without ever
+     * desyncing this parser.
+     */
+    private int readLoop(LocalSocket sock, String token) throws IOException {
+        InputStream in = sock.getInputStream();
+        byte[] buf = new byte[REC_SIZE * 64];
+        ByteBuffer bb = ByteBuffer.wrap(buf).order(ByteOrder.LITTLE_ENDIAN);
+        int have = 0;
+        int[] batch = new int[512];
+        int batchLen = 0;
+
+        while (!stopping) {
+            int n = in.read(buf, have, buf.length - have);
+            if (n < 0)
+                return REASON_PEER_GONE;
+            have += n;
+
+            int off = 0;
+            while (have - off >= REC_SIZE) {
+                final int rec = off;
+                off += REC_SIZE;
+
+                int rtype = bb.getShort(rec) & 0xFFFF;
+                int dev   = bb.getShort(rec + 2) & 0xFFFF;
+                int etype = bb.getShort(rec + 4) & 0xFFFF;
+                int code  = bb.getShort(rec + 6) & 0xFFFF;
+                int value = bb.getInt(rec + 8);
+
+                switch (rtype) {
+                    case REC_HELLO:
+                        Log.i(TAG, "helper v" + value + " pid=" + bb.getInt(rec + AUX0 + 4)
+                                + " grabbed=" + bb.getInt(rec + AUX0));
+                        break;
+                    case REC_DEVICE: {
+                        final int d = dev, cls = etype;
+                        final int minX = bb.getInt(rec + AUX0);
+                        final int maxX = bb.getInt(rec + AUX0 + 4);
+                        final int minY = bb.getInt(rec + AUX0 + 8);
+                        final int maxY = bb.getInt(rec + AUX0 + 12);
+                        final int flags = bb.getInt(rec + AUX0 + 16);
+                        main.post(() -> {
+                            if (running)
+                                listener.onDevice(d, cls, minX, maxX, minY, maxY, flags);
+                        });
+                        break;
+                    }
+                    case REC_READY: {
+                        final int grabbed = bb.getInt(rec + AUX0);
+                        main.post(() -> {
+                            if (running)
+                                listener.onReady(grabbed);
+                        });
+                        break;
+                    }
+                    case REC_EVENT:
+                        if (batchLen + 4 > batch.length)
+                            batchLen = flush(batch, batchLen);
+                        batch[batchLen++] = dev;
+                        batch[batchLen++] = etype;
+                        batch[batchLen++] = code;
+                        batch[batchLen++] = value;
+                        if (etype == 0 && code == 0)   // EV_SYN / SYN_REPORT
+                            batchLen = flush(batch, batchLen);
+                        break;
+                    case REC_BYE:
+                        flush(batch, batchLen);
+                        // The helper only sends this on its way out, so no kill
+                        // is needed for this session.
+                        finishedToken = token;
+                        return (value >= REASON_TOGGLE && value <= REASON_HELPER_ERR)
+                                ? value : REASON_PEER_GONE;
+                    default:
+                        Log.e(TAG, "bad record type " + rtype + "; ending session");
+                        flush(batch, batchLen);
+                        return REASON_IO;
+                }
+            }
+
+            if (off > 0 && off < have)
+                System.arraycopy(buf, off, buf, 0, have - off);
+            have -= off;
+            // Nothing left to parse: push what is pending rather than sit on it
+            // waiting for a SYN that a key-only device never sends.
+            batchLen = flush(batch, batchLen);
+        }
+        return REASON_STOPPED;
+    }
+
+    private int flush(int[] batch, int len) {
+        if (len == 0)
+            return 0;
+        final int[] copy = new int[len];
+        System.arraycopy(batch, 0, copy, 0, len);
+        main.post(() -> {
+            if (running)
+                listener.onEvents(copy, copy.length);
+        });
+        return 0;
+    }
+
+    // ---- teardown --------------------------------------------------------
+
+    private void finish(int reason) {
+        if (endReported)
+            return;
+        endReported = true;
+        running = false;
+        main.removeCallbacks(mainBeacon);
+        listener.onEnded(reason);
+    }
+
+    private void closeServer() {
+        LocalServerSocket srv = server;
+        server = null;
+        if (srv != null) {
+            try {
+                srv.close();
+            } catch (IOException ignored) {
+            }
+        }
+        // `binder` shares the listening fd with `server`; closing it a second time
+        // would close whatever fd number has been reused since. Drop the
+        // reference only — it exists to keep the fd alive, not to own it.
+        binder = null;
+    }
+
+    private void closeAll() {
+        closeServer();
+        LocalSocket c = client;
+        client = null;
+        if (c != null) {
+            try {
+                // Half-close first so the helper's read() sees EOF immediately
+                // and starts ungrabbing, rather than waiting on the close.
+                c.shutdownOutput();
+            } catch (IOException ignored) {
+            }
+            try {
+                c.close();
+            } catch (IOException ignored) {
+            }
+        }
+        Thread hb = heartbeat;
+        heartbeat = null;
+        if (hb != null)
+            hb.interrupt();
+    }
+
+    /**
+     * Last resort when the helper did not announce its own exit. Matched on the
+     * token this session put in its argv rather than on a pid, so a recycled pid
+     * can never be the target; the "[x]" prefix keeps the pattern from matching
+     * the shell that runs pkill.
+     */
+    private void killHelper(final String token) {
+        if (token == null || token.isEmpty() || token.equals(finishedToken))
+            return;
+        finishedToken = token;
+        Thread t = new Thread(() -> {
+            String pattern = "igrabtoken=[" + token.charAt(0) + "]" + token.substring(1);
+            Process p = null;
+            try {
+                p = new ProcessBuilder("su", "-c",
+                        "pkill -9 -f '" + pattern + "' >/dev/null 2>&1").start();
+                p.waitFor();
+            } catch (Exception ignored) {
+            } finally {
+                if (p != null)
+                    p.destroy();
+            }
+        }, "anland-inputgrab-kill");
+        t.setDaemon(true);
+        t.start();
+    }
+}

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/InputGrab.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/InputGrab.java
@@ -377,6 +377,11 @@ final class InputGrab {
                                 + " grabbed=" + bb.getInt(rec + AUX0));
                         break;
                     case REC_DEVICE: {
+                        // A hotplug replacement is preceded by a global
+                        // SYN_DROPPED. Post that batch before replacing devs[d],
+                        // otherwise the main thread can cancel old state through
+                        // the new device object when both records share a read.
+                        batchLen = flush(batch, batchLen);
                         final int d = dev, cls = etype;
                         final int minX = bb.getInt(rec + AUX0);
                         final int maxX = bb.getInt(rec + AUX0 + 4);
@@ -390,6 +395,7 @@ final class InputGrab {
                         break;
                     }
                     case REC_READY: {
+                        batchLen = flush(batch, batchLen);
                         final int grabbed = bb.getInt(rec + AUX0);
                         main.post(() -> {
                             if (running)
@@ -408,7 +414,7 @@ final class InputGrab {
                             batchLen = flush(batch, batchLen);
                         break;
                     case REC_BYE:
-                        flush(batch, batchLen);
+                        batchLen = flush(batch, batchLen);
                         // The helper only sends this on its way out, so no kill
                         // is needed for this session.
                         finishedToken = token;

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/KeyCodeMapper.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/KeyCodeMapper.java
@@ -1,10 +1,45 @@
 package com.anland.consumer;
 
+import android.content.Context;
 import android.util.SparseIntArray;
 import android.view.KeyEvent;
 
 public class KeyCodeMapper {
     private static final SparseIntArray MAP = new SparseIntArray();
+
+    /** Android keycode → localized name, for the keys worth binding to. */
+    private static final SparseIntArray NAME_RES = new SparseIntArray();
+    static {
+        NAME_RES.put(KeyEvent.KEYCODE_VOLUME_UP, R.string.key_volume_up);
+        NAME_RES.put(KeyEvent.KEYCODE_VOLUME_DOWN, R.string.key_volume_down);
+        NAME_RES.put(KeyEvent.KEYCODE_VOLUME_MUTE, R.string.key_volume_mute);
+        NAME_RES.put(KeyEvent.KEYCODE_POWER, R.string.key_power);
+        NAME_RES.put(KeyEvent.KEYCODE_CAMERA, R.string.key_camera);
+        NAME_RES.put(KeyEvent.KEYCODE_HEADSETHOOK, R.string.key_headset_hook);
+        NAME_RES.put(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, R.string.key_media_play_pause);
+        NAME_RES.put(KeyEvent.KEYCODE_MEDIA_NEXT, R.string.key_media_next);
+        NAME_RES.put(KeyEvent.KEYCODE_MEDIA_PREVIOUS, R.string.key_media_previous);
+        NAME_RES.put(KeyEvent.KEYCODE_BRIGHTNESS_UP, R.string.key_brightness_up);
+        NAME_RES.put(KeyEvent.KEYCODE_BRIGHTNESS_DOWN, R.string.key_brightness_down);
+        NAME_RES.put(KeyEvent.KEYCODE_HOME, R.string.key_home);
+        NAME_RES.put(KeyEvent.KEYCODE_BACK, R.string.key_back);
+    }
+
+    /**
+     * A name for a bound key, for status lines and toasts. Falls back to the raw
+     * key code, or to the evdev scan code when Android had no key code for it at
+     * all (some vendor keys only report a scan code).
+     */
+    public static String keyName(Context ctx, int keyCode, int scanCode) {
+        int nameRes = NAME_RES.get(keyCode);
+        if (nameRes != 0)
+            return ctx.getString(nameRes);
+        if (keyCode != -1 && keyCode != KeyEvent.KEYCODE_UNKNOWN)
+            return ctx.getString(R.string.keycode_unknown, keyCode);
+        if (scanCode > 0)
+            return ctx.getString(R.string.scancode_unknown, scanCode);
+        return ctx.getString(R.string.status_current_none);
+    }
 
     static {
         // 字母 A-Z

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -7,6 +7,7 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
@@ -40,7 +41,7 @@ import java.nio.charset.StandardCharsets;
 
 
 public class MainActivity extends Activity
-        implements SurfaceHolder.Callback, SystemIME.Host {
+        implements SurfaceHolder.Callback, SystemIME.Host, ImmersiveMode.Host {
     private static final String TAG = "Anland";
 
     private SurfaceView surfaceView;
@@ -203,6 +204,17 @@ public class MainActivity extends Activity
     // across the midline before lift-off cannot strand a held button.
     private int lastTouchpadBtnPressed = 0;
 
+    // Immersive mode: a root helper grabs the physical input devices so nothing
+    // reaches Android at all, and their events are replayed onto the desktop
+    // through the same paths as the on-screen ones. Off unless the user both
+    // enables it in Settings and presses the key they bound to it.
+    private ImmersiveMode immersive;
+    private boolean immersiveActive = false;
+    // Cached display rotation. A grabbed touchscreen reports in the panel's own
+    // fixed frame, so the rotation has to be undone before its coordinates mean
+    // anything on screen; reading it per contact would be wasteful.
+    private int displayRotation = Surface.ROTATION_0;
+
     static {
         // Loads the single shared .so backing MainActivity, Native and
         // CameraServices; the last two only declare their natives.
@@ -216,10 +228,19 @@ public class MainActivity extends Activity
             @Override public void onDisplayRemoved(int displayId) {}
             @Override public void onDisplayChanged(int displayId) {
                 Display d = getDisplay();
-                if (d != null && d.getDisplayId() == displayId)
+                if (d != null && d.getDisplayId() == displayId) {
                     pushRefreshRate();
+                    updateDisplayRotation();
+                }
             }
         };
+
+    /** Keep the cached rotation current; see {@link #displayRotation}. */
+    private void updateDisplayRotation() {
+        Display d = getDisplay();
+        if (d != null)
+            displayRotation = d.getRotation();
+    }
 
     // Called from native on_fallback (display lib dropped the connection). Runs on a
     // native worker thread, so hop to the UI thread before touching the toast/finish.
@@ -266,6 +287,11 @@ public class MainActivity extends Activity
                 releasePointerCapture(false);
             }
         }
+        // Losing focus means something else is on screen (a system dialog, a
+        // call). Holding an exclusive grab on every input device through that
+        // would leave the user with nothing to answer it with.
+        if (!hasFocus && immersive != null)
+            immersive.stop();
     }
 
     private void pushRefreshRate() {
@@ -549,6 +575,10 @@ public class MainActivity extends Activity
         capturedTouchpad = new Touchpad(this, new TouchpadOutput(false), false);
         applyTouchpadPrefs(prefs);
         pointerCaptureEnabled = prefs.getBoolean(KEY_POINTER_CAPTURE, false);
+        updateDisplayRotation();
+        // Never starts a session by itself: the user has to enable it in Settings
+        // and press the key they bound to it.
+        immersive = new ImmersiveMode(this);
 
         // Requesting capture before the window is attached is a no-op. The post
         // below covers the initial attach; onWindowFocusChanged() retries after a
@@ -713,26 +743,26 @@ public class MainActivity extends Activity
     private void applyTouchpadPrefs(SharedPreferences prefs) {
         capturedTouchpadAccel = Math.max(0.5f,
                 Math.min(10.0f, prefs.getFloat(KEY_MOUSE_ACCEL, 1.0f)));
-        float scrollSpeed = prefs.getFloat(KEY_SCROLL_SPEED,
-                Touchpad.DEFAULT_SCROLL_SPEED);
-        boolean scrollReversed = prefs.getBoolean(KEY_SCROLL_REVERSE, false);
-        float scrollFactor = prefs.getFloat(KEY_SCROLL_THRESHOLD,
-                Touchpad.DEFAULT_SCROLL_THRESHOLD_FACTOR);
-        float moveFactor = prefs.getFloat(KEY_MOVE_THRESHOLD,
-                Touchpad.DEFAULT_MOVE_THRESHOLD_FACTOR);
-        float gestureScale = prefs.getFloat(KEY_GESTURE_SCALE,
-                Touchpad.DEFAULT_GESTURE_SCALE);
+        applyTouchpadPrefs(prefs, screenTouchpad);
+        applyTouchpadPrefs(prefs, capturedTouchpad);
+    }
 
-        Touchpad[] touchpads = {screenTouchpad, capturedTouchpad};
-        for (Touchpad pad : touchpads) {
-            if (pad == null)
-                continue;
-            pad.setAccelStrength(capturedTouchpadAccel);
-            pad.setScrollSpeed(scrollSpeed);
-            pad.setScrollReversed(scrollReversed);
-            pad.setGestureThresholds(scrollFactor, moveFactor);
-            pad.setGestureScale(gestureScale);
-        }
+    /** The same tuning for one pad, so an immersive session's pad shares it. */
+    private void applyTouchpadPrefs(SharedPreferences prefs, Touchpad pad) {
+        if (pad == null)
+            return;
+        pad.setAccelStrength(Math.max(0.5f,
+                Math.min(10.0f, prefs.getFloat(KEY_MOUSE_ACCEL, 1.0f))));
+        pad.setScrollSpeed(prefs.getFloat(KEY_SCROLL_SPEED,
+                Touchpad.DEFAULT_SCROLL_SPEED));
+        pad.setScrollReversed(prefs.getBoolean(KEY_SCROLL_REVERSE, false));
+        pad.setGestureThresholds(
+                prefs.getFloat(KEY_SCROLL_THRESHOLD,
+                        Touchpad.DEFAULT_SCROLL_THRESHOLD_FACTOR),
+                prefs.getFloat(KEY_MOVE_THRESHOLD,
+                        Touchpad.DEFAULT_MOVE_THRESHOLD_FACTOR));
+        pad.setGestureScale(prefs.getFloat(KEY_GESTURE_SCALE,
+                Touchpad.DEFAULT_GESTURE_SCALE));
     }
 
     /**
@@ -765,9 +795,11 @@ public class MainActivity extends Activity
     }
 
     /** Whether pointer capture should be active. Setting ON -> always on (the var is
-     *  ignored); setting OFF -> follows the producer's CONSUMER_VAR_CAPTURE_MOUSE. */
+     *  ignored); setting OFF -> follows the producer's CONSUMER_VAR_CAPTURE_MOUSE.
+     *  An immersive session overrides both: the pointer is already grabbed at the
+     *  evdev level, so Android's capture would only fight with it. */
     private boolean pointerCaptureWanted() {
-        return pointerCaptureEnabled || captureMouseForced;
+        return !immersiveActive && (pointerCaptureEnabled || captureMouseForced);
     }
 
     /** Called from the native event thread when the producer sets a consumer var.
@@ -1443,6 +1475,7 @@ public class MainActivity extends Activity
         DisplayManager dm = getSystemService(DisplayManager.class);
         if (dm != null)
             dm.registerDisplayListener(displayListener, null);
+        updateDisplayRotation();
         // Bring the camera service up (or confirm it disabled) BEFORE nativeStart, so
         // the render thread's do_connect() sees a settled camera_service_is_ready()
         // and registers SERVICE_TYPE_CAMERA on the very first connect rather than a
@@ -1481,6 +1514,9 @@ public class MainActivity extends Activity
         // Socket-missing bounce: no pipeline exists, so skip teardown (mNative is
         // null) and don't let the jump to Settings trigger any of it.
         if (mForceSettings) return;
+        // A session must never outlive the foreground: leaving the input devices
+        // grabbed for a window the user has left is how a tablet gets bricked.
+        if (immersive != null) immersive.stop();
         clearPointerCaptureBackTracking();
         releasePointerCapture(false);
         NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
@@ -1495,6 +1531,7 @@ public class MainActivity extends Activity
     @Override
     protected void onDestroy() {
         abandonMediaAudioFocus();
+        if (immersive != null) immersive.stop();
         releasePointerCapture(false);
         if (mRegisteredSocket != null) {
             sWindowsBySocket.remove(mRegisteredSocket, this);
@@ -1605,6 +1642,7 @@ public class MainActivity extends Activity
         Log.i(TAG, "surfaceChanged: " + width + "x" + height);
         viewWidth = width;
         viewHeight = height;
+        updateDisplayRotation();
         ensurePointerPosition();
         surfaceReady = true;
         // Same ordering guarantee as onResume: camera service settled before connect.
@@ -1626,6 +1664,7 @@ public class MainActivity extends Activity
     @Override
     public void surfaceDestroyed(SurfaceHolder holder) {
         surfaceReady = false;
+        if (immersive != null) immersive.stop();
         releasePointerCapture(false);
         mNative.stop();
     }
@@ -1858,6 +1897,163 @@ public class MainActivity extends Activity
         }
     }
 
+    // ---- ImmersiveMode.Host ----
+    //
+    // Immersive mode replays grabbed devices through the paths the on-screen
+    // input already uses, so touchpad mode, the pointer sensitivity and the
+    // gesture tuning apply to it without any of it being reimplemented.
+
+    @Override
+    public Context context() {
+        return this;
+    }
+
+    @Override
+    public int outputWidth() {
+        return pointerViewWidth();
+    }
+
+    @Override
+    public int outputHeight() {
+        return pointerViewHeight();
+    }
+
+    /** The panel's current rate, for the session's telemetry line. */
+    @Override
+    public float displayRefreshHz() {
+        Display d = getDisplay();
+        return d != null ? d.getRefreshRate() : 0f;
+    }
+
+    // Letterboxed output starts at the surface's centering offset, the same
+    // origin the virtual cursor is clamped to.
+    @Override
+    public float outputOriginX() {
+        return pointerOriginX();
+    }
+
+    @Override
+    public float outputOriginY() {
+        return pointerOriginY();
+    }
+
+    @Override
+    public int displayRotation() {
+        return displayRotation;
+    }
+
+    /**
+     * A frame from the grabbed touchscreen, already in view pixels. This is the
+     * non-mouse branch of {@link #onTouchEvent} verbatim, which is the point:
+     * with touchpad mode on the finger drives the cursor relatively, with it off
+     * the touch maps straight onto the desktop.
+     */
+    @Override
+    public void onGrabbedTouch(MotionEvent ev) {
+        if (mNative == null)
+            return;
+        if (isTouchpadMode) {
+            updateTouchpadBounds(null);
+            screenTouchpad.onTouch(ev);
+        } else {
+            handleTouchEvent(ev);
+        }
+    }
+
+    /**
+     * A {@link Touchpad} for a grabbed physical pad. Its recognized motion is the
+     * cursor here (emitMotion), unlike Android's captured pad, whose movement
+     * comes from the driver's own relative axes; and its taps are the only click
+     * source, since the tap-to-click Android would have done is bypassed.
+     */
+    @Override
+    public Touchpad newGrabbedPad() {
+        Touchpad pad = new Touchpad(this, new TouchpadOutput(true), true);
+        applyTouchpadPrefs(getSharedPreferences(PREFS_NAME, MODE_PRIVATE), pad);
+        pad.setOutputSize(pointerViewWidth(), pointerViewHeight());
+        return pad;
+    }
+
+    @Override
+    public void movePointerRelative(float dx, float dy) {
+        // Same acceleration curve as a captured pad, so the sensitivity slider
+        // under Touchpad & Mouse means the same thing in an immersive session.
+        sendCapturedTouchpadMotion(dx, dy);
+    }
+
+    @Override
+    public void sendKey(int action, int evdev) {
+        if (mNative != null)
+            mNative.sendKey(action, evdev);
+    }
+
+    @Override
+    public void sendMouseButton(int button, boolean pressed) {
+        if (mNative != null)
+            mNative.sendMouseButton(button, pressed);
+    }
+
+    @Override
+    public void sendMouseScroll(int axis, float value) {
+        if (mNative != null)
+            mNative.sendMouseScroll(axis, value);
+    }
+
+    @Override
+    public void onImmersiveChanged(boolean active) {
+        immersiveActive = active;
+        if (active) {
+            // The pointer is grabbed at the evdev level for the whole session, so
+            // Android's capture is dropped for its duration. The user's "capture
+            // external pointer" setting is left alone and takes effect again as
+            // soon as the session ends.
+            releasePointerCapture(false);
+            pinDisplayRefreshRate(true);
+        } else {
+            pinDisplayRefreshRate(false);
+            if (mRoot != null)
+                mRoot.post(this::syncPointerCapture);
+        }
+    }
+
+    /**
+     * While an immersive session runs, the desktop is the only thing on screen.
+     * Panels with power-saving mode switching drop to 30-60 Hz when the image
+     * goes still, which reads as a sudden refresh-rate drop and stutter the
+     * moment the user stops moving the pointer; a touch on the panel would have
+     * kept it boosted before. Pin the display to a high rate for the duration
+     * (KWin follows the resulting mode switch through pushRefreshRate).
+     */
+    private void pinDisplayRefreshRate(boolean pin) {
+        try {
+            Surface s = surfaceView.getHolder().getSurface();
+            if (s == null || !s.isValid())
+                return;
+            if (!pin) {
+                s.setFrameRate(0f, Surface.FRAME_RATE_COMPATIBILITY_DEFAULT,
+                        Surface.CHANGE_FRAME_RATE_ALWAYS);
+                return;
+            }
+            Display d = getDisplay();
+            if (d == null)
+                return;
+            float hz = d.getRefreshRate();
+            if (hz < 90f) {
+                // Entered mid-drop: go for the panel's best instead of pinning
+                // whatever low rate it has fallen to.
+                for (float r : d.getSupportedRefreshRates()) {
+                    if (r > hz)
+                        hz = r;
+                }
+            }
+            s.setFrameRate(hz, Surface.FRAME_RATE_COMPATIBILITY_DEFAULT,
+                    Surface.CHANGE_FRAME_RATE_ALWAYS);
+            Log.i(TAG, "immersive: display pinned at " + hz + " Hz");
+        } catch (Exception e) {
+            Log.w(TAG, "setFrameRate failed: " + e);
+        }
+    }
+
     // ================================================================
     // Route touchscreen gestures and ordinary (non-captured) mouse events.
     // ================================================================
@@ -1943,6 +2139,10 @@ public class MainActivity extends Activity
 
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
+        // First: the immersive toggle is the way out of a session that has taken
+        // every input device, so nothing else may consume it.
+        if (immersive != null && immersive.handleKey(event))
+            return true;
         if (handlePointerCaptureBackKey(event))
             return true;
         // Mouse Back is already forwarded as BTN_SIDE from the MotionEvent path.
@@ -1991,6 +2191,11 @@ public class MainActivity extends Activity
     // Called from KeyInterceptor (accessibility service) to handle keys that
     // the normal onKeyDown/onKeyUp might miss (e.g. Fn combos).
     public boolean handleAccessibilityKey(KeyEvent event) {
+        // With interception on, KeyInterceptor consumes keys before the window
+        // ever sees them, so the immersive toggle has to be recognised here too —
+        // the two features are wanted by exactly the same users.
+        if (immersive != null && immersive.handleKey(event))
+            return true;
         if (handlePointerCaptureBackKey(event))
             return true;
         if (event.getKeyCode() == KeyEvent.KEYCODE_BACK && isMouseKeyEvent(event))
@@ -2052,6 +2257,8 @@ public class MainActivity extends Activity
 
     @Override
     public boolean onKeyUp(int keyCode, KeyEvent event) {
+        if (immersive != null && immersive.handleKey(event))
+            return true;
         if (handlePointerCaptureBackKey(event))
             return true;
         if (keyCode == KeyEvent.KEYCODE_BACK && isMouseKeyEvent(event))

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -1001,11 +1001,14 @@ public class MainActivity extends Activity
         if (action == MotionEvent.ACTION_MOVE || action == MotionEvent.ACTION_HOVER_MOVE) {
             // Relative mouse samples can be batched.  Consume every historical
             // sample so fast movements do not lose deltas between frames.
+            // Same acceleration curve as the touchpads: a Bluetooth mouse is
+            // SOURCE_MOUSE_RELATIVE, and without this it would bypass the
+            // sensitivity setting entirely.
             for (int i = 0; i < event.getHistorySize(); i++) {
-                movePointerBy(event.getHistoricalX(0, i),
+                sendCapturedTouchpadMotion(event.getHistoricalX(0, i),
                         event.getHistoricalY(0, i));
             }
-            movePointerBy(event.getX(), event.getY());
+            sendCapturedTouchpadMotion(event.getX(), event.getY());
         }
 
         if (action == MotionEvent.ACTION_SCROLL) {

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
@@ -14,7 +14,6 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.text.InputType;
 import android.util.Log;
-import android.util.SparseIntArray;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.KeyEvent;
@@ -50,6 +49,9 @@ public class SettingsActivity extends Activity {
     private static final String KEY_SPEAKER_LATENCY_MS = "speaker_latency_ms";
     private static final String KEY_MIC_LATENCY_MS = "mic_latency_ms";
     private static final String KEY_ACCESSIBILITY_ENABLED = "accessibility_key_intercept";
+    private static final String KEY_IMMERSIVE_ENABLED = ImmersiveMode.KEY_ENABLED;
+    private static final String KEY_IMMERSIVE_KEYCODE = ImmersiveMode.KEY_KEYCODE;
+    private static final String KEY_IMMERSIVE_SCANCODE = ImmersiveMode.KEY_SCANCODE;
     private static final String KEY_EXTRA_KEYS_MODE = "extra_keys_mode";
     // Mapped to R.array.extra_keys_mode_options positions
     private static final String MODE_ALWAYS = "always";
@@ -83,32 +85,13 @@ public class SettingsActivity extends Activity {
     private enum Page { HOME, KEYBOARD, TOUCHPAD, CONNECTION, RESOLUTION, GENERAL }
     private Page currentPage = Page.HOME;
 
-    private Button bindButton;
-    private TextView statusText;
-    private CountDownTimer listenTimer;
-    private boolean isListening = false;
+    // The key-binding row currently counting down, if any: it gets the next key
+    // press. The rows themselves live in the page's view hierarchy.
+    private KeyBinding listeningBinding;
 
     // Custom extra-keys layout editor (JSON), and the SAF file-picker request code.
     private EditText layoutInput;
     private static final int REQ_PICK_LAYOUT = 2001;
-
-    // Android keycode → localized name string resource
-    private static final SparseIntArray KEY_NAME_RES = new SparseIntArray();
-    static {
-        KEY_NAME_RES.put(KeyEvent.KEYCODE_VOLUME_UP, R.string.key_volume_up);
-        KEY_NAME_RES.put(KeyEvent.KEYCODE_VOLUME_DOWN, R.string.key_volume_down);
-        KEY_NAME_RES.put(KeyEvent.KEYCODE_VOLUME_MUTE, R.string.key_volume_mute);
-        KEY_NAME_RES.put(KeyEvent.KEYCODE_POWER, R.string.key_power);
-        KEY_NAME_RES.put(KeyEvent.KEYCODE_CAMERA, R.string.key_camera);
-        KEY_NAME_RES.put(KeyEvent.KEYCODE_HEADSETHOOK, R.string.key_headset_hook);
-        KEY_NAME_RES.put(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, R.string.key_media_play_pause);
-        KEY_NAME_RES.put(KeyEvent.KEYCODE_MEDIA_NEXT, R.string.key_media_next);
-        KEY_NAME_RES.put(KeyEvent.KEYCODE_MEDIA_PREVIOUS, R.string.key_media_previous);
-        KEY_NAME_RES.put(KeyEvent.KEYCODE_BRIGHTNESS_UP, R.string.key_brightness_up);
-        KEY_NAME_RES.put(KeyEvent.KEYCODE_BRIGHTNESS_DOWN, R.string.key_brightness_down);
-        KEY_NAME_RES.put(KeyEvent.KEYCODE_HOME, R.string.key_home);
-        KEY_NAME_RES.put(KeyEvent.KEYCODE_BACK, R.string.key_back);
-    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -147,6 +130,7 @@ public class SettingsActivity extends Activity {
     }
 
     private void showHome() {
+        stopListening();
         currentPage = Page.HOME;
 
         LinearLayout root = new LinearLayout(this);
@@ -236,6 +220,7 @@ public class SettingsActivity extends Activity {
 
     // A fresh page root with a back link and a bold page title.
     private LinearLayout newPage(int titleRes) {
+        stopListening();
         LinearLayout root = new LinearLayout(this);
         root.setOrientation(LinearLayout.VERTICAL);
 
@@ -263,11 +248,11 @@ public class SettingsActivity extends Activity {
         currentPage = Page.KEYBOARD;
         LinearLayout root = newPage(R.string.cat_keyboard_title);
         buildVirtualKeyboardSection(root);
+        buildImmersiveSection(root);
         buildAccessibilitySection(root);
         buildExtraKeysSection(root);
         buildCustomLayoutSection(root);
         setContent(root);
-        updateStatus();
     }
 
     private void showTouchpadPage() {
@@ -303,7 +288,7 @@ public class SettingsActivity extends Activity {
     public void onBackPressed() {
         // While listening for a key binding, let onKeyDown capture the Back key
         // instead of navigating back.
-        if (isListening) return;
+        if (listeningBinding != null) return;
         if (currentPage != Page.HOME) {
             showHome();
         } else {
@@ -316,23 +301,162 @@ public class SettingsActivity extends Activity {
     // ============================================================
 
     private void buildVirtualKeyboardSection(LinearLayout root) {
-        TextView bindLabel = new TextView(this);
-        bindLabel.setText(R.string.section_virtual_keyboard);
-        bindLabel.setTextSize(16);
-        bindLabel.setTypeface(null, Typeface.BOLD);
-        bindLabel.setPadding(0, 0, 0, dp(8));
-        root.addView(bindLabel);
+        addSectionHeader(root, R.string.section_virtual_keyboard, 0);
+        // Constructing the row appends it to `root`.
+        new KeyBinding(root, KEY_BOUND_KEYCODE, null, R.string.bind_key_button);
+    }
 
-        statusText = new TextView(this);
-        statusText.setTextSize(14);
-        statusText.setTextColor(Color.GRAY);
-        statusText.setPadding(0, 0, 0, dp(16));
-        root.addView(statusText);
+    /**
+     * Immersive mode: a root helper takes the touchscreen, keyboard and pointer
+     * away from Android for as long as the session lasts, so every input goes to
+     * the Linux desktop instead. The switch is a safety gate rather than the
+     * feature itself — with it off the bound key does nothing — and the binding
+     * below records the key's raw scan code, which is the only thing the root
+     * helper can compare while Android is no longer in the loop.
+     */
+    private void buildImmersiveSection(LinearLayout root) {
+        SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
 
-        bindButton = new Button(this);
-        bindButton.setText(R.string.bind_key_button);
-        bindButton.setOnClickListener(v -> startListening());
-        root.addView(bindButton);
+        addSectionHeader(root, R.string.section_immersive, dp(24));
+
+        Switch immersiveSwitch = new Switch(this);
+        immersiveSwitch.setText(R.string.immersive_switch);
+        immersiveSwitch.setTextSize(14);
+        immersiveSwitch.setPadding(0, 0, 0, 0);
+        immersiveSwitch.setChecked(prefs.getBoolean(KEY_IMMERSIVE_ENABLED, false));
+        immersiveSwitch.setOnCheckedChangeListener((v, checked) ->
+            getSharedPreferences(PREFS_NAME, MODE_PRIVATE).edit()
+                .putBoolean(KEY_IMMERSIVE_ENABLED, checked).apply());
+        root.addView(immersiveSwitch);
+
+        TextView immersiveHint = new TextView(this);
+        immersiveHint.setText(R.string.immersive_hint);
+        immersiveHint.setTextSize(12);
+        immersiveHint.setTextColor(Color.GRAY);
+        immersiveHint.setPadding(0, dp(4), 0, dp(12));
+        root.addView(immersiveHint);
+
+        // Constructing the row appends it to `root`.
+        new KeyBinding(root, KEY_IMMERSIVE_KEYCODE, KEY_IMMERSIVE_SCANCODE,
+                R.string.bind_immersive_key_button);
+    }
+
+    private void addSectionHeader(LinearLayout root, int titleRes, int topPadding) {
+        TextView header = new TextView(this);
+        header.setText(titleRes);
+        header.setTextSize(16);
+        header.setTypeface(null, Typeface.BOLD);
+        header.setPadding(0, topPadding, 0, dp(8));
+        root.addView(header);
+    }
+
+    /**
+     * One "bind a key" row: a status line plus a button that listens for the next
+     * key press for five seconds. Both bindings on this page use it, so the
+     * listening state lives per row instead of on the activity.
+     */
+    private final class KeyBinding {
+        private final String keyPref;
+        /**
+         * Where to store the raw evdev scan code, or null when only the Android
+         * key code matters. Immersive mode needs it: {@link KeyCodeMapper} has no
+         * entry for the volume keys, and its root helper only ever sees evdev
+         * codes.
+         */
+        private final String scanPref;
+        private final int buttonLabelRes;
+        private final Button button;
+        private final TextView status;
+        private CountDownTimer timer;
+
+        KeyBinding(LinearLayout root, String keyPref, String scanPref,
+                   int buttonLabelRes) {
+            this.keyPref = keyPref;
+            this.scanPref = scanPref;
+            this.buttonLabelRes = buttonLabelRes;
+
+            status = new TextView(SettingsActivity.this);
+            status.setTextSize(14);
+            status.setTextColor(Color.GRAY);
+            status.setPadding(0, 0, 0, dp(16));
+            root.addView(status);
+
+            button = new Button(SettingsActivity.this);
+            button.setText(buttonLabelRes);
+            button.setOnClickListener(v -> startListening());
+            root.addView(button);
+
+            updateStatus();
+        }
+
+        private void startListening() {
+            if (listeningBinding == this)
+                return;
+            stopListening();
+            listeningBinding = this;
+            button.setText(getString(R.string.listening_countdown, 5));
+            timer = new CountDownTimer(5000, 1000) {
+                @Override
+                public void onTick(long millisUntilFinished) {
+                    button.setText(getString(R.string.listening_countdown,
+                        (int) (millisUntilFinished / 1000)));
+                }
+
+                @Override
+                public void onFinish() {
+                    // Timed out with no key: clear the binding, matching the
+                    // original behaviour of "listen, then store whatever came".
+                    bind(UNBOUND, UNBOUND);
+                }
+            }.start();
+        }
+
+        /** Stop listening without changing what is bound. */
+        void cancel() {
+            if (timer != null) {
+                timer.cancel();
+                timer = null;
+            }
+            button.setText(buttonLabelRes);
+        }
+
+        void bind(int keycode, int scancode) {
+            cancel();
+            listeningBinding = null;
+            SharedPreferences.Editor edit =
+                getSharedPreferences(PREFS_NAME, MODE_PRIVATE).edit();
+            edit.putInt(keyPref, keycode);
+            if (scanPref != null)
+                edit.putInt(scanPref, scancode);
+            edit.apply();
+            updateStatus();
+        }
+
+        void updateStatus() {
+            SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+            int bound = prefs.getInt(keyPref, UNBOUND);
+            int scan = scanPref == null ? UNBOUND : prefs.getInt(scanPref, UNBOUND);
+            if (bound == UNBOUND && scan <= 0) {
+                status.setText(R.string.status_current_none);
+                status.setTextColor(Color.GRAY);
+                return;
+            }
+            String name = KeyCodeMapper.keyName(SettingsActivity.this, bound, scan);
+            // A binding that resolves to no evdev code is useless to the root
+            // helper, so say so here rather than let the key quietly do nothing.
+            if (scanPref != null && resolveEvdev(bound, scan) <= 0) {
+                status.setText(getString(R.string.status_current_no_scancode, name));
+                status.setTextColor(0xFFC62828);  // red
+                return;
+            }
+            status.setText(getString(R.string.status_current, name));
+            status.setTextColor(Color.GRAY);
+        }
+
+        private int resolveEvdev(int keycode, int scancode) {
+            return scancode > 0 ? scancode
+                    : (keycode == UNBOUND ? -1 : KeyCodeMapper.getScanCode(keycode));
+        }
     }
 
     private void buildAccessibilitySection(LinearLayout root) {
@@ -1057,60 +1181,26 @@ public class SettingsActivity extends Activity {
         return box;
     }
 
-    private void startListening() {
-        if (isListening) return;
-        isListening = true;
-        bindButton.setText(getString(R.string.listening_countdown, 5));
-
-        listenTimer = new CountDownTimer(5000, 1000) {
-            @Override
-            public void onTick(long millisUntilFinished) {
-                bindButton.setText(getString(R.string.listening_countdown,
-                    (int) (millisUntilFinished / 1000)));
-            }
-
-            @Override
-            public void onFinish() {
-                finishListening(UNBOUND);
-            }
-        }.start();
-    }
-
-    private void finishListening(int keycode) {
-        isListening = false;
-        listenTimer.cancel();
-
-        SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
-        prefs.edit().putInt(KEY_BOUND_KEYCODE, keycode).apply();
-
-        bindButton.setText(R.string.bind_key_button);
-        updateStatus();
-    }
-
-    private void updateStatus() {
-        if (statusText == null) return;
-        SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
-        int bound = prefs.getInt(KEY_BOUND_KEYCODE, UNBOUND);
-        if (bound == UNBOUND) {
-            statusText.setText(R.string.status_current_none);
-        } else {
-            int nameRes = KEY_NAME_RES.get(bound);
-            String name = nameRes != 0
-                ? getString(nameRes)
-                : getString(R.string.keycode_unknown, bound);
-            statusText.setText(getString(R.string.status_current, name));
+    /** Stop whichever row is counting down, leaving its binding untouched. */
+    private void stopListening() {
+        if (listeningBinding != null) {
+            listeningBinding.cancel();
+            listeningBinding = null;
         }
     }
 
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        if (!isListening) return super.onKeyDown(keyCode, event);
+        if (listeningBinding == null) return super.onKeyDown(keyCode, event);
 
         // Ignore generic Virtual Keyboard keycode (it's a placeholder)
         if (keyCode == KeyEvent.KEYCODE_UNKNOWN) return true;
 
-        finishListening(keyCode);
-        Log.i(TAG, "Bound keycode: " + keyCode);
+        // The scan code is recorded alongside the key code: it is what the
+        // immersive-mode root helper matches on, and it is the only identity a
+        // key like Volume Up has once Android is out of the picture.
+        listeningBinding.bind(keyCode, event.getScanCode());
+        Log.i(TAG, "Bound keycode: " + keyCode + " scancode: " + event.getScanCode());
         return true;
     }
 

--- a/consumers/anland_v5/android_consumer/app/src/main/jni/CMakeLists.txt
+++ b/consumers/anland_v5/android_consumer/app/src/main/jni/CMakeLists.txt
@@ -48,3 +48,24 @@ set_target_properties(fdhelper PROPERTIES
 )
 
 target_link_libraries(fdhelper log)
+
+# Root helper for "immersive mode": grabs the input devices (EVIOCGRAB) and
+# streams their events to the app over a bridge socket. Same lib*.so packaging
+# trick as fdhelper above -- the app launches it via `su -c` because
+# untrusted_app cannot read /dev/input itself.
+add_executable(inputgrab
+    input_grab.c
+    ${LIBDISPLAY_DIR}/common/socket_utils.c
+)
+
+target_include_directories(inputgrab PRIVATE
+    ${LIBDISPLAY_DIR}/common
+)
+
+set_target_properties(inputgrab PROPERTIES
+    PREFIX "lib"
+    OUTPUT_NAME "inputgrab"
+    SUFFIX ".so"
+)
+
+target_link_libraries(inputgrab log)

--- a/consumers/anland_v5/android_consumer/app/src/main/jni/input_grab.c
+++ b/consumers/anland_v5/android_consumer/app/src/main/jni/input_grab.c
@@ -29,10 +29,10 @@
  *      (or EOF, which the kernel guarantees when the app dies) releases
  *      everything. The app only heartbeats while its main thread is running, so
  *      an ANR frees the input too.
- *   5. Pure Android hardware-button nodes (Power/Volume/Wakeup) are watched but
- *      never grabbed: those physical buttons always stay with Android. Mixed
- *      devices such as touch panels and keyboards still get grabbed, even if
- *      their capability bitmap also advertises KEY_POWER.
+ *   5. Pure Android hardware-button nodes, and every non-keyboard node that
+ *      reports Power, are watched but never grabbed. That preserves Android's
+ *      lock/wake path even on panels that expose KEY_POWER alongside contacts.
+ *      Full keyboards remain grabbable because their ordinary keys cannot leak.
  */
 #define _GNU_SOURCE
 #include <android/log.h>
@@ -83,6 +83,7 @@ struct dev_entry {
     int  fd;
     int  cls;        /* IGRAB_CLASS_* */
     int  grabbed;    /* 0 => watched only (toggle detection), events not forwarded */
+    int  announced;  /* the app has received this entry's DEVICE record */
     int  multitouch;
     int  clickpad;   /* one button under the pad: BTN_LEFT alone means "a click" */
     int  min_x, max_x, min_y, max_y;
@@ -251,6 +252,28 @@ static int send_resync(int fd)
     return 0;
 }
 
+/*
+ * Finish a partial record and, after any loss, deliver the global SYN_DROPPED
+ * marker before normal traffic resumes. This is also driven by POLLOUT while
+ * idle: waiting for another input event leaves a final KEY_UP or SYN_REPORT
+ * stranded forever when the user stops moving.
+ *
+ *  1: normal records may be sent; 0: socket still back-pressured; -1: dead.
+ */
+static int recover_output(int fd)
+{
+    int flushed = flush_pending(fd);
+    if (flushed < 0)
+        return -1;
+    if (flushed == 0)
+        return 0;
+    if (!g_need_resync)
+        return 1;
+    if (send_resync(fd) < 0)
+        return -1;
+    return (!g_need_resync && g_pending_len == 0) ? 1 : 0;
+}
+
 static int send_bye(int fd, int reason)
 {
     /* Finish any half-written record first: leaving one truncated would put the
@@ -279,6 +302,36 @@ static int any_key_bit(const unsigned long *key)
         if (TEST_BIT(i, key))
             return 1;
     }
+    return 0;
+}
+
+/* A full keyboard is allowed to advertise KEY_POWER: many docks expose that
+ * capability on their ordinary keyboard node while the tablet's real power
+ * switch is a separate node. Non-keyboard nodes have no safe way to split one
+ * evdev fd after EVIOCGRAB, so a Power-bearing panel/mouse/controller stays
+ * watch-only and Android retains its lock/wake path. */
+static int has_alpha_keys(const unsigned long *key)
+{
+    static const int letters[] = {
+        KEY_Q, KEY_W, KEY_E, KEY_R, KEY_T, KEY_Y,
+        KEY_A, KEY_S, KEY_D, KEY_F, KEY_G,
+        KEY_Z, KEY_X, KEY_C, KEY_V,
+    };
+    for (size_t i = 0; i < sizeof(letters) / sizeof(letters[0]); i++) {
+        if (!TEST_BIT(letters[i], key))
+            return 0;
+    }
+    return 1;
+}
+
+static int has_power_key(const unsigned long *key)
+{
+    if (TEST_BIT(KEY_POWER, key))
+        return 1;
+#ifdef KEY_POWER2
+    if (TEST_BIT(KEY_POWER2, key))
+        return 1;
+#endif
     return 0;
 }
 
@@ -372,6 +425,8 @@ static int inspect_device(const char *path, struct dev_entry *out)
     int touch   = TEST_BIT(BTN_TOUCH, key);
     int click   = TEST_BIT(BTN_LEFT, key);
     int pen     = TEST_BIT(BTN_TOOL_PEN, key) || TEST_BIT(BTN_STYLUS, key);
+    int alpha   = has_alpha_keys(key);
+    int power   = has_power_key(key);
     int keys    = any_key_bit(key);
 
     /* A stylus digitizer overlaps the panel; forwarding it as a second finger
@@ -379,6 +434,17 @@ static int inspect_device(const char *path, struct dev_entry *out)
     if (pen) {
         close(fd);
         return -1;
+    }
+
+    /* A single EVIOCGRAB applies to the whole node. Do not take a touchscreen,
+     * touchpad, mouse or consumer-control node that carries Power: forwarding
+     * its KEY_POWER to the desktop cannot make Android lock the device, so the
+     * ACTION_SCREEN_OFF safety receiver would never run. Full keyboards retain
+     * the existing exception above because their ordinary keys must not leak. */
+    if (power && !alpha) {
+        out->cls = IGRAB_CLASS_KEYBOARD;
+        out->grabbed = 0;
+        return 0;
     }
 
     /* Contacts, not axes: a gamepad also reports ABS_X/ABS_Y, and its sticks
@@ -401,8 +467,8 @@ static int inspect_device(const char *path, struct dev_entry *out)
         /* Physical Android buttons must remain available to Android while
          * immersive mode is active. Keep these fds open watch-only so the bound
          * toggle key can still release the session, but do not EVIOCGRAB them.
-         * Keyboards/consumer-control nodes that also advertise KEY_POWER are not
-         * protected here because their ordinary keys must not leak to Android. */
+         * Non-keyboard Power nodes returned above; this path protects the rest
+         * of the dedicated Android button devices. */
         if (has_only_physical_android_keys(key)) {
             out->cls = IGRAB_CLASS_KEYBOARD;
             out->grabbed = 0;
@@ -502,6 +568,70 @@ static int already_tracked(int rdev)
     return 0;
 }
 
+static void fill_device_record(struct igrab_rec *rec, int idx)
+{
+    const struct dev_entry *de = &g_devs[idx];
+    memset(rec, 0, sizeof(*rec));
+    rec->rtype = IGRAB_REC_DEVICE;
+    rec->dev   = (uint16_t)idx;
+    rec->etype = (uint16_t)de->cls;
+    rec->aux[IGRAB_AUX_MIN_X] = de->min_x;
+    rec->aux[IGRAB_AUX_MAX_X] = de->max_x;
+    rec->aux[IGRAB_AUX_MIN_Y] = de->min_y;
+    rec->aux[IGRAB_AUX_MAX_Y] = de->max_y;
+    rec->aux[IGRAB_AUX_FLAGS] =
+        (de->grabbed ? IGRAB_DEV_GRABBED : 0) |
+        (de->multitouch ? IGRAB_DEV_MULTITOUCH : 0) |
+        (de->clickpad ? IGRAB_DEV_CLICKPAD : 0);
+}
+
+/* Reuse a detached device id before growing the table. The Java side only sees
+ * a replacement DEVICE record after the global resync sent on removal, so the
+ * old state cannot be confused with the new node. */
+static int find_free_device_slot(void)
+{
+    for (int i = 0; i < g_ndevs; i++) {
+        if (g_devs[i].fd < 0)
+            return i;
+    }
+    return g_ndevs < IGRAB_MAX_DEVICES ? g_ndevs : -1;
+}
+
+/* A hotplugged device is grabbed before it can leak input to Android, but its
+ * events stay local until its DEVICE record is definitely on the stream. The
+ * non-blocking transport may drop a record under pressure, so retry on every
+ * writable turn instead of treating that one announcement as expendable. */
+static int announce_pending_devices(int sock)
+{
+    for (int i = 0; i < g_ndevs; i++) {
+        if (g_devs[i].fd < 0 || g_devs[i].announced)
+            continue;
+
+        int ready = recover_output(sock);
+        if (ready <= 0)
+            return ready;
+
+        struct igrab_rec rec;
+        fill_device_record(&rec, i);
+        if (send_rec(sock, &rec) < 0)
+            return -1;
+        if (g_pending_len != 0 || g_need_resync)
+            return 0;
+        g_devs[i].announced = 1;
+        LOGI("announced device %d '%s'", i, g_devs[i].name);
+    }
+    return 1;
+}
+
+static int has_unannounced_devices(void)
+{
+    for (int i = 0; i < g_ndevs; i++) {
+        if (g_devs[i].fd >= 0 && !g_devs[i].announced)
+            return 1;
+    }
+    return 0;
+}
+
 /*
  * Grab any input device that appeared since the last scan. A Bluetooth mouse
  * that went to sleep reconnects as a brand-new node mid-session; without this
@@ -510,14 +640,14 @@ static int already_tracked(int rdev)
  * start, a DEVICE record announces them to the app, and the toggle key is
  * watched on them like on everything else.
  */
-static void scan_new_devices(int sock)
+static void scan_new_devices(void)
 {
     DIR *dir = opendir("/dev/input");
     if (!dir)
         return;
 
     struct dirent *ent;
-    while ((ent = readdir(dir)) != NULL && g_ndevs < IGRAB_MAX_DEVICES) {
+    while ((ent = readdir(dir)) != NULL) {
         if (strncmp(ent->d_name, "event", 5) != 0)
             continue;
         char path[300];
@@ -526,29 +656,18 @@ static void scan_new_devices(int sock)
         if (rdev < 0 || already_tracked(rdev))
             continue;
 
+        int idx = find_free_device_slot();
+        if (idx < 0)
+            break;
+
         struct dev_entry de;
         if (inspect_device(path, &de) < 0)
             continue;   /* uninteresting, ungrabbable, or already grabbed by us */
-        int idx = g_ndevs;
         g_devs[idx] = de;
-        g_ndevs++;
+        if (idx == g_ndevs)
+            g_ndevs++;
         LOGI("new device %s '%s' class=%d %s", path, de.name, de.cls,
-             de.grabbed ? "GRABBED" : "watch-only");
-
-        struct igrab_rec rec;
-        memset(&rec, 0, sizeof(rec));
-        rec.rtype = IGRAB_REC_DEVICE;
-        rec.dev   = (uint16_t)idx;
-        rec.etype = (uint16_t)de.cls;
-        rec.aux[IGRAB_AUX_MIN_X] = de.min_x;
-        rec.aux[IGRAB_AUX_MAX_X] = de.max_x;
-        rec.aux[IGRAB_AUX_MIN_Y] = de.min_y;
-        rec.aux[IGRAB_AUX_MAX_Y] = de.max_y;
-        rec.aux[IGRAB_AUX_FLAGS] =
-            (de.grabbed ? IGRAB_DEV_GRABBED : 0) |
-            (de.multitouch ? IGRAB_DEV_MULTITOUCH : 0) |
-            (de.clickpad ? IGRAB_DEV_CLICKPAD : 0);
-        send_rec(sock, &rec);   /* non-blocking; a drop is harmless */
+             de.grabbed ? "GRABBED (awaiting DEVICE)" : "watch-only (awaiting DEVICE)");
     }
     closedir(dir);
 }
@@ -566,20 +685,10 @@ static int send_device_list(int sock, int grabbed)
         return -1;
 
     for (int i = 0; i < g_ndevs; i++) {
-        memset(&rec, 0, sizeof(rec));
-        rec.rtype = IGRAB_REC_DEVICE;
-        rec.dev   = (uint16_t)i;
-        rec.etype = (uint16_t)g_devs[i].cls;
-        rec.aux[IGRAB_AUX_MIN_X] = g_devs[i].min_x;
-        rec.aux[IGRAB_AUX_MAX_X] = g_devs[i].max_x;
-        rec.aux[IGRAB_AUX_MIN_Y] = g_devs[i].min_y;
-        rec.aux[IGRAB_AUX_MAX_Y] = g_devs[i].max_y;
-        rec.aux[IGRAB_AUX_FLAGS] =
-            (g_devs[i].grabbed ? IGRAB_DEV_GRABBED : 0) |
-            (g_devs[i].multitouch ? IGRAB_DEV_MULTITOUCH : 0) |
-            (g_devs[i].clickpad ? IGRAB_DEV_CLICKPAD : 0);
+        fill_device_record(&rec, i);
         if (send_all(sock, &rec, sizeof(rec)) < 0)
             return -1;
+        g_devs[i].announced = 1;
     }
 
     memset(&rec, 0, sizeof(rec));
@@ -625,8 +734,28 @@ static int pump_device(int sock, int idx, int toggle)
             if (!g_devs[idx].grabbed)
                 continue;   /* Android still owns it; forwarding would duplicate */
 
-            if (g_need_resync && send_resync(sock) < 0)
+            /* A hotplugged node stays silent until the Java side has its DEVICE
+             * descriptor. Discarding a transition here requires a global reset:
+             * otherwise its first delivered record could be a KEY_UP for a key
+             * the desktop never saw go down. */
+            if (!g_devs[idx].announced) {
+                g_need_resync = 1;
+                continue;
+            }
+
+            int ready = recover_output(sock);
+            if (ready < 0)
                 return -1;
+            if (ready == 0) {
+                g_drops++;
+                g_need_resync = 1;
+                if (g_drops > MAX_DROPS) {
+                    LOGE("app is not reading (%d dropped records); giving input back",
+                         g_drops);
+                    return -3;
+                }
+                continue;
+            }
 
             struct igrab_rec rec;
             memset(&rec, 0, sizeof(rec));
@@ -715,6 +844,8 @@ int main(int argc, char **argv)
         int nfds = 0;
         pfds[nfds].fd = sock;
         pfds[nfds].events = POLLIN;
+        if (g_pending_len != 0 || g_need_resync || has_unannounced_devices())
+            pfds[nfds].events |= POLLOUT;
         pfds[nfds].revents = 0;
         nfds++;
         for (int i = 0; i < g_ndevs; i++) {
@@ -757,11 +888,29 @@ int main(int argc, char **argv)
             break;
         }
 
-        /* Bluetooth devices wake and reconnect as new nodes; pick them up and
-         * pull them into the session. */
+        /* Finish any partial stream work even when the user has stopped moving.
+         * POLLOUT wakes this promptly; the unconditional call also handles a
+         * race where the socket became writable between poll() and here. */
+        int output_ready = recover_output(sock);
+        if (output_ready < 0) {
+            reason = IGRAB_BYE_PEER_GONE;
+            break;
+        }
+
+        /* Bluetooth devices wake and reconnect as new nodes. A device is held
+         * locally until announce_pending_devices() has put its DEVICE record on
+         * the stream, so Android and the desktop can never both own it. */
         if (now_ms() - last_scan > RESCAN_INTERVAL_MS) {
-            scan_new_devices(sock);
+            scan_new_devices();
             last_scan = now_ms();
+        }
+
+        if (output_ready > 0) {
+            int announced = announce_pending_devices(sock);
+            if (announced < 0) {
+                reason = IGRAB_BYE_PEER_GONE;
+                break;
+            }
         }
 
         int stop = 0;
@@ -790,11 +939,16 @@ int main(int argc, char **argv)
                 stop = 1;
             } else if (r == -2) {
                 /* Device vanished (unplugged dock/keyboard). Drop it and carry
-                 * on -- the remaining devices are still grabbed. */
+                 * on -- the remaining devices are still grabbed. Release every
+                 * remote state first; otherwise a key/button held at unplug stays
+                 * pressed until the whole immersive session ends. */
                 LOGI("device '%s' went away", g_devs[idx].name);
+                if (g_devs[idx].grabbed && g_devs[idx].announced)
+                    g_need_resync = 1;
                 if (g_devs[idx].grabbed)
                     ioctl(g_devs[idx].fd, EVIOCGRAB, 0);
                 close(g_devs[idx].fd);
+                memset(&g_devs[idx], 0, sizeof(g_devs[idx]));
                 g_devs[idx].fd = -1;
             }
         }

--- a/consumers/anland_v5/android_consumer/app/src/main/jni/input_grab.c
+++ b/consumers/anland_v5/android_consumer/app/src/main/jni/input_grab.c
@@ -1,0 +1,812 @@
+/*
+ * inputgrab -- the root helper behind "immersive mode".
+ *
+ * Immersive mode hands the device over to the Linux desktop: the touchscreen,
+ * the keyboard and any pointer stop reaching Android entirely and are streamed
+ * to the app instead, which replays them onto the remote desktop.
+ *
+ * The app cannot read /dev/input itself (untrusted_app is denied
+ * input_device:chr_file), so it launches this helper through `su -c`. The
+ * helper opens and EVIOCGRABs the devices in the root context and forwards a
+ * fixed-size record stream over a unix socket the app listens on -- the same
+ * bridge pattern fd_helper.c uses to hand back the daemon connection. It is
+ * shipped inside the APK as lib*.so so Android extracts it into the app's
+ * nativeLibraryDir with execute permission.
+ *
+ *   usage: libinputgrab.so <bridge_socket_path> <toggle_scancode>
+ *
+ * Grabbing every input device is a good way to brick a tablet, so the escape
+ * hatches are the design, in the order they matter:
+ *
+ *   1. EVIOCGRAB hangs off the open file description, so the kernel drops every
+ *      grab as soon as this process dies -- including on SIGKILL.
+ *   2. <toggle_scancode> is mandatory and is watched on every device: pressing
+ *      it ungrabs and exits, so the user gets out even if the app is wedged.
+ *   3. Records are sent non-blocking and dropped under back-pressure. A stalled
+ *      app can therefore never park this process inside send() and stop it from
+ *      ever reaching the toggle key -- which is what actually locks a device up.
+ *   4. The app heartbeats over the same socket. Silence for HEARTBEAT_TIMEOUT_MS
+ *      (or EOF, which the kernel guarantees when the app dies) releases
+ *      everything. The app only heartbeats while its main thread is running, so
+ *      an ANR frees the input too.
+ *   5. Devices carrying KEY_POWER that are not keyboards are watched but never
+ *      grabbed: the power button always stays with Android.
+ */
+#define _GNU_SOURCE
+#include <android/log.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/input.h>
+#include <poll.h>
+#include <signal.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "input_grab.h"
+#include "socket_utils.h"
+
+#define TAG "AnlandGrab"
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, TAG, __VA_ARGS__)
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, TAG, __VA_ARGS__)
+
+/* No heartbeat for this long => the app is gone or frozen; release everything. */
+#define HEARTBEAT_TIMEOUT_MS 6000
+/* How often to look for input devices that appeared since the session started.
+ * Bluetooth mice and keyboards sleep and reconnect as brand-new nodes
+ * mid-session; a one-time scan at start would leave them out of the grab and
+ * at Android's mercy. */
+#define RESCAN_INTERVAL_MS 2000
+/* Consecutive dropped records before we give the input back rather than keep
+ * grabbing for an app that is plainly not reading. */
+#define MAX_DROPS 2000
+/* Poll slice; also how often the timeout above is re-checked. */
+#define POLL_SLICE_MS 250
+
+#define BITS_PER_LONG  (8 * (int)sizeof(unsigned long))
+#define NBITS(x)       ((((x) - 1) / BITS_PER_LONG) + 1)
+#define TEST_BIT(bit, arr) \
+    (((arr)[(bit) / BITS_PER_LONG] >> ((bit) % BITS_PER_LONG)) & 1UL)
+
+struct dev_entry {
+    int  fd;
+    int  cls;        /* IGRAB_CLASS_* */
+    int  grabbed;    /* 0 => watched only (toggle detection), events not forwarded */
+    int  multitouch;
+    int  clickpad;   /* one button under the pad: BTN_LEFT alone means "a click" */
+    int  min_x, max_x, min_y, max_y;
+    char name[80];
+};
+
+static struct dev_entry g_devs[IGRAB_MAX_DEVICES];
+static int g_ndevs = 0;
+static volatile sig_atomic_t g_quit = 0;
+
+static void on_signal(int sig)
+{
+    (void)sig;
+    g_quit = 1;
+}
+
+static long now_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (long)ts.tv_sec * 1000L + ts.tv_nsec / 1000000L;
+}
+
+/*
+ * Connect to the app's listening socket, which lives in the abstract namespace
+ * (that is what android.net.LocalServerSocket creates). Abstract means there is
+ * no file to find, chmod or clean up, and root needs one SELinux permission
+ * fewer than for a socket inside the app's data directory. socket_utils'
+ * connect_unix() only speaks filesystem paths, hence this one.
+ */
+static int connect_abstract(const char *name)
+{
+    size_t len = strlen(name);
+    struct sockaddr_un addr;
+    if (len + 1 > sizeof(addr.sun_path))
+        return -1;
+
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0)
+        return -1;
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    addr.sun_path[0] = '\0';            /* leading NUL == abstract namespace */
+    memcpy(addr.sun_path + 1, name, len);
+    socklen_t alen = (socklen_t)(offsetof(struct sockaddr_un, sun_path) + 1 + len);
+
+    if (connect(fd, (struct sockaddr *)&addr, alen) < 0) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+/* Release every grab and close. Called on every exit path; the kernel would do
+ * it anyway when the process dies, but doing it explicitly keeps the window
+ * where Android sees no input as short as possible. */
+static void release_all(void)
+{
+    for (int i = 0; i < g_ndevs; i++) {
+        if (g_devs[i].fd < 0)
+            continue;
+        if (g_devs[i].grabbed)
+            ioctl(g_devs[i].fd, EVIOCGRAB, 0);
+        close(g_devs[i].fd);
+        g_devs[i].fd = -1;
+    }
+    g_ndevs = 0;
+}
+
+/* ---------------- record transport ---------------- */
+
+/* Tail of a record that only went out partially. A stream socket can accept
+ * fewer than 32 bytes, and losing the rest would desync the framing for good,
+ * so the remainder is held here and flushed before anything else. */
+static uint8_t g_pending[IGRAB_REC_SIZE];
+static size_t  g_pending_len = 0;
+static int     g_drops = 0;
+static int     g_need_resync = 0;
+
+static int writable(int fd)
+{
+    struct pollfd p = { .fd = fd, .events = POLLOUT };
+    return poll(&p, 1, 0) > 0 && (p.revents & POLLOUT);
+}
+
+/* Flush a partial record. 1 = nothing pending anymore, 0 = still pending. */
+static int flush_pending(int fd)
+{
+    while (g_pending_len > 0) {
+        if (!writable(fd))
+            return 0;
+        ssize_t n = send(fd, g_pending + (IGRAB_REC_SIZE - g_pending_len),
+                         g_pending_len, MSG_DONTWAIT | MSG_NOSIGNAL);
+        if (n > 0) {
+            g_pending_len -= (size_t)n;
+            continue;
+        }
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR))
+            return 0;
+        return -1;
+    }
+    return 1;
+}
+
+/*
+ * Send one record, never blocking. Under back-pressure the record is dropped
+ * and counted: input that cannot be delivered is worth less than the ability to
+ * keep polling for the toggle key. Returns 0 on success or a drop, -1 when the
+ * socket is dead.
+ */
+static int send_rec(int fd, const struct igrab_rec *rec)
+{
+    int fp = flush_pending(fd);
+    if (fp < 0)
+        return -1;
+    if (fp == 0) {
+        g_drops++;
+        g_need_resync = 1;
+        return 0;
+    }
+
+    if (!writable(fd)) {
+        g_drops++;
+        g_need_resync = 1;
+        return 0;
+    }
+
+    ssize_t n = send(fd, rec, IGRAB_REC_SIZE, MSG_DONTWAIT | MSG_NOSIGNAL);
+    if (n == IGRAB_REC_SIZE) {
+        g_drops = 0;
+        return 0;
+    }
+    if (n > 0) {
+        /* Partial: stash the tail so the next call restores the framing. */
+        memcpy(g_pending, rec, IGRAB_REC_SIZE);
+        g_pending_len = IGRAB_REC_SIZE - (size_t)n;
+        g_drops = 0;
+        return 0;
+    }
+    if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)) {
+        g_drops++;
+        g_need_resync = 1;
+        return 0;
+    }
+    return -1;
+}
+
+/* Tell the app that records were lost, so it can release every key/contact it
+ * still believes is held instead of leaving them stuck on the desktop. Mirrors
+ * what the kernel does with SYN_DROPPED. */
+static int send_resync(int fd)
+{
+    struct igrab_rec rec;
+    memset(&rec, 0, sizeof(rec));
+    rec.rtype = IGRAB_REC_EVENT;
+    rec.dev   = IGRAB_DEV_ALL;
+    rec.etype = EV_SYN;
+    rec.code  = SYN_DROPPED;
+    if (send_rec(fd, &rec) < 0)
+        return -1;
+    /* Only clear once it actually left: a dropped resync marker is worse than
+     * useless, it would hide the drop it was meant to report. */
+    if (g_drops == 0 && g_pending_len == 0)
+        g_need_resync = 0;
+    return 0;
+}
+
+static int send_bye(int fd, int reason)
+{
+    /* Finish any half-written record first: leaving one truncated would put the
+     * app's parser out of step with the stream, and this is the one record it
+     * really has to be able to read. */
+    if (g_pending_len > 0) {
+        send_all(fd, g_pending + (IGRAB_REC_SIZE - g_pending_len), g_pending_len);
+        g_pending_len = 0;
+    }
+
+    struct igrab_rec rec;
+    memset(&rec, 0, sizeof(rec));
+    rec.rtype = IGRAB_REC_BYE;
+    rec.value = reason;
+    /* Blocking on purpose: this is the last record and the socket has a send
+     * timeout, so it cannot hang. Losing it would leave the app waiting for a
+     * stream that has already ended. */
+    return send_all(fd, &rec, sizeof(rec));
+}
+
+/* ---------------- device discovery ---------------- */
+
+/* A real keyboard: the letter block. Used both to keep alphabetic keyboards out
+ * of the "carries KEY_POWER, do not grab" rule (external keyboards commonly
+ * report a power key) and to classify key-only devices. */
+static int has_alpha_keys(const unsigned long *key)
+{
+    static const int letters[] = {
+        KEY_Q, KEY_W, KEY_E, KEY_R, KEY_T, KEY_Y,
+        KEY_A, KEY_S, KEY_D, KEY_F, KEY_G,
+        KEY_Z, KEY_X, KEY_C, KEY_V,
+    };
+    for (size_t i = 0; i < sizeof(letters) / sizeof(letters[0]); i++) {
+        if (!TEST_BIT(letters[i], key))
+            return 0;
+    }
+    return 1;
+}
+
+static int any_key_bit(const unsigned long *key)
+{
+    for (int i = 0; i <= KEY_MAX; i++) {
+        if (TEST_BIT(i, key))
+            return 1;
+    }
+    return 0;
+}
+
+static void read_abs_range(int fd, int axis, int *min, int *max)
+{
+    struct input_absinfo info;
+    if (ioctl(fd, EVIOCGABS(axis), &info) == 0 && info.maximum > info.minimum) {
+        *min = info.minimum;
+        *max = info.maximum;
+    }
+}
+
+/*
+ * Open one /dev/input node and decide what it is. Returns 0 when the node was
+ * taken (entry filled in, fd owned by the caller), -1 when it was skipped.
+ *
+ * Classification is by capability bits, never by event number: the numbering
+ * shifts as soon as a keyboard or dock is attached.
+ */
+static int inspect_device(const char *path, struct dev_entry *out)
+{
+    int fd = open(path, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+    if (fd < 0)
+        return -1;
+
+    unsigned long ev[NBITS(EV_MAX)];
+    unsigned long key[NBITS(KEY_MAX)];
+    unsigned long abs[NBITS(ABS_MAX)];
+    unsigned long rel[NBITS(REL_MAX)];
+    unsigned long prop[NBITS(INPUT_PROP_MAX)];
+    memset(ev, 0, sizeof(ev));
+    memset(key, 0, sizeof(key));
+    memset(abs, 0, sizeof(abs));
+    memset(rel, 0, sizeof(rel));
+    memset(prop, 0, sizeof(prop));
+
+    if (ioctl(fd, EVIOCGBIT(0, sizeof(ev)), ev) < 0) {
+        close(fd);
+        return -1;
+    }
+    if (TEST_BIT(EV_KEY, ev))
+        ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(key)), key);
+    if (TEST_BIT(EV_ABS, ev))
+        ioctl(fd, EVIOCGBIT(EV_ABS, sizeof(abs)), abs);
+    if (TEST_BIT(EV_REL, ev))
+        ioctl(fd, EVIOCGBIT(EV_REL, sizeof(rel)), rel);
+    ioctl(fd, EVIOCGPROP(sizeof(prop)), prop);
+
+    memset(out, 0, sizeof(*out));
+    out->fd = fd;
+    if (ioctl(fd, EVIOCGNAME(sizeof(out->name)), out->name) < 0)
+        out->name[0] = '\0';
+    out->name[sizeof(out->name) - 1] = '\0';
+
+    int mt      = TEST_BIT(ABS_MT_POSITION_X, abs) && TEST_BIT(ABS_MT_POSITION_Y, abs);
+    int abs_xy  = TEST_BIT(ABS_X, abs) && TEST_BIT(ABS_Y, abs);
+    int rel_xy  = TEST_BIT(REL_X, rel) && TEST_BIT(REL_Y, rel);
+    int direct  = TEST_BIT(INPUT_PROP_DIRECT, prop);
+    int pointer = TEST_BIT(INPUT_PROP_POINTER, prop);
+    int touch   = TEST_BIT(BTN_TOUCH, key);
+    int click   = TEST_BIT(BTN_LEFT, key);
+    int pen     = TEST_BIT(BTN_TOOL_PEN, key) || TEST_BIT(BTN_STYLUS, key);
+    int alpha   = has_alpha_keys(key);
+    int power   = TEST_BIT(KEY_POWER, key);
+    int keys    = any_key_bit(key);
+
+    /* A stylus digitizer overlaps the panel; forwarding it as a second finger
+     * only confuses the gesture engine, and its barrel keys are useless here. */
+    if (pen) {
+        close(fd);
+        return -1;
+    }
+
+    /* The power button (and the fingerprint/hall nodes that ride along with it)
+     * is the last way out of a wedged grab, so it is never taken away from
+     * Android. The node is still opened so the toggle key can be seen on
+     * chipsets that put the volume keys on the same node. */
+    if (power && !alpha) {
+        out->cls = IGRAB_CLASS_KEYBOARD;
+        out->grabbed = 0;
+        return 0;
+    }
+
+    /* Contacts, not axes: a gamepad also reports ABS_X/ABS_Y, and its sticks
+     * must not be mistaken for a finger. */
+    int contacts = mt || (abs_xy && (direct || pointer || touch));
+
+    if (contacts) {
+        /* The property bits say it outright when they are set. Panels that set
+         * neither are told apart by the clickpad button: a touchscreen has no
+         * BTN_LEFT, an integrated pad almost always does. */
+        if (direct)
+            out->cls = IGRAB_CLASS_TOUCHSCREEN;
+        else if (pointer || click)
+            out->cls = IGRAB_CLASS_TOUCHPAD;
+        else
+            out->cls = IGRAB_CLASS_TOUCHSCREEN;
+    } else if (rel_xy) {
+        out->cls = IGRAB_CLASS_MOUSE;
+    } else if (keys) {
+        out->cls = IGRAB_CLASS_KEYBOARD;
+    } else {
+        close(fd);
+        return -1;
+    }
+
+    out->multitouch = mt;
+    /* A clickpad has one button under the whole surface, so every press comes in
+     * as BTN_LEFT and the app has to work out left vs right from where the
+     * finger is. INPUT_PROP_BUTTONPAD is the authoritative bit; a pad that
+     * offers no BTN_RIGHT at all is one in practice too. */
+    out->clickpad = TEST_BIT(INPUT_PROP_BUTTONPAD, prop)
+            || (click && !TEST_BIT(BTN_RIGHT, key));
+    if (out->cls == IGRAB_CLASS_TOUCHSCREEN || out->cls == IGRAB_CLASS_TOUCHPAD) {
+        if (mt) {
+            read_abs_range(fd, ABS_MT_POSITION_X, &out->min_x, &out->max_x);
+            read_abs_range(fd, ABS_MT_POSITION_Y, &out->min_y, &out->max_y);
+        }
+        /* Single-touch panels only have ABS_X/ABS_Y; multitouch ones still use
+         * them as a fallback when the MT axes report nothing usable. */
+        if (out->max_x <= out->min_x)
+            read_abs_range(fd, ABS_X, &out->min_x, &out->max_x);
+        if (out->max_y <= out->min_y)
+            read_abs_range(fd, ABS_Y, &out->min_y, &out->max_y);
+        if (out->max_x <= out->min_x || out->max_y <= out->min_y) {
+            close(fd);
+            return -1;
+        }
+    }
+
+    if (ioctl(fd, EVIOCGRAB, 1) < 0) {
+        /* Someone else already owns it exclusively. Watching it would double up
+         * with Android's own delivery, so let it go entirely. */
+        LOGE("grab '%s' failed: %s", out->name, strerror(errno));
+        close(fd);
+        return -1;
+    }
+    out->grabbed = 1;
+    return 0;
+}
+
+static int scan_devices(void)
+{
+    DIR *dir = opendir("/dev/input");
+    if (!dir) {
+        LOGE("opendir(/dev/input): %s", strerror(errno));
+        return -1;
+    }
+
+    struct dirent *ent;
+    int grabbed = 0;
+    while ((ent = readdir(dir)) != NULL && g_ndevs < IGRAB_MAX_DEVICES) {
+        if (strncmp(ent->d_name, "event", 5) != 0)
+            continue;
+        char path[300];
+        snprintf(path, sizeof(path), "/dev/input/%s", ent->d_name);
+        if (inspect_device(path, &g_devs[g_ndevs]) < 0)
+            continue;
+        LOGI("%s '%s' class=%d %s", path, g_devs[g_ndevs].name,
+             g_devs[g_ndevs].cls, g_devs[g_ndevs].grabbed ? "GRABBED" : "watch-only");
+        if (g_devs[g_ndevs].grabbed)
+            grabbed++;
+        g_ndevs++;
+    }
+    closedir(dir);
+    return grabbed;
+}
+
+/* ---------------- mid-session device hotplug ---------------- */
+
+/* Device number of an event node; -1 when it is gone or not a device. */
+static int node_identity(const char *path)
+{
+    struct stat st;
+    if (stat(path, &st) != 0 || !S_ISCHR(st.st_mode))
+        return -1;
+    return (int)st.st_rdev;
+}
+
+/* Whether a tracked device still owns this node (dead fds do not count: the
+ * device was unplugged, and a reconnect with the same number must be treated
+ * as new). */
+static int already_tracked(int rdev)
+{
+    for (int i = 0; i < g_ndevs; i++) {
+        if (g_devs[i].fd < 0)
+            continue;
+        struct stat st;
+        if (fstat(g_devs[i].fd, &st) == 0 && (int)st.st_rdev == rdev)
+            return 1;
+    }
+    return 0;
+}
+
+/*
+ * Grab any input device that appeared since the last scan. A Bluetooth mouse
+ * that went to sleep reconnects as a brand-new node mid-session; without this
+ * it would keep feeding Android, and the app would forward it unaccelerated
+ * and ungated. New devices get the same classification rules as at session
+ * start, a DEVICE record announces them to the app, and the toggle key is
+ * watched on them like on everything else.
+ */
+static void scan_new_devices(int sock)
+{
+    DIR *dir = opendir("/dev/input");
+    if (!dir)
+        return;
+
+    struct dirent *ent;
+    while ((ent = readdir(dir)) != NULL && g_ndevs < IGRAB_MAX_DEVICES) {
+        if (strncmp(ent->d_name, "event", 5) != 0)
+            continue;
+        char path[300];
+        snprintf(path, sizeof(path), "/dev/input/%s", ent->d_name);
+        int rdev = node_identity(path);
+        if (rdev < 0 || already_tracked(rdev))
+            continue;
+
+        struct dev_entry de;
+        if (inspect_device(path, &de) < 0)
+            continue;   /* uninteresting, ungrabbable, or already grabbed by us */
+        int idx = g_ndevs;
+        g_devs[idx] = de;
+        g_ndevs++;
+        LOGI("new device %s '%s' class=%d %s", path, de.name, de.cls,
+             de.grabbed ? "GRABBED" : "watch-only");
+
+        struct igrab_rec rec;
+        memset(&rec, 0, sizeof(rec));
+        rec.rtype = IGRAB_REC_DEVICE;
+        rec.dev   = (uint16_t)idx;
+        rec.etype = (uint16_t)de.cls;
+        rec.aux[IGRAB_AUX_MIN_X] = de.min_x;
+        rec.aux[IGRAB_AUX_MAX_X] = de.max_x;
+        rec.aux[IGRAB_AUX_MIN_Y] = de.min_y;
+        rec.aux[IGRAB_AUX_MAX_Y] = de.max_y;
+        rec.aux[IGRAB_AUX_FLAGS] =
+            (de.grabbed ? IGRAB_DEV_GRABBED : 0) |
+            (de.multitouch ? IGRAB_DEV_MULTITOUCH : 0) |
+            (de.clickpad ? IGRAB_DEV_CLICKPAD : 0);
+        send_rec(sock, &rec);   /* non-blocking; a drop is harmless */
+    }
+    closedir(dir);
+}
+
+static int send_device_list(int sock, int grabbed)
+{
+    struct igrab_rec rec;
+
+    memset(&rec, 0, sizeof(rec));
+    rec.rtype  = IGRAB_REC_HELLO;
+    rec.value  = IGRAB_PROTO_VERSION;
+    rec.aux[0] = grabbed;
+    rec.aux[1] = (int32_t)getpid();
+    if (send_all(sock, &rec, sizeof(rec)) < 0)
+        return -1;
+
+    for (int i = 0; i < g_ndevs; i++) {
+        memset(&rec, 0, sizeof(rec));
+        rec.rtype = IGRAB_REC_DEVICE;
+        rec.dev   = (uint16_t)i;
+        rec.etype = (uint16_t)g_devs[i].cls;
+        rec.aux[IGRAB_AUX_MIN_X] = g_devs[i].min_x;
+        rec.aux[IGRAB_AUX_MAX_X] = g_devs[i].max_x;
+        rec.aux[IGRAB_AUX_MIN_Y] = g_devs[i].min_y;
+        rec.aux[IGRAB_AUX_MAX_Y] = g_devs[i].max_y;
+        rec.aux[IGRAB_AUX_FLAGS] =
+            (g_devs[i].grabbed ? IGRAB_DEV_GRABBED : 0) |
+            (g_devs[i].multitouch ? IGRAB_DEV_MULTITOUCH : 0) |
+            (g_devs[i].clickpad ? IGRAB_DEV_CLICKPAD : 0);
+        if (send_all(sock, &rec, sizeof(rec)) < 0)
+            return -1;
+    }
+
+    memset(&rec, 0, sizeof(rec));
+    rec.rtype = IGRAB_REC_READY;
+    rec.aux[0] = grabbed;
+    return send_all(sock, &rec, sizeof(rec));
+}
+
+/* ---------------- main loop ---------------- */
+
+/*
+ * Drain one device. Returns 1 to keep going, 0 when the toggle key was pressed
+ * and the session must end, -1 when the socket died.
+ */
+static int pump_device(int sock, int idx, int toggle)
+{
+    struct input_event evs[64];
+    for (;;) {
+        ssize_t n = read(g_devs[idx].fd, evs, sizeof(evs));
+        if (n < 0) {
+            if (errno == EINTR)
+                continue;
+            if (errno == EAGAIN || errno == EWOULDBLOCK)
+                return 1;   /* drained */
+            return -2;      /* ENODEV: the device was unplugged */
+        }
+        if (n == 0)
+            return -2;      /* would otherwise spin: poll keeps reporting POLLIN */
+
+        int count = (int)(n / (ssize_t)sizeof(struct input_event));
+        for (int i = 0; i < count; i++) {
+            struct input_event *e = &evs[i];
+
+            if (e->type == EV_KEY && e->code == toggle) {
+                /* Press ends the session; the release and any auto-repeat are
+                 * swallowed so the key never reaches the desktop. Checked before
+                 * the grabbed test so a watch-only node can still trigger it. */
+                if (e->value == 1)
+                    return 0;
+                continue;
+            }
+
+            if (!g_devs[idx].grabbed)
+                continue;   /* Android still owns it; forwarding would duplicate */
+
+            if (g_need_resync && send_resync(sock) < 0)
+                return -1;
+
+            struct igrab_rec rec;
+            memset(&rec, 0, sizeof(rec));
+            rec.rtype = IGRAB_REC_EVENT;
+            rec.dev   = (uint16_t)idx;
+            rec.etype = e->type;
+            rec.code  = e->code;
+            rec.value = e->value;
+            if (send_rec(sock, &rec) < 0)
+                return -1;
+            if (g_drops > MAX_DROPS) {
+                LOGE("app is not reading (%d dropped records); giving input back",
+                     g_drops);
+                return -3;
+            }
+        }
+    }
+}
+
+int main(int argc, char **argv)
+{
+    if (argc < 3) {
+        LOGE("usage: %s <bridge_socket> <toggle_scancode>", argv[0]);
+        return 1;
+    }
+
+    const char *bridge = argv[1];
+    int toggle = atoi(argv[2]);
+    /* A session with no way out is never started: the toggle key is the only
+     * thing that guarantees the user can hand the input back. */
+    if (toggle <= 0 || toggle > KEY_MAX) {
+        LOGE("refusing to grab without a valid toggle scancode (%d)", toggle);
+        return 2;
+    }
+
+    signal(SIGPIPE, SIG_IGN);
+    signal(SIGTERM, on_signal);
+    signal(SIGINT, on_signal);
+    signal(SIGHUP, on_signal);
+
+    int sock = connect_abstract(bridge);
+    if (sock < 0) {
+        LOGE("connect to bridge '%s' failed: %s", bridge, strerror(errno));
+        return 3;
+    }
+
+    /* The hello/device records are sent blocking; bound them so a peer that
+     * connects and then stops reading cannot wedge the handshake. A large send
+     * buffer keeps the event stream from dropping during a UI hiccup. */
+    struct timeval tv = { .tv_sec = 2, .tv_usec = 0 };
+    setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+    int sndbuf = 512 * 1024;
+    setsockopt(sock, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf));
+
+    int grabbed = scan_devices();
+    if (grabbed <= 0) {
+        LOGE("no grabbable input devices");
+        send_bye(sock, IGRAB_BYE_ERROR);
+        release_all();
+        close(sock);
+        return 4;
+    }
+
+    if (send_device_list(sock, grabbed) < 0) {
+        LOGE("handshake failed: %s", strerror(errno));
+        release_all();
+        close(sock);
+        return 5;
+    }
+    LOGI("immersive session started: %d grabbed device(s), toggle=%d",
+         grabbed, toggle);
+
+    struct pollfd pfds[IGRAB_MAX_DEVICES + 1];
+    long last_beat = now_ms();
+    long last_scan = now_ms();
+    int reason = IGRAB_BYE_PEER_GONE;
+
+    for (;;) {
+        if (g_quit) {
+            /* SIGTERM comes from the app's own last-resort kill, i.e. it has
+             * already given up on the session. */
+            reason = IGRAB_BYE_PEER_GONE;
+            break;
+        }
+
+        int nfds = 0;
+        pfds[nfds].fd = sock;
+        pfds[nfds].events = POLLIN;
+        pfds[nfds].revents = 0;
+        nfds++;
+        for (int i = 0; i < g_ndevs; i++) {
+            if (g_devs[i].fd < 0)
+                continue;
+            pfds[nfds].fd = g_devs[i].fd;
+            pfds[nfds].events = POLLIN;
+            pfds[nfds].revents = 0;
+            nfds++;
+        }
+
+        int ret = poll(pfds, (nfds_t)nfds, POLL_SLICE_MS);
+        if (ret < 0) {
+            if (errno == EINTR)
+                continue;
+            reason = IGRAB_BYE_ERROR;
+            break;
+        }
+
+        if (pfds[0].revents & (POLLHUP | POLLERR | POLLNVAL)) {
+            reason = IGRAB_BYE_PEER_GONE;
+            break;
+        }
+        if (pfds[0].revents & POLLIN) {
+            char beat[64];
+            ssize_t n = recv(sock, beat, sizeof(beat), MSG_DONTWAIT);
+            if (n == 0) {
+                reason = IGRAB_BYE_PEER_GONE;   /* app closed / died */
+                break;
+            }
+            if (n > 0)
+                last_beat = now_ms();
+        }
+
+        /* A frozen app keeps its socket open but stops beating. Treat that the
+         * same as death: the input has to go back to Android either way. */
+        if (now_ms() - last_beat > HEARTBEAT_TIMEOUT_MS) {
+            LOGE("no heartbeat for %d ms; releasing", HEARTBEAT_TIMEOUT_MS);
+            reason = IGRAB_BYE_STALLED;
+            break;
+        }
+
+        /* Bluetooth devices wake and reconnect as new nodes; pick them up and
+         * pull them into the session. */
+        if (now_ms() - last_scan > RESCAN_INTERVAL_MS) {
+            scan_new_devices(sock);
+            last_scan = now_ms();
+        }
+
+        int stop = 0;
+        for (int p = 1; p < nfds && !stop; p++) {
+            if (!(pfds[p].revents & (POLLIN | POLLHUP | POLLERR)))
+                continue;
+            int idx = -1;
+            for (int i = 0; i < g_ndevs; i++) {
+                if (g_devs[i].fd == pfds[p].fd) {
+                    idx = i;
+                    break;
+                }
+            }
+            if (idx < 0)
+                continue;
+
+            int r = pump_device(sock, idx, toggle);
+            if (r == 0) {
+                reason = IGRAB_BYE_TOGGLE;
+                stop = 1;
+            } else if (r == -1) {
+                reason = IGRAB_BYE_PEER_GONE;
+                stop = 1;
+            } else if (r == -3) {
+                reason = IGRAB_BYE_STALLED;
+                stop = 1;
+            } else if (r == -2) {
+                /* Device vanished (unplugged dock/keyboard). Drop it and carry
+                 * on -- the remaining devices are still grabbed. */
+                LOGI("device '%s' went away", g_devs[idx].name);
+                if (g_devs[idx].grabbed)
+                    ioctl(g_devs[idx].fd, EVIOCGRAB, 0);
+                close(g_devs[idx].fd);
+                g_devs[idx].fd = -1;
+            }
+        }
+        if (stop)
+            break;
+
+        /* Every grabbed device is gone (dock unplugged mid-session). There is
+         * nothing left to hold, and staying alive would only keep the app
+         * believing it is still immersive. */
+        int alive = 0;
+        for (int i = 0; i < g_ndevs; i++) {
+            if (g_devs[i].fd >= 0 && g_devs[i].grabbed)
+                alive++;
+        }
+        if (alive == 0) {
+            LOGI("all grabbed devices are gone; ending session");
+            reason = IGRAB_BYE_ERROR;
+            break;
+        }
+    }
+
+    /* Ungrab first: the app is about to be told the session ended, and the
+     * sooner Android has its input back the shorter the dead window. */
+    release_all();
+    send_bye(sock, reason);
+    close(sock);
+    LOGI("immersive session ended (reason=%d)", reason);
+    return 0;
+}

--- a/consumers/anland_v5/android_consumer/app/src/main/jni/input_grab.c
+++ b/consumers/anland_v5/android_consumer/app/src/main/jni/input_grab.c
@@ -29,8 +29,10 @@
  *      (or EOF, which the kernel guarantees when the app dies) releases
  *      everything. The app only heartbeats while its main thread is running, so
  *      an ANR frees the input too.
- *   5. Devices carrying KEY_POWER that are not keyboards are watched but never
- *      grabbed: the power button always stays with Android.
+ *   5. Pure Android hardware-button nodes (Power/Volume/Wakeup) are watched but
+ *      never grabbed: those physical buttons always stay with Android. Mixed
+ *      devices such as touch panels and keyboards still get grabbed, even if
+ *      their capability bitmap also advertises KEY_POWER.
  */
 #define _GNU_SOURCE
 #include <android/log.h>
@@ -271,23 +273,6 @@ static int send_bye(int fd, int reason)
 
 /* ---------------- device discovery ---------------- */
 
-/* A real keyboard: the letter block. Used both to keep alphabetic keyboards out
- * of the "carries KEY_POWER, do not grab" rule (external keyboards commonly
- * report a power key) and to classify key-only devices. */
-static int has_alpha_keys(const unsigned long *key)
-{
-    static const int letters[] = {
-        KEY_Q, KEY_W, KEY_E, KEY_R, KEY_T, KEY_Y,
-        KEY_A, KEY_S, KEY_D, KEY_F, KEY_G,
-        KEY_Z, KEY_X, KEY_C, KEY_V,
-    };
-    for (size_t i = 0; i < sizeof(letters) / sizeof(letters[0]); i++) {
-        if (!TEST_BIT(letters[i], key))
-            return 0;
-    }
-    return 1;
-}
-
 static int any_key_bit(const unsigned long *key)
 {
     for (int i = 0; i <= KEY_MAX; i++) {
@@ -295,6 +280,37 @@ static int any_key_bit(const unsigned long *key)
             return 1;
     }
     return 0;
+}
+
+static int is_physical_android_key(int code)
+{
+    switch (code) {
+    case KEY_POWER:
+#ifdef KEY_POWER2
+    case KEY_POWER2:
+#endif
+    case KEY_WAKEUP:
+    case KEY_SLEEP:
+    case KEY_VOLUMEUP:
+    case KEY_VOLUMEDOWN:
+    case KEY_MUTE:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+static int has_only_physical_android_keys(const unsigned long *key)
+{
+    int any = 0;
+    for (int i = 0; i <= KEY_MAX; i++) {
+        if (!TEST_BIT(i, key))
+            continue;
+        any = 1;
+        if (!is_physical_android_key(i))
+            return 0;
+    }
+    return any;
 }
 
 static void read_abs_range(int fd, int axis, int *min, int *max)
@@ -356,8 +372,6 @@ static int inspect_device(const char *path, struct dev_entry *out)
     int touch   = TEST_BIT(BTN_TOUCH, key);
     int click   = TEST_BIT(BTN_LEFT, key);
     int pen     = TEST_BIT(BTN_TOOL_PEN, key) || TEST_BIT(BTN_STYLUS, key);
-    int alpha   = has_alpha_keys(key);
-    int power   = TEST_BIT(KEY_POWER, key);
     int keys    = any_key_bit(key);
 
     /* A stylus digitizer overlaps the panel; forwarding it as a second finger
@@ -365,16 +379,6 @@ static int inspect_device(const char *path, struct dev_entry *out)
     if (pen) {
         close(fd);
         return -1;
-    }
-
-    /* The power button (and the fingerprint/hall nodes that ride along with it)
-     * is the last way out of a wedged grab, so it is never taken away from
-     * Android. The node is still opened so the toggle key can be seen on
-     * chipsets that put the volume keys on the same node. */
-    if (power && !alpha) {
-        out->cls = IGRAB_CLASS_KEYBOARD;
-        out->grabbed = 0;
-        return 0;
     }
 
     /* Contacts, not axes: a gamepad also reports ABS_X/ABS_Y, and its sticks
@@ -394,6 +398,16 @@ static int inspect_device(const char *path, struct dev_entry *out)
     } else if (rel_xy) {
         out->cls = IGRAB_CLASS_MOUSE;
     } else if (keys) {
+        /* Physical Android buttons must remain available to Android while
+         * immersive mode is active. Keep these fds open watch-only so the bound
+         * toggle key can still release the session, but do not EVIOCGRAB them.
+         * Keyboards/consumer-control nodes that also advertise KEY_POWER are not
+         * protected here because their ordinary keys must not leak to Android. */
+        if (has_only_physical_android_keys(key)) {
+            out->cls = IGRAB_CLASS_KEYBOARD;
+            out->grabbed = 0;
+            return 0;
+        }
         out->cls = IGRAB_CLASS_KEYBOARD;
     } else {
         close(fd);

--- a/consumers/anland_v5/android_consumer/app/src/main/jni/input_grab.h
+++ b/consumers/anland_v5/android_consumer/app/src/main/jni/input_grab.h
@@ -1,0 +1,66 @@
+/*
+ * Wire format between the root input-grab helper (input_grab.c, shipped as
+ * libinputgrab.so) and the app's InputGrab.java.
+ *
+ * One fixed-size 32-byte record for everything, little-endian, no padding
+ * surprises: every field is naturally aligned inside the struct, so the Java
+ * side can parse it with a plain ByteBuffer. Fixed framing matters because the
+ * helper drops records under back-pressure instead of blocking -- a variable
+ * length would desync the stream the moment one is dropped.
+ *
+ * Keep IGRAB_* in sync with the constants at the top of InputGrab.java.
+ */
+#ifndef ANLAND_INPUT_GRAB_H
+#define ANLAND_INPUT_GRAB_H
+
+#include <stdint.h>
+
+#define IGRAB_PROTO_VERSION 1
+
+/* rtype */
+#define IGRAB_REC_HELLO   1   /* value=version, aux[0]=grabbed count, aux[1]=pid */
+#define IGRAB_REC_DEVICE  2   /* one per opened device, before READY */
+#define IGRAB_REC_READY    3  /* device list complete, event stream starts */
+#define IGRAB_REC_EVENT   4   /* etype/code/value = evdev type/code/value */
+#define IGRAB_REC_BYE     5   /* value = IGRAB_BYE_*; helper is exiting */
+
+/* DEVICE.etype -- what the app should do with this device's events. */
+#define IGRAB_CLASS_TOUCHSCREEN 1
+#define IGRAB_CLASS_TOUCHPAD    2
+#define IGRAB_CLASS_MOUSE       3
+#define IGRAB_CLASS_KEYBOARD    4
+
+/* DEVICE.aux layout */
+#define IGRAB_AUX_MIN_X 0
+#define IGRAB_AUX_MAX_X 1
+#define IGRAB_AUX_MIN_Y 2
+#define IGRAB_AUX_MAX_Y 3
+#define IGRAB_AUX_FLAGS 4
+
+/* DEVICE.aux[IGRAB_AUX_FLAGS] bits */
+#define IGRAB_DEV_GRABBED    (1 << 0)  /* clear => watched only, Android still sees it */
+#define IGRAB_DEV_MULTITOUCH (1 << 1)  /* ABS_MT_POSITION_X/Y (protocol B) present */
+#define IGRAB_DEV_CLICKPAD   (1 << 2)  /* one physical button under the whole pad */
+
+/* BYE.value */
+#define IGRAB_BYE_TOGGLE    1  /* the toggle key was pressed */
+#define IGRAB_BYE_PEER_GONE 2  /* app closed the socket */
+#define IGRAB_BYE_STALLED   3  /* app stopped heartbeating / would not read */
+#define IGRAB_BYE_ERROR     4  /* nothing grabbable, or a fatal device error */
+
+/* Broadcast device id, used by the resync marker after dropped records. */
+#define IGRAB_DEV_ALL 0xFFFF
+
+#define IGRAB_MAX_DEVICES 32
+#define IGRAB_REC_SIZE    32
+
+struct igrab_rec {
+    uint16_t rtype;
+    uint16_t dev;
+    uint16_t etype;
+    uint16_t code;
+    int32_t  value;
+    int32_t  aux[5];
+} __attribute__((packed));
+
+#endif /* ANLAND_INPUT_GRAB_H */

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values-zh-rTW/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values-zh-rTW/strings.xml
@@ -15,7 +15,7 @@
     <!-- Settings home: category rows and back navigation -->
     <string name="nav_back">‹ 返回</string>
     <string name="cat_keyboard_title">鍵盤與按鍵</string>
-    <string name="cat_keyboard_subtitle">按鍵綁定、無障礙與擴充按鍵列</string>
+    <string name="cat_keyboard_subtitle">按鍵綁定、沉浸模式、無障礙與擴充按鍵列</string>
     <string name="cat_touchpad_title">觸控板與滑鼠</string>
     <string name="cat_touchpad_subtitle">觸控板模式、指標擷取與靈敏度</string>
     <string name="cat_connection_subtitle">socket、root、麥克風、相機與音訊延遲</string>
@@ -37,7 +37,21 @@
     <string name="listening_countdown">正在監聽…（%1$d 秒）</string>
     <string name="status_current_none">目前：無</string>
     <string name="status_current">目前：%1$s</string>
+    <string name="status_current_no_scancode">目前：%1$s —— 該按鍵不回報掃描碼，沉浸模式無法使用它。請改綁音量+等硬體按鍵。</string>
     <string name="keycode_unknown">鍵碼 %1$d</string>
+    <string name="scancode_unknown">掃描碼 %1$d</string>
+
+    <!-- Immersive mode -->
+    <string name="section_immersive">沉浸模式</string>
+    <string name="immersive_switch">啟用沉浸模式</string>
+    <string name="immersive_hint">透過 root 獨佔接管（EVIOCGRAB）觸控螢幕、鍵盤與指標裝置，讓 Android 完全收不到這些輸入，全部直接送往 Linux 桌面，系統手勢、通知列與導覽列都不會再干擾。需要 root。預設關閉且不會自行啟動：先開啟此開關並在下方綁定按鍵，然後按該鍵進入，再按一次離開。工作階段期間本應用程式自身的螢幕控制項按設計無法點選；「擷取外接指標」會暫時停用（該開關本身不受影響）；觸控板模式依然生效——手指移動游標，靈敏度沿用「觸控板與滑鼠」中的設定。應用程式失去焦點時工作階段也會結束。</string>
+    <string name="bind_immersive_key_button">綁定沉浸模式按鍵</string>
+    <string name="immersive_entering">已進入沉浸模式：所有輸入交給桌面，再按一次 %1$s 離開</string>
+    <string name="immersive_exited">已離開沉浸模式</string>
+    <string name="immersive_no_scancode">請先為沉浸模式綁定按鍵</string>
+    <string name="immersive_failed">無法進入沉浸模式：root 遭拒或無法使用</string>
+    <string name="immersive_no_devices">無法進入沉浸模式：沒有可接管的輸入裝置</string>
+    <string name="immersive_interrupted">沉浸模式已結束，輸入已交還 Android</string>
 
     <!-- Accessibility -->
     <string name="accessibility_switch">無障礙按鍵攔截</string>

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values-zh-rTW/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values-zh-rTW/strings.xml
@@ -42,9 +42,9 @@
     <string name="scancode_unknown">掃描碼 %1$d</string>
 
     <!-- Immersive mode -->
-    <string name="section_immersive">沉浸模式</string>
-    <string name="immersive_switch">啟用沉浸模式</string>
-    <string name="immersive_hint">透過 root 獨佔接管（EVIOCGRAB）觸控螢幕、鍵盤與指標裝置，讓 Android 完全收不到這些輸入，全部直接送往 Linux 桌面，系統手勢、通知列與導覽列都不會再干擾。需要 root。預設關閉且不會自行啟動：先開啟此開關並在下方綁定按鍵，然後按該鍵進入，再按一次離開。工作階段期間本應用程式自身的螢幕控制項按設計無法點選；「擷取外接指標」會暫時停用（該開關本身不受影響）；觸控板模式依然生效——手指移動游標，靈敏度沿用「觸控板與滑鼠」中的設定。應用程式失去焦點時工作階段也會結束。</string>
+    <string name="section_immersive">沉浸模式(實驗性)</string>
+    <string name="immersive_switch">啟用沉浸模式(實驗性)</string>
+    <string name="immersive_hint">將觸控、鍵盤和滑鼠等輸入直接交給 Linux 桌面，避免 Android 系統手勢干擾。需要 root。在下方設定切換按鍵：按一次進入，再按一次離開；切換到其他應用程式時會自動離開。</string>
     <string name="bind_immersive_key_button">綁定沉浸模式按鍵</string>
     <string name="immersive_entering">已進入沉浸模式：所有輸入交給桌面，再按一次 %1$s 離開</string>
     <string name="immersive_exited">已離開沉浸模式</string>

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
@@ -42,9 +42,9 @@
     <string name="scancode_unknown">扫描码 %1$d</string>
 
     <!-- Immersive mode -->
-    <string name="section_immersive">沉浸模式</string>
-    <string name="immersive_switch">启用沉浸模式</string>
-    <string name="immersive_hint">通过 root 独占接管（EVIOCGRAB）触摸屏、键盘与指针设备，让安卓完全收不到这些输入，全部直接送往 Linux 桌面，系统手势、通知栏与导航栏都不会再干扰。需要 root。默认关闭且不会自行开启：先打开此开关并在下方绑定按键，然后按该键进入，再按一次退出。会话期间本应用自身的屏上控件按设计无法点击；「捕获外接指针」会被暂时挂起（该开关本身不受影响）；触摸板模式依然生效——手指移动光标，灵敏度沿用「触摸板与鼠标」中的设置。应用失去焦点时会话也会结束。</string>
+    <string name="section_immersive">沉浸模式(实验性)</string>
+    <string name="immersive_switch">启用沉浸模式(实验性)</string>
+    <string name="immersive_hint">将触摸、键盘和鼠标等输入直接交给 Linux 桌面，避免 Android 系统手势干扰。需要 root。在下方设置切换按键：按一次进入，再按一次退出；切换到其他应用时会自动退出。</string>
     <string name="bind_immersive_key_button">绑定沉浸模式按键</string>
     <string name="immersive_entering">已进入沉浸模式：所有输入交给桌面，再按一次 %1$s 退出</string>
     <string name="immersive_exited">已退出沉浸模式</string>

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
@@ -15,7 +15,7 @@
     <!-- Settings home: category rows and back navigation -->
     <string name="nav_back">‹ 返回</string>
     <string name="cat_keyboard_title">键盘与按键</string>
-    <string name="cat_keyboard_subtitle">按键绑定、无障碍与扩展按键栏</string>
+    <string name="cat_keyboard_subtitle">按键绑定、沉浸模式、无障碍与扩展按键栏</string>
     <string name="cat_touchpad_title">触摸板与鼠标</string>
     <string name="cat_touchpad_subtitle">触摸板模式、指针捕获与灵敏度</string>
     <string name="cat_connection_subtitle">套接字、root、麦克风、摄像头与音频延迟</string>
@@ -37,7 +37,21 @@
     <string name="listening_countdown">正在监听…（%1$d 秒）</string>
     <string name="status_current_none">当前：无</string>
     <string name="status_current">当前：%1$s</string>
+    <string name="status_current_no_scancode">当前：%1$s —— 该按键不上报扫描码，沉浸模式无法使用它。请改绑音量+等硬件按键。</string>
     <string name="keycode_unknown">键码 %1$d</string>
+    <string name="scancode_unknown">扫描码 %1$d</string>
+
+    <!-- Immersive mode -->
+    <string name="section_immersive">沉浸模式</string>
+    <string name="immersive_switch">启用沉浸模式</string>
+    <string name="immersive_hint">通过 root 独占接管（EVIOCGRAB）触摸屏、键盘与指针设备，让安卓完全收不到这些输入，全部直接送往 Linux 桌面，系统手势、通知栏与导航栏都不会再干扰。需要 root。默认关闭且不会自行开启：先打开此开关并在下方绑定按键，然后按该键进入，再按一次退出。会话期间本应用自身的屏上控件按设计无法点击；「捕获外接指针」会被暂时挂起（该开关本身不受影响）；触摸板模式依然生效——手指移动光标，灵敏度沿用「触摸板与鼠标」中的设置。应用失去焦点时会话也会结束。</string>
+    <string name="bind_immersive_key_button">绑定沉浸模式按键</string>
+    <string name="immersive_entering">已进入沉浸模式：所有输入交给桌面，再按一次 %1$s 退出</string>
+    <string name="immersive_exited">已退出沉浸模式</string>
+    <string name="immersive_no_scancode">请先为沉浸模式绑定按键</string>
+    <string name="immersive_failed">无法进入沉浸模式：root 被拒绝或不可用</string>
+    <string name="immersive_no_devices">无法进入沉浸模式：没有可接管的输入设备</string>
+    <string name="immersive_interrupted">沉浸模式已结束，输入已交还安卓</string>
 
     <!-- Accessibility -->
     <string name="accessibility_switch">无障碍按键拦截</string>

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
@@ -42,9 +42,9 @@
     <string name="scancode_unknown">Scan code %1$d</string>
 
     <!-- Immersive mode -->
-    <string name="section_immersive">Immersive Mode</string>
-    <string name="immersive_switch">Enable immersive mode</string>
-    <string name="immersive_hint">Uses root to take the touchscreen, keyboard and pointer devices away from Android entirely (EVIOCGRAB) and sends everything to the Linux desktop, so system gestures, the notification shade and the navigation bar cannot get in the way. Requires root. Off by default and never starts on its own: turn this on, bind a key below, then press that key to enter and press it again to leave. While a session runs, this app\'s own on-screen controls are unreachable by design, \"Capture external pointer\" is suspended (that setting itself is left alone), and Touchpad Mode still applies — a finger moves the cursor, at the sensitivity set under Touchpad &amp; Mouse. A session also ends whenever the app loses focus.</string>
+    <string name="section_immersive">Immersive Mode (Experimental)</string>
+    <string name="immersive_switch">Enable Immersive Mode (Experimental)</string>
+    <string name="immersive_hint">Sends touch, keyboard and mouse input directly to the Linux desktop, keeping Android gestures out of the way. Requires root. Set a toggle key below: press it once to enter and again to exit. The mode also ends when you switch apps.</string>
     <string name="bind_immersive_key_button">Bind Immersive Mode Key</string>
     <string name="immersive_entering">Immersive mode: all input goes to the desktop. Press %1$s again to leave.</string>
     <string name="immersive_exited">Immersive mode off</string>

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
     <!-- Settings home: category rows and back navigation -->
     <string name="nav_back">‹ Back</string>
     <string name="cat_keyboard_title">Keyboard &amp; Keys</string>
-    <string name="cat_keyboard_subtitle">Key binding, accessibility &amp; extra keys bar</string>
+    <string name="cat_keyboard_subtitle">Key binding, immersive mode, accessibility &amp; extra keys bar</string>
     <string name="cat_touchpad_title">Touchpad &amp; Mouse</string>
     <string name="cat_touchpad_subtitle">Touchpad mode, pointer capture &amp; sensitivity</string>
     <string name="cat_connection_subtitle">Socket, root, mic, camera &amp; audio latency</string>
@@ -37,7 +37,21 @@
     <string name="listening_countdown">Listening… (%1$ds)</string>
     <string name="status_current_none">Current: None</string>
     <string name="status_current">Current: %1$s</string>
+    <string name="status_current_no_scancode">Current: %1$s — this key reports no scan code, so immersive mode cannot use it. Bind a hardware key such as Volume Up.</string>
     <string name="keycode_unknown">Keycode %1$d</string>
+    <string name="scancode_unknown">Scan code %1$d</string>
+
+    <!-- Immersive mode -->
+    <string name="section_immersive">Immersive Mode</string>
+    <string name="immersive_switch">Enable immersive mode</string>
+    <string name="immersive_hint">Uses root to take the touchscreen, keyboard and pointer devices away from Android entirely (EVIOCGRAB) and sends everything to the Linux desktop, so system gestures, the notification shade and the navigation bar cannot get in the way. Requires root. Off by default and never starts on its own: turn this on, bind a key below, then press that key to enter and press it again to leave. While a session runs, this app\'s own on-screen controls are unreachable by design, \"Capture external pointer\" is suspended (that setting itself is left alone), and Touchpad Mode still applies — a finger moves the cursor, at the sensitivity set under Touchpad &amp; Mouse. A session also ends whenever the app loses focus.</string>
+    <string name="bind_immersive_key_button">Bind Immersive Mode Key</string>
+    <string name="immersive_entering">Immersive mode: all input goes to the desktop. Press %1$s again to leave.</string>
+    <string name="immersive_exited">Immersive mode off</string>
+    <string name="immersive_no_scancode">Bind a key for immersive mode first</string>
+    <string name="immersive_failed">Could not start immersive mode: root was denied or is unavailable</string>
+    <string name="immersive_no_devices">Could not start immersive mode: no input device could be taken over</string>
+    <string name="immersive_interrupted">Immersive mode ended; input returned to Android</string>
 
     <!-- Accessibility -->
     <string name="accessibility_switch">Accessibility Key Interception</string>


### PR DESCRIPTION
沉浸模式通过Root权限独占接管触摸屏、键盘和鼠标等物理输入，并将操作直接发送到Linux桌面。开启后，安卓不再处理这些输入，系统手势、通知栏和导航栏不会干扰桌面操
  作。设置切换按键后，按一次进入，再按一次退出；切换到其他应用时会自动结束并归还输入。
