### PR TITLE
sepolicy: Fix untrusted_app_34 AVC denials for Android 17

### DIFF
--- a/magisk_module/sepolicy.rule
+++ b/magisk_module/sepolicy.rule
@@ -1,9 +1,13 @@
 allow untrusted_app droidspacesd fd use
+allow untrusted_app_34 droidspacesd fd use
 allow droidspacesd untrusted_app fd use
+allow droidspacesd untrusted_app_34 fd use
 allow droidspacesd untrusted_app unix_stream_socket { read write }
+allow droidspacesd untrusted_app_34 unix_stream_socket { read write }
 allow droidspacesd device chr_file { open read write ioctl map }
 allow droidspacesd droidspacesd unix_stream_socket { create connect listen accept bind getattr getopt setopt shutdown read write }
 allow droidspacesd hal_graphics_allocator_default fd use
 allow surfaceflinger droidspacesd fd use
 allow hal_graphics_composer_default droidspacesd fd use
 allow untrusted_app su unix_stream_socket { read write }
+allow untrusted_app_34 su unix_stream_socket { read write }


### PR DESCRIPTION
* The Anland app is labeled as untrusted_app_34 on Android 17, causing AVC denials when trying to access droidspacesd and su.

Log:
W anland.consumer: type=1400 audit(0.0:247): avc:  denied  { read write } for  path="socket:[45895]" dev="sockfs" ino=45895 scontext=u:r:untrusted_app_34:s0:c34,c257,c512,c768 tcontext=u:r:su:s0 tclass=unix_stream_socket permissive=0 app=com.anland.consumer W anland.consumer: type=1400 audit(0.0:248): avc:  denied  { read write } for  path="socket:[81997]" dev="sockfs" ino=81997 scontext=u:r:untrusted_app_34:s0:c34,c257,c512,c768 tcontext=u:r:su:s0 tclass=unix_stream_socket permissive=0 app=com.anland.consumer W anland.consumer: type=1400 audit(0.0:249): avc:  denied  { read write } for  path="socket:[70602]" dev="sockfs" ino=70602 scontext=u:r:untrusted_app_34:s0:c34,c257,c512,c768 tcontext=u:r:su:s0 tclass=unix_stream_socket permissive=0 app=com.anland.consumer W anland.consumer: type=1400 audit(0.0:250): avc:  denied  { read write } for  path="socket:[81226]" dev="sockfs" ino=81226 scontext=u:r:untrusted_app_34:s0:c34,c257,c512,c768 tcontext=u:r:su:s0 tclass=unix_stream_socket permissive=0 app=com.anland.consumer