### PR TITLE
feat: add setting to disable pinch and multi-finger gestures

### DIFF
--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -137,6 +137,10 @@ public class MainActivity extends Activity
     public static final String KEY_MOVE_THRESHOLD = "touchpad_move_threshold";
     // Magnifies declined gestures forwarded as touch; see Touchpad.setGestureScale.
     public static final String KEY_GESTURE_SCALE = "touchpad_gesture_scale";
+    // Disable pinch (two-finger spread) and three-or-more-finger gestures: they
+    // are swallowed instead of being forwarded to the desktop as touch.
+    public static final String KEY_DISABLE_MULTI_FINGER_GESTURES =
+            "disable_multi_finger_gestures";
     // Capture an external mouse/touchpad as a relative pointer so it cannot reach
     // the Android screen edges. This is deliberately opt-in: existing installations
     // keep the old absolute-pointer behaviour until the user enables it.
@@ -768,6 +772,8 @@ public class MainActivity extends Activity
                         Touchpad.DEFAULT_MOVE_THRESHOLD_FACTOR));
         pad.setGestureScale(prefs.getFloat(KEY_GESTURE_SCALE,
                 Touchpad.DEFAULT_GESTURE_SCALE));
+        pad.setMultiFingerGesturesDisabled(
+                prefs.getBoolean(KEY_DISABLE_MULTI_FINGER_GESTURES, false));
     }
 
     /**

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
@@ -76,6 +76,8 @@ public class SettingsActivity extends Activity {
     private static final String KEY_SCROLL_THRESHOLD = "touchpad_scroll_threshold";
     private static final String KEY_MOVE_THRESHOLD = "touchpad_move_threshold";
     private static final String KEY_GESTURE_SCALE = "touchpad_gesture_scale";
+    private static final String KEY_DISABLE_MULTI_FINGER_GESTURES =
+            "disable_multi_finger_gestures";
 
     // Latency presets: target buffer in ms (0 = auto). The user-visible labels live
     // in the R.array.latency_labels string-array, parallel to this array.
@@ -799,6 +801,25 @@ public class SettingsActivity extends Activity {
         reverseScrollHint.setTextColor(Color.GRAY);
         reverseScrollHint.setPadding(0, dp(4), 0, dp(12));
         root.addView(reverseScrollHint);
+
+        // Disable pinch (two-finger spread) and three-or-more-finger gestures.
+        Switch disableMultiFingerSwitch = new Switch(this);
+        disableMultiFingerSwitch.setText(R.string.disable_multi_finger_switch);
+        disableMultiFingerSwitch.setTextSize(14);
+        disableMultiFingerSwitch.setPadding(0, dp(8), 0, 0);
+        disableMultiFingerSwitch.setChecked(prefs.getBoolean(
+                KEY_DISABLE_MULTI_FINGER_GESTURES, false));
+        disableMultiFingerSwitch.setOnCheckedChangeListener((v, checked) ->
+                getSharedPreferences(PREFS_NAME, MODE_PRIVATE).edit()
+                        .putBoolean(KEY_DISABLE_MULTI_FINGER_GESTURES, checked).apply());
+        root.addView(disableMultiFingerSwitch);
+
+        TextView disableMultiFingerHint = new TextView(this);
+        disableMultiFingerHint.setText(R.string.disable_multi_finger_hint);
+        disableMultiFingerHint.setTextSize(12);
+        disableMultiFingerHint.setTextColor(Color.GRAY);
+        disableMultiFingerHint.setPadding(0, dp(4), 0, dp(12));
+        root.addView(disableMultiFingerHint);
 
         addFloatSlider(root, R.string.scroll_speed_label, R.string.scroll_speed_value,
                 null, KEY_SCROLL_SPEED, 0.05f, 3.0f, 0.05f, 0.5f);

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/Touchpad.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/Touchpad.java
@@ -88,6 +88,14 @@ public final class Touchpad {
     private static final int TWO_FINGER_SCROLL = 1;
     private static final int TWO_FINGER_NOT_SCROLL = 2;
     private int twoFingerMode = TWO_FINGER_UNDECIDED;
+    // Same phase classified as NOT_SCROLL (a pinch) while multi-finger gestures
+    // are disabled: the whole phase is swallowed instead of being forwarded as
+    // touch, so the gesture does nothing and lifting one finger resumes normal
+    // one-finger cursor control.
+    private static final int TWO_FINGER_IGNORED = 3;
+    // True while three or more fingers are on the pad and multi-finger gestures
+    // are disabled: swallow the stream (see recognize) until it drops to one.
+    private boolean multiFingerIgnored = false;
     // Both fingers' positions when the two-finger phase began. The scroll test
     // measures displacement from here rather than frame to frame, matching AOSP.
     private float twoFingerStartX1, twoFingerStartY1;
@@ -131,6 +139,10 @@ public final class Touchpad {
     private float gestureScale = DEFAULT_GESTURE_SCALE;
 
     private float mouseAccelStrength = 1.0f; // 加速度强度，0.5 ~ 10.0
+
+    // 禁用双指捏合/张开与三指及以上的触摸转发手势（缩放等）。开启后这些
+    // 手势被吞掉（不转发为触摸），双指滚动与双指右键点击不受影响。
+    private boolean multiFingerGesturesDisabled = false;
 
     // ===== 调整后的平滑/抗抖动参数（更灵敏、更连续） =====
     private static final float DEAD_ZONE = 0.3f;          // 死区从 0.5 降到 0.3
@@ -213,6 +225,16 @@ public final class Touchpad {
     /** Invert both scroll axes ("natural" scrolling). */
     void setScrollReversed(boolean reversed) {
         scrollReversed = reversed;
+    }
+
+    /** 是否禁用双指捏合/张开与三指及以上的触摸转发手势。 */
+    void setMultiFingerGesturesDisabled(boolean disabled) {
+        multiFingerGesturesDisabled = disabled;
+        if (disabled) {
+            // A partially-observed gesture must not stay latched as "forwarded".
+            multiFingerIgnored = false;
+            twoFingerMode = TWO_FINGER_UNDECIDED;
+        }
     }
 
     /**
@@ -452,6 +474,24 @@ public final class Touchpad {
             return false;
         }
 
+        // 三指及以上手势被禁用时，吞掉整个流，直到手指减到一根（此时落回
+        // ACTION_POINTER_UP 的正常处理恢复单指控制）。
+        if (multiFingerIgnored) {
+            if (action == MotionEvent.ACTION_POINTER_UP
+                    && (event.getPointerCount() - 1) <= 1) {
+                multiFingerIgnored = false;
+                // fall through to the ACTION_POINTER_UP branch below
+            } else if (action == MotionEvent.ACTION_UP
+                    || action == MotionEvent.ACTION_CANCEL) {
+                multiFingerIgnored = false;
+                resetTouchpadState();
+                resetSmoothing();
+                return true;
+            } else {
+                return true; // swallow
+            }
+        }
+
         switch (action) {
             case MotionEvent.ACTION_DOWN: {
                 float x = event.getX();
@@ -487,8 +527,14 @@ public final class Touchpad {
                     lastY2 = twoFingerStartY2 = event.getY(1);
                     twoFingerMode = TWO_FINGER_UNDECIDED;
                 } else if (pointerCount >= 3) {
-                    // Three or more fingers is never one of ours.
-                    return declineGesture();
+                    if (multiFingerGesturesDisabled) {
+                        // 三指及以上手势被禁用，吞掉。
+                        multiFingerIgnored = true;
+                        isMultiFinger = true;
+                    } else {
+                        // Three or more fingers is never one of ours.
+                        return declineGesture();
+                    }
                 }
                 break;
             }
@@ -554,13 +600,28 @@ public final class Touchpad {
                         if (twoFingerMode == TWO_FINGER_UNDECIDED) {
                             twoFingerMode = classifyTwoFinger(x1, y1, x2, y2);
                             if (twoFingerMode == TWO_FINGER_NOT_SCROLL) {
-                                // A pinch, or one finger travelling against a resting
-                                // one. Hand the gesture to the forwarding path.
-                                return declineGesture();
+                                if (multiFingerGesturesDisabled) {
+                                    // 双指捏合/张开被禁用，吞掉这一阶段
+                                    //（不滚动也不转发为触摸）。
+                                    twoFingerMode = TWO_FINGER_IGNORED;
+                                } else {
+                                    // A pinch, or one finger travelling against a
+                                    // resting one. Hand the gesture to the
+                                    // forwarding path.
+                                    return declineGesture();
+                                }
                             }
                         }
 
-                        if (twoFingerMode == TWO_FINGER_SCROLL) {
+                        if (twoFingerMode == TWO_FINGER_IGNORED) {
+                            // Swallow the pinch: keep the anchors current so the
+                            // next touch that resumes normal input does not see
+                            // one giant delta.
+                            lastX1 = x1;
+                            lastY1 = y1;
+                            lastX2 = x2;
+                            lastY2 = y2;
+                        } else if (twoFingerMode == TWO_FINGER_SCROLL) {
                             float avgDx = ((x1 - lastX1) + (x2 - lastX2)) / 2;
                             float avgDy = ((y1 - lastY1) + (y2 - lastY2)) / 2;
 
@@ -815,6 +876,7 @@ public final class Touchpad {
         isLongPressPossible = false;
         isMultiFinger = false;
         twoFingerMode = TWO_FINGER_UNDECIDED;
+        multiFingerIgnored = false;
         // Cleared here rather than in declineGesture: the latch has to outlive the
         // events that follow it and only lifts when the gesture itself ends.
         gestureUnhandled = false;

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
@@ -97,6 +97,8 @@
     <string name="gesture_scale_label">手势幅度</string>
     <string name="gesture_scale_value">%1$.0f 像素</string>
     <string name="gesture_scale_hint">转为触摸的手势（双指开合、三指及以上）会映射到以指针为中心、边长为此值的正方形内。值越大，相同的手指移动幅度越大。</string>
+    <string name="disable_multi_finger_switch">禁用双指开合与多指手势</string>
+    <string name="disable_multi_finger_hint">开启：双指捏合/张开和三指及以上的手势会被吞掉，不会传到桌面；双指滚动和双指右键仍正常。关闭：双指开合、多指手势作为触摸转发到桌面。</string>
 
     <!-- Connection -->
     <string name="socket_path_label">守护进程套接字路径</string>

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
@@ -97,6 +97,8 @@
     <string name="gesture_scale_label">Gesture magnitude</string>
     <string name="gesture_scale_value">%1$.0f px</string>
     <string name="gesture_scale_hint">Gestures forwarded as touch (pinch, three or more fingers) are mapped into a square of this size centred on the pointer. Larger values make the same finger movement travel further.</string>
+    <string name="disable_multi_finger_switch">Disable pinch and multi-finger gestures</string>
+    <string name="disable_multi_finger_hint">ON: two-finger pinch/zoom and three-or-more-finger gestures are swallowed and never reach the desktop; two-finger scrolling and two-finger right-click still work. OFF: pinch and multi-finger gestures are forwarded to the desktop as touch.</string>
 
     <!-- Connection -->
     <string name="socket_path_label">Daemon socket path</string>


### PR DESCRIPTION
## 问题背景

当前触摸板模式下，双指捏合/张开（pinch/zoom）与三指及以上的手势会被
作为触摸事件转发到桌面（见 Touchpad.forwardAsTouch）。对部分用户：

- 双指上下滚动时，手指的轻微张开/收拢会被手势识别器误判为双指缩放
  （classifyTwoFinger 中 large*small <= 0 即判为非滚动），滚动体验不稳定；
- 不需要触摸板缩放手势的用户，无法阻止这些触摸被转发到桌面。

## 改动内容

新增设置项「禁用双指开合与多指手势」（Disable pinch and multi-finger
gestures，默认关闭，保持原有转发行为）：

- Touchpad.java
  - 新增 `multiFingerGesturesDisabled` 标志与 `setMultiFingerGesturesDisabled()`；
  - 禁用时双指捏合/张开进入 `TWO_FINGER_IGNORED` 状态被吞掉；
  - 三指及以上进入 `multiFingerIgnored`，整段手势流被吞掉，手指减到一根
    时恢复正常单指控制；
  - 双指滚动、双指右键点击不受影响。
- MainActivity.java：`KEY_DISABLE_MULTI_FINGER_GESTURES` 常量，
  `applyTouchpadPrefs` 读取并应用到两个 Touchpad 实例。
- SettingsActivity.java：触摸板区域新增开关（含中英文文案）。
- strings.xml / values-zh/strings.xml：新增中英文字符串。

默认关闭：只有用户主动开启后，捏合/多指手势才被吞掉，现有用户行为不变。

## 备注

- 仅新增一个可选设置，未改动任何默认行为；
- 设置即时生效（onResume 重读偏好），无需重启应用。
