### PR TITLE
producers: add Mutter support for Ubuntu 26.04 & Debian 13

### DIFF
--- a/producers/gnome/Debian13_v5/build.sh
+++ b/producers/gnome/Debian13_v5/build.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+#
+# build.sh — rebuild the patched Mutter and XWayland .deb packages and install them.
+#
+# Run this INSIDE the container (e.g. `droidspaces -n kde run` or a shell there).
+# It uses sudo for the privileged steps (apt / dpkg), so it works whether you
+# are root or an ordinary user with sudo rights.
+#
+# The Mutter patch enables the Anland backend, and the sibling 'mutter/'
+# directory contains the backend files copied into the source tree. The Mutter
+# source version is pinned below because the patch targets that Ubuntu package
+# revision. XWayland follows the latest source version available to apt.
+#
+# You can override the patch locations with MUTTER_PATCH=... and
+# XWAYLAND_PATCH=... ./build.sh.
+#
+set -u
+
+MUTTER_VERSION='48.7-0+deb13u1'
+
+# ---- sudo helper (no-op if already root) -----------------------------------
+if [ "$(id -u)" -eq 0 ]; then
+    SUDO=""
+else
+    SUDO="sudo"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKDIR="${WORKDIR:-$HOME/anland-debbuild}"
+JOBS="$(nproc)"
+
+# ---- locate a patch file by name, regardless of where it lives -------------
+find_patch() {
+    # $1 = base name to look for (e.g. mutter.patch)
+    local name="$1" explicit="${2:-}"
+    if [ -n "$explicit" ] && [ -f "$explicit" ]; then
+        printf '%s\n' "$explicit"; return 0
+    fi
+    local c
+    for c in "$SCRIPT_DIR/$name" "./$name" "$SCRIPT_DIR/../$name"; do
+        if [ -f "$c" ]; then printf '%s\n' "$c"; return 0; fi
+    done
+    # last resort: search a couple of likely roots
+    local hit
+    hit="$(find "$SCRIPT_DIR" "$PWD" -maxdepth 3 -name "$name" -type f 2>/dev/null | head -1)"
+    if [ -n "$hit" ]; then printf '%s\n' "$hit"; return 0; fi
+    return 1
+}
+
+log()  { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+warn() { printf '\033[1;33m[warn] %s\033[0m\n' "$*"; }
+die()  { printf '\033[1;31m[error] %s\033[0m\n' "$*" >&2; exit 1; }
+
+# ---- ensure deb-src entries exist so `apt source` works --------------------
+ensure_deb_src() {
+    if ! $SUDO grep -rqsE '^Types:.*deb-src|^deb-src ' \
+            /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null; then
+        log "Enabling deb-src repositories"
+        if [ -f /etc/apt/sources.list.d/debian.sources ]; then
+            $SUDO sed -i 's/^Types: deb$/Types: deb deb-src/' \
+                /etc/apt/sources.list.d/debian.sources
+        elif [ -f /etc/apt/sources.list ]; then
+            $SUDO sed -i 's/^deb \(.*\)$/deb \1\ndeb-src \1/' /etc/apt/sources.list
+        fi
+    fi
+    $SUDO apt-get update -qq || warn "apt-get update reported issues"
+}
+
+# ---- build one source package with an optional overlay and patch ------------
+build_pkg() {
+    local src="$1" patch="$2" version="${3:-}" overlay_dir="${4:-}" \
+        sentinel="${5:-}" source_spec="$1" source_label
+
+    if [ -n "$version" ]; then
+        source_spec="$src=$version"
+        source_label="$version"
+    else
+        source_label='latest available'
+    fi
+
+    log "Installing build dependencies for '$src' ($source_label)"
+    $SUDO apt-get build-dep -y "$source_spec" \
+        || warn "build-dep for $src had issues; continuing"
+
+    log "Fetching source for '$src' ($source_label)"
+    rm -rf "${WORKDIR:?}/$src"
+    mkdir -p "$WORKDIR/$src"
+    ( cd "$WORKDIR/$src" && apt-get source "$source_spec" ) \
+        || die "apt-get source $src failed"
+
+    local tree
+    tree="$(find "$WORKDIR/$src" -maxdepth 1 -type d -name "${src}-*" | head -1)"
+    [ -n "$tree" ] || die "could not find unpacked source tree for $src"
+
+    if [ -n "$overlay_dir" ]; then
+        [ -d "$overlay_dir" ] || die "overlay directory not found: $overlay_dir"
+        log "Overlaying '$overlay_dir' -> $tree (overwrite-merge)"
+        cp -a "$overlay_dir/." "$tree/"
+    fi
+
+    log "Applying patch: $patch -> $tree"
+    if ( cd "$tree" && patch --batch -p1 --forward --reject-file=- < "$patch" ); then
+        :
+    else
+        # already applied? Verify using the caller's patch sentinel.
+        if [ -n "$sentinel" ] && grep -rqF -- "$sentinel" "$tree" 2>/dev/null; then
+            warn "patch looks already applied, continuing"
+        else
+            die "patch did not apply cleanly for $src"
+        fi
+    fi
+
+    log "Building '$src' $source_label (.deb)"
+    # -d: don't re-check build-deps (already installed above)
+    # -b -uc -us: binary only, unsigned. changelog untouched -> official version.
+    ( cd "$tree" && DEB_BUILD_OPTIONS="nocheck parallel=$JOBS" \
+        dpkg-buildpackage -b -uc -us -d ) \
+        || die "dpkg-buildpackage failed for $src"
+
+    log "Installing built .deb(s) for '$src'"
+    local debs
+    debs="$(find "$WORKDIR/$src" -maxdepth 1 -name '*.deb' -type f)"
+    [ -n "$debs" ] || die "no .deb produced for $src"
+    printf '%s\n' "$debs"
+    # shellcheck disable=SC2086
+    $SUDO dpkg --force-confdef --force-confold -i $debs \
+        || warn "dpkg -i for $src reported issues (deps?)"
+}
+
+# ---------------------------------------------------------------------------
+main() {
+    local mutter_patch xwayland_patch
+    mutter_patch="$(find_patch mutter.patch "${MUTTER_PATCH:-}")" \
+        || die "mutter.patch not found (set MUTTER_PATCH=... to override)"
+    xwayland_patch="$(find_patch xwayland.patch "${XWAYLAND_PATCH:-}")" \
+        || die "xwayland.patch not found (set XWAYLAND_PATCH=... to override)"
+
+    log "mutter version : $MUTTER_VERSION"
+    log "mutter.patch   : $mutter_patch"
+    log "xwayland.patch : $xwayland_patch"
+    log "xwayland source: latest available"
+    log "work dir       : $WORKDIR"
+
+    ensure_deb_src
+
+    build_pkg mutter "$mutter_patch" "$MUTTER_VERSION" "$SCRIPT_DIR/mutter" \
+        'have_anland = get_option'
+    build_pkg xwayland "$xwayland_patch" '' '' \
+        'No usable linux-dmabuf main device'
+
+    sed -i '/PULSE_SERVER=unix:\/tmp\/.pulse-socket/d' /etc/environment
+
+    log "Done. Patched Mutter and XWayland built and installed."
+    echo "Built packages are under: $WORKDIR/{mutter,xwayland}/"
+    echo "Restart the compositor session for the changes to take effect."
+}
+
+main "$@"

--- a/producers/gnome/Debian13_v5/mutter.patch
+++ b/producers/gnome/Debian13_v5/mutter.patch
@@ -1,0 +1,1144 @@
+diff --git a/debian/libmutter-16-0.symbols b/debian/libmutter-16-0.symbols
+index 61b8e99a1e..4ca004f9e9 100644
+--- a/debian/libmutter-16-0.symbols
++++ b/debian/libmutter-16-0.symbols
+@@ -1925,10 +1925,13 @@ libmutter-clutter-16.so.0 libmutter-16-0 #MINVER#
+  clutter_stage_view_notify_presented@Base 43.0
+  clutter_stage_view_notify_ready@Base 43.0
+  clutter_stage_view_peek_scanout@Base 43.0
++ clutter_stage_view_present@Base 48.7
++ clutter_stage_view_replace_framebuffer@Base 48.7
+  clutter_stage_view_schedule_update@Base 43.0
+  clutter_stage_view_schedule_update_now@Base 44~rc
+  clutter_stage_view_set_color_state@Base 47~rc
+  clutter_stage_view_set_output_color_state@Base 47~rc
++ clutter_stage_view_set_present_func@Base 48.7
+  clutter_stage_view_take_accumulated_redraw_clip@Base 43.0
+  clutter_stage_view_take_scanout@Base 43.0
+  clutter_stage_window_get_type@Base 43.0
+diff --git a/debian/rules b/debian/rules
+index 19c720fbe6..d2a340e703 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -23,7 +23,8 @@ CONFFLAGS = \
+ 	-Dauto_features=enabled \
+ 	-Degl_device=true \
+ 	-Dremote_desktop=true \
+-	-Dwayland_eglstream=true
++	-Dwayland_eglstream=true \
++	-Danland=enabled
+ export deb_udevdir = $(shell pkg-config --variable=udevdir udev | sed s,^/,,)
+ 
+ # Update the cogl_trace architectures in the symbols file to match this list:
+diff --git a/clutter/clutter/clutter-stage-view-private.h b/clutter/clutter/clutter-stage-view-private.h
+index 31ac7e144e..246bb5afc2 100644
+--- a/clutter/clutter/clutter-stage-view-private.h
++++ b/clutter/clutter/clutter-stage-view-private.h
+@@ -21,6 +21,11 @@
+ #include "clutter/clutter-types.h"
+ #include "mtk/mtk.h"
+ 
++typedef gboolean (* MetaStageViewPresentFunc) (ClutterStageView *view,
++                                                ClutterFrame     *frame,
++                                                int64_t           global_frame_counter,
++                                                gpointer          user_data);
++
+ CLUTTER_EXPORT
+ void clutter_stage_view_after_paint (ClutterStageView *view,
+                                      MtkRegion        *redraw_clip);
+@@ -46,6 +51,20 @@ void clutter_stage_view_invalidate_projection (ClutterStageView *view);
+ void clutter_stage_view_set_projection (ClutterStageView        *view,
+                                         const graphene_matrix_t *matrix);
+ 
++CLUTTER_EXPORT
++void clutter_stage_view_replace_framebuffer (ClutterStageView *view,
++                                              CoglFramebuffer  *framebuffer);
++
++CLUTTER_EXPORT
++void clutter_stage_view_set_present_func (ClutterStageView        *view,
++                                           MetaStageViewPresentFunc present_func,
++                                           gpointer                 user_data);
++
++CLUTTER_EXPORT
++gboolean clutter_stage_view_present (ClutterStageView *view,
++                                      ClutterFrame     *frame,
++                                      int64_t           global_frame_counter);
++
+ CLUTTER_EXPORT
+ void clutter_stage_view_add_redraw_clip (ClutterStageView   *view,
+                                          const MtkRectangle *clip);
+diff --git a/clutter/clutter/clutter-stage-view.c b/clutter/clutter/clutter-stage-view.c
+index 271abb396b..7ed72f93ce 100644
+--- a/clutter/clutter/clutter-stage-view.c
++++ b/clutter/clutter/clutter-stage-view.c
+@@ -90,6 +90,9 @@ typedef struct _ClutterStageViewPrivate
+   gboolean has_accumulated_redraw_clip;
+   MtkRegion *accumulated_redraw_clip;
+ 
++  MetaStageViewPresentFunc present_func;
++  gpointer present_user_data;
++
+   float refresh_rate;
+   int64_t vblank_duration_us;
+   ClutterFrameClock *frame_clock;
+@@ -1191,6 +1194,51 @@ clutter_stage_view_set_framebuffer (ClutterStageView *view,
+     }
+ }
+ 
++void
++clutter_stage_view_replace_framebuffer (ClutterStageView *view,
++                                        CoglFramebuffer  *framebuffer)
++{
++  ClutterStageViewPrivate *priv =
++    clutter_stage_view_get_instance_private (view);
++
++  g_return_if_fail (framebuffer != NULL);
++  g_return_if_fail (cogl_framebuffer_get_width (priv->framebuffer) ==
++                    cogl_framebuffer_get_width (framebuffer));
++  g_return_if_fail (cogl_framebuffer_get_height (priv->framebuffer) ==
++                    cogl_framebuffer_get_height (framebuffer));
++
++  g_set_object (&priv->framebuffer, framebuffer);
++  clutter_stage_view_invalidate_viewport (view);
++  clutter_stage_view_invalidate_projection (view);
++}
++
++void
++clutter_stage_view_set_present_func (ClutterStageView        *view,
++                                     MetaStageViewPresentFunc present_func,
++                                     gpointer                 user_data)
++{
++  ClutterStageViewPrivate *priv =
++    clutter_stage_view_get_instance_private (view);
++
++  priv->present_func = present_func;
++  priv->present_user_data = user_data;
++}
++
++gboolean
++clutter_stage_view_present (ClutterStageView *view,
++                            ClutterFrame     *frame,
++                            int64_t           global_frame_counter)
++{
++  ClutterStageViewPrivate *priv =
++    clutter_stage_view_get_instance_private (view);
++
++  if (!priv->present_func)
++    return FALSE;
++
++  return priv->present_func (view, frame, global_frame_counter,
++                             priv->present_user_data);
++}
++
+ static void
+ clutter_stage_view_set_transform (ClutterStageView    *view,
+                                   MtkMonitorTransform  transform)
+diff --git a/config.h.meson b/config.h.meson
+index 5db69a1d22..1cfa288bde 100644
+--- a/config.h.meson
++++ b/config.h.meson
+@@ -57,6 +57,9 @@
+ /* Define if you want to enable the native (KMS) backend based on systemd */
+ #mesondefine HAVE_NATIVE_BACKEND
+ 
++/* Define if the Anland display backend is enabled */
++#mesondefine HAVE_ANLAND
++
+ /* Define if you want to enable Wayland support */
+ #mesondefine HAVE_WAYLAND
+ 
+diff --git a/meson.build b/meson.build
+index 283f3389d2..8b3763366d 100644
+--- a/meson.build
++++ b/meson.build
+@@ -291,6 +291,16 @@ if have_native_backend
+   endif
+ endif
+ 
++have_anland = get_option('anland').enabled()
++if have_anland
++  if not have_native_backend
++    error('The Anland backend requires the native backend')
++  endif
++  if not have_wayland
++    error('The Anland backend requires Wayland support')
++  endif
++endif
++
+ if have_wayland or have_native_backend
+   libdrm_dep = dependency('libdrm', version: libdrm_req)
+   have_drm_plane_size_hint = cc.has_type('struct drm_plane_size_hint',
+@@ -333,7 +343,7 @@ if have_startup_notification
+ endif
+ 
+ have_remote_desktop = get_option('remote_desktop')
+-if have_remote_desktop
++if have_remote_desktop or have_anland
+   libpipewire_dep = dependency('libpipewire-0.3', version: libpipewire_req)
+ endif
+ 
+@@ -574,6 +584,7 @@ cdata.set('HAVE_X11', have_x11)
+ cdata.set('HAVE_X11_CLIENT', have_x11_client)
+ cdata.set('HAVE_LOGIND', have_logind)
+ cdata.set('HAVE_NATIVE_BACKEND', have_native_backend)
++cdata.set('HAVE_ANLAND', have_anland)
+ cdata.set('HAVE_REMOTE_DESKTOP', have_remote_desktop)
+ cdata.set('HAVE_GNOME_DESKTOP', have_gnome_desktop)
+ cdata.set('HAVE_SOUND_PLAYER', have_sound_player)
+diff --git a/meson.options b/meson.options
+index b47b97267b..a91b93c0e0 100644
+--- a/meson.options
++++ b/meson.options
+@@ -63,6 +63,12 @@ option('native_backend',
+   description: 'Enable the native backend'
+ )
+ 
++option('anland',
++  type: 'feature',
++  value: 'disabled',
++  description: 'Enable the Anland display backend'
++)
++
+ option('remote_desktop',
+   type: 'boolean',
+   value: true,
+diff --git a/src/backends/meta-stage-impl.c b/src/backends/meta-stage-impl.c
+index 7936f3af40..1bd96112d0 100644
+--- a/src/backends/meta-stage-impl.c
++++ b/src/backends/meta-stage-impl.c
+@@ -315,6 +315,13 @@ swap_framebuffer (ClutterStageWindow *stage_window,
+     {
+       MetaStageView *view = META_STAGE_VIEW (stage_view);
+ 
++      if (clutter_stage_view_present (stage_view, frame,
++                                      priv->global_frame_counter))
++        {
++          priv->global_frame_counter++;
++          return;
++        }
++
+       meta_topic (META_DEBUG_BACKEND,
+                   "fake offscreen swap (framebuffer: %p)",
+                   framebuffer);
+diff --git a/src/backends/native/meta-renderer-native.c b/src/backends/native/meta-renderer-native.c
+index 54cc994ed1..b857fb43f3 100644
+--- a/src/backends/native/meta-renderer-native.c
++++ b/src/backends/native/meta-renderer-native.c
+@@ -677,11 +677,43 @@ meta_renderer_native_create_dma_buf_framebuffer (MetaRendererNative  *renderer_n
+   CoglTexture *cogl_tex;
+   CoglOffscreen *cogl_fbo;
+   const MetaFormatInfo *format_info;
++  const uint64_t *import_modifiers = modifiers;
+ 
+   format_info = meta_format_info_from_drm_format (drm_format);
+-  g_assert (format_info);
++  if (!format_info)
++    {
++      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
++                   "Unsupported dma-buf format 0x%08x", drm_format);
++      return NULL;
++    }
+   cogl_format = format_info->cogl_format;
+ 
++  if (!meta_egl_has_extensions (egl, egl_display, NULL,
++                                "EGL_EXT_image_dma_buf_import", NULL))
++    {
++      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
++                   "EGL does not support dma-buf image import");
++      return NULL;
++    }
++
++  if (modifiers &&
++      !meta_egl_has_extensions (egl, egl_display, NULL,
++                                "EGL_EXT_image_dma_buf_import_modifiers",
++                                NULL))
++    {
++      for (int i = 0; i < n_planes; i++)
++        {
++          if (modifiers[i] != DRM_FORMAT_MOD_LINEAR)
++            {
++              g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
++                           "EGL cannot import non-linear dma-buf modifiers");
++              return NULL;
++            }
++        }
++
++      import_modifiers = NULL;
++    }
++
+   egl_image = meta_egl_create_dmabuf_image (egl,
+                                             egl_display,
+                                             width,
+@@ -691,7 +723,7 @@ meta_renderer_native_create_dma_buf_framebuffer (MetaRendererNative  *renderer_n
+                                             fds,
+                                             strides,
+                                             offsets,
+-                                            modifiers,
++                                            import_modifiers,
+                                             error);
+   if (egl_image == EGL_NO_IMAGE_KHR)
+     return NULL;
+diff --git a/src/backends/native/meta-seat-impl.c b/src/backends/native/meta-seat-impl.c
+index df5ad833fd..7583bc968e 100644
+--- a/src/backends/native/meta-seat-impl.c
++++ b/src/backends/native/meta-seat-impl.c
+@@ -878,6 +878,66 @@ meta_seat_impl_notify_absolute_motion_in_impl (MetaSeatImpl       *seat_impl,
+   queue_event (seat_impl, event);
+ }
+ 
++void
++meta_seat_impl_notify_absolute_relative_motion_in_impl (MetaSeatImpl       *seat_impl,
++                                                        ClutterInputDevice *input_device,
++                                                        uint64_t            time_us,
++                                                        float               x,
++                                                        float               y,
++                                                        float               dx,
++                                                        float               dy,
++                                                        float               dx_unaccel,
++                                                        float               dy_unaccel,
++                                                        double             *axes)
++{
++  MetaInputDeviceNative *device_native =
++    META_INPUT_DEVICE_NATIVE (input_device);
++  ClutterModifierType modifiers;
++  ClutterEvent *event;
++  float cur_x, cur_y;
++  float dx_constrained, dy_constrained;
++
++  if (clutter_input_device_get_device_type (input_device) == CLUTTER_TABLET_DEVICE)
++    {
++      meta_input_device_native_get_coords_in_impl (device_native, &cur_x, &cur_y);
++      modifiers = device_native->button_state;
++    }
++  else
++    {
++      meta_input_device_native_get_coords_in_impl (
++        META_INPUT_DEVICE_NATIVE (seat_impl->core_pointer), &cur_x, &cur_y);
++      modifiers = seat_impl->button_state;
++    }
++
++  constrain_coordinates (seat_impl, input_device, time_us, x, y, &x, &y);
++  dx_constrained = x - cur_x;
++  dy_constrained = y - cur_y;
++  update_device_coords_in_impl (seat_impl, input_device,
++                                GRAPHENE_POINT_INIT (x, y));
++
++  modifiers |= xkb_state_serialize_mods (seat_impl->xkb, XKB_STATE_MODS_EFFECTIVE);
++
++  g_signal_emit (seat_impl, signals[POINTER_POSITION_CHANGED_IN_IMPL], 0,
++                 &GRAPHENE_POINT_INIT (seat_impl->pointer_x,
++                                       seat_impl->pointer_y));
++
++  event =
++    clutter_event_motion_new (CLUTTER_EVENT_FLAG_RELATIVE_MOTION,
++                              time_us,
++                              input_device,
++                              device_native->last_tool,
++                              modifiers,
++                              GRAPHENE_POINT_INIT (x, y),
++                              GRAPHENE_POINT_INIT (dx, dy),
++                              GRAPHENE_POINT_INIT (dx_unaccel,
++                                                   dy_unaccel),
++                              GRAPHENE_POINT_INIT (dx_constrained,
++                                                   dy_constrained),
++                              axes);
++
++  queue_event (seat_impl, event);
++}
++
+ void
+ meta_seat_impl_notify_button_in_impl (MetaSeatImpl       *seat_impl,
+                                       ClutterInputDevice *input_device,
+diff --git a/src/backends/native/meta-seat-impl.h b/src/backends/native/meta-seat-impl.h
+index 56eb5d228d..971fe4de92 100644
+--- a/src/backends/native/meta-seat-impl.h
++++ b/src/backends/native/meta-seat-impl.h
+@@ -161,6 +161,17 @@ void meta_seat_impl_notify_absolute_motion_in_impl (MetaSeatImpl       *seat_imp
+                                                     float               y,
+                                                     double             *axes);
+ 
++void meta_seat_impl_notify_absolute_relative_motion_in_impl (MetaSeatImpl       *seat_impl,
++                                                             ClutterInputDevice *input_device,
++                                                             uint64_t            time_us,
++                                                             float               x,
++                                                             float               y,
++                                                             float               dx,
++                                                             float               dy,
++                                                             float               dx_unaccel,
++                                                             float               dy_unaccel,
++                                                             double             *axes);
++
+ void meta_seat_impl_notify_button_in_impl (MetaSeatImpl       *seat_impl,
+                                            ClutterInputDevice *input_device,
+                                            uint64_t            time_us,
+diff --git a/src/backends/native/meta-virtual-input-device-native.c b/src/backends/native/meta-virtual-input-device-native.c
+index d309ef81ad..564c24e63d 100644
+--- a/src/backends/native/meta-virtual-input-device-native.c
++++ b/src/backends/native/meta-virtual-input-device-native.c
+@@ -64,6 +64,15 @@ typedef struct
+   double y;
+ } MetaVirtualEventMotion;
+ 
++typedef struct
++{
++  uint64_t time_us;
++  double x;
++  double y;
++  double dx;
++  double dy;
++} MetaVirtualEventAbsoluteRelativeMotion;
++
+ typedef struct
+ {
+   uint64_t time_us;
+@@ -96,6 +105,12 @@ typedef struct
+   double y;
+ } MetaVirtualEventTouch;
+ 
++typedef struct
++{
++  uint64_t time_us;
++  GArray *events;
++} MetaVirtualEventTouchBatch;
++
+ G_DEFINE_TYPE (MetaVirtualInputDeviceNative,
+                meta_virtual_input_device_native,
+                CLUTTER_TYPE_VIRTUAL_INPUT_DEVICE)
+@@ -312,6 +327,57 @@ meta_virtual_input_device_native_notify_absolute_motion (ClutterVirtualInputDevi
+   g_object_unref (task);
+ }
+ 
++static gboolean
++notify_absolute_relative_motion_in_impl (GTask *task)
++{
++  MetaVirtualInputDeviceNative *virtual_native =
++    g_task_get_source_object (task);
++  MetaSeatNative *seat_native =
++    meta_virtual_input_device_native_get_seat_native (virtual_native);
++  MetaVirtualEventAbsoluteRelativeMotion *event = g_task_get_task_data (task);
++
++  if (event->time_us == CLUTTER_CURRENT_TIME)
++    event->time_us = g_get_monotonic_time ();
++
++  meta_seat_impl_notify_absolute_relative_motion_in_impl (
++    seat_native->impl, virtual_native->impl_state->device, event->time_us,
++    (float) event->x, (float) event->y, (float) event->dx, (float) event->dy,
++    (float) event->dx, (float) event->dy, NULL);
++  g_task_return_boolean (task, TRUE);
++  return G_SOURCE_REMOVE;
++}
++
++void
++meta_virtual_input_device_native_notify_absolute_relative_motion (
++  MetaVirtualInputDeviceNative *virtual_native,
++  uint64_t                      time_us,
++  double                        x,
++  double                        y,
++  double                        dx,
++  double                        dy)
++{
++  MetaSeatNative *seat_native;
++  MetaVirtualEventAbsoluteRelativeMotion *event;
++  GTask *task;
++
++  g_return_if_fail (META_IS_VIRTUAL_INPUT_DEVICE_NATIVE (virtual_native));
++  g_return_if_fail (virtual_native->impl_state != NULL);
++
++  seat_native = meta_virtual_input_device_native_get_seat_native (virtual_native);
++  event = g_new0 (MetaVirtualEventAbsoluteRelativeMotion, 1);
++  event->time_us = time_us;
++  event->x = x;
++  event->y = y;
++  event->dx = dx;
++  event->dy = dy;
++
++  task = g_task_new (virtual_native, NULL, NULL, NULL);
++  g_task_set_task_data (task, event, g_free);
++  meta_seat_impl_run_input_task (seat_native->impl, task,
++                                 (GSourceFunc) notify_absolute_relative_motion_in_impl);
++  g_object_unref (task);
++}
++
+ static gboolean
+ notify_button_in_impl (GTask *task)
+ {
+@@ -1000,6 +1066,123 @@ meta_virtual_input_device_native_notify_touch_up (ClutterVirtualInputDevice *vir
+   g_object_unref (task);
+ }
+ 
++static gboolean
++notify_touch_events_in_impl (GTask *task)
++{
++  MetaVirtualInputDeviceNative *virtual_native =
++    g_task_get_source_object (task);
++  MetaSeatNative *seat_native =
++    meta_virtual_input_device_native_get_seat_native (virtual_native);
++  MetaSeatImpl *seat = seat_native->impl;
++  MetaVirtualEventTouchBatch *batch = g_task_get_task_data (task);
++  GArray *events = batch->events;
++  uint64_t time_us = batch->time_us;
++  guint i;
++
++  for (i = 0; i < events->len; i++)
++    {
++      const MetaVirtualTouchEvent *event =
++        &g_array_index (events, MetaVirtualTouchEvent, i);
++      MetaTouchState *touch_state;
++      int device_slot = virtual_native->slot_base + event->slot;
++
++      switch (event->type)
++        {
++        case META_VIRTUAL_TOUCH_EVENT_DOWN:
++          touch_state = meta_seat_impl_acquire_touch_state_in_impl (seat,
++                                                                    device_slot);
++          if (!touch_state)
++            continue;
++
++          touch_state->coords.x = (float) event->x;
++          touch_state->coords.y = (float) event->y;
++          meta_seat_impl_notify_touch_event_in_impl (
++            seat, virtual_native->impl_state->device, CLUTTER_TOUCH_BEGIN,
++            time_us, touch_state->seat_slot, touch_state->coords.x,
++            touch_state->coords.y);
++          break;
++        case META_VIRTUAL_TOUCH_EVENT_MOTION:
++          touch_state = meta_seat_impl_lookup_touch_state_in_impl (seat,
++                                                                   device_slot);
++          if (!touch_state)
++            continue;
++
++          touch_state->coords.x = (float) event->x;
++          touch_state->coords.y = (float) event->y;
++          meta_seat_impl_notify_touch_event_in_impl (
++            seat, virtual_native->impl_state->device, CLUTTER_TOUCH_UPDATE,
++            time_us, touch_state->seat_slot, touch_state->coords.x,
++            touch_state->coords.y);
++          break;
++        case META_VIRTUAL_TOUCH_EVENT_UP:
++        case META_VIRTUAL_TOUCH_EVENT_CANCEL:
++          touch_state = meta_seat_impl_lookup_touch_state_in_impl (seat,
++                                                                   device_slot);
++          if (!touch_state)
++            continue;
++
++          meta_seat_impl_notify_touch_event_in_impl (
++            seat, virtual_native->impl_state->device,
++            event->type == META_VIRTUAL_TOUCH_EVENT_UP ? CLUTTER_TOUCH_END :
++                                                         CLUTTER_TOUCH_CANCEL,
++            time_us, touch_state->seat_slot, touch_state->coords.x,
++            touch_state->coords.y);
++          meta_seat_impl_release_touch_state_in_impl (seat,
++                                                       touch_state->seat_slot);
++          break;
++        }
++    }
++
++  g_task_return_boolean (task, TRUE);
++  return G_SOURCE_REMOVE;
++}
++
++static void
++meta_virtual_event_touch_batch_free (MetaVirtualEventTouchBatch *batch)
++{
++  g_clear_pointer (&batch->events, g_array_unref);
++  g_free (batch);
++}
++
++void
++meta_virtual_input_device_native_notify_touch_events (
++  MetaVirtualInputDeviceNative *virtual_native,
++  uint64_t                      time_us,
++  const MetaVirtualTouchEvent  *events,
++  gsize                         n_events)
++{
++  MetaSeatNative *seat_native;
++  MetaVirtualEventTouchBatch *batch;
++  GArray *copied_events;
++  GTask *task;
++  gsize i;
++
++  g_return_if_fail (META_IS_VIRTUAL_INPUT_DEVICE_NATIVE (virtual_native));
++  g_return_if_fail (virtual_native->impl_state != NULL);
++  g_return_if_fail (n_events > 0);
++  g_return_if_fail (events != NULL);
++
++  copied_events = g_array_sized_new (FALSE, FALSE, sizeof (*events), n_events);
++  for (i = 0; i < n_events; i++)
++    {
++      g_return_if_fail (events[i].slot >= 0 &&
++                        events[i].slot < CLUTTER_VIRTUAL_INPUT_DEVICE_MAX_TOUCH_SLOTS);
++      g_array_append_val (copied_events, events[i]);
++    }
++
++  seat_native = meta_virtual_input_device_native_get_seat_native (virtual_native);
++  batch = g_new0 (MetaVirtualEventTouchBatch, 1);
++  batch->time_us = time_us == CLUTTER_CURRENT_TIME ?
++    g_get_monotonic_time () : time_us;
++  batch->events = copied_events;
++  task = g_task_new (virtual_native, NULL, NULL, NULL);
++  g_task_set_task_data (task, batch,
++                        (GDestroyNotify) meta_virtual_event_touch_batch_free);
++  meta_seat_impl_run_input_task (seat_native->impl, task,
++                                 (GSourceFunc) notify_touch_events_in_impl);
++  g_object_unref (task);
++}
++
+ static void
+ meta_virtual_input_device_native_get_property (GObject    *object,
+                                                guint       prop_id,
+diff --git a/src/backends/native/meta-virtual-input-device-native.h b/src/backends/native/meta-virtual-input-device-native.h
+index a41b5ed294..149c989282 100644
+--- a/src/backends/native/meta-virtual-input-device-native.h
++++ b/src/backends/native/meta-virtual-input-device-native.h
+@@ -19,6 +19,8 @@
+ 
+ #pragma once
+ 
++#include <stdint.h>
++
+ #include "clutter/clutter-virtual-input-device.h"
+ 
+ #define META_TYPE_VIRTUAL_INPUT_DEVICE_NATIVE (meta_virtual_input_device_native_get_type ())
+@@ -26,3 +28,33 @@ G_DECLARE_FINAL_TYPE (MetaVirtualInputDeviceNative,
+                       meta_virtual_input_device_native,
+                       META, VIRTUAL_INPUT_DEVICE_NATIVE,
+                       ClutterVirtualInputDevice)
++
++typedef enum
++{
++  META_VIRTUAL_TOUCH_EVENT_DOWN,
++  META_VIRTUAL_TOUCH_EVENT_MOTION,
++  META_VIRTUAL_TOUCH_EVENT_UP,
++  META_VIRTUAL_TOUCH_EVENT_CANCEL,
++} MetaVirtualTouchEventType;
++
++typedef struct
++{
++  MetaVirtualTouchEventType type;
++  int slot;
++  double x;
++  double y;
++} MetaVirtualTouchEvent;
++
++void meta_virtual_input_device_native_notify_absolute_relative_motion (
++  MetaVirtualInputDeviceNative *virtual_device,
++  uint64_t                      time_us,
++  double                        x,
++  double                        y,
++  double                        dx,
++  double                        dy);
++
++void meta_virtual_input_device_native_notify_touch_events (
++  MetaVirtualInputDeviceNative *virtual_device,
++  uint64_t                      time_us,
++  const MetaVirtualTouchEvent  *events,
++  gsize                         n_events);
+diff --git a/src/core/display.c b/src/core/display.c
+index c2600ec753..36bf1582d9 100644
+--- a/src/core/display.c
++++ b/src/core/display.c
+@@ -35,6 +35,9 @@
+ #include <unistd.h>
+ 
+ #include "backends/meta-backend-private.h"
++#ifdef HAVE_ANLAND
++#include "backends/anland/meta-backend-anland.h"
++#endif
+ #include "backends/meta-cursor-sprite-xcursor.h"
+ #include "backends/meta-cursor-tracker-private.h"
+ #include "backends/meta-input-capture.h"
+@@ -830,15 +833,29 @@ meta_display_init_x11_finish (MetaDisplay   *display,
+                               GError       **error)
+ {
+   MetaX11Display *x11_display;
++  gboolean x11_services_started;
+ 
+   g_assert (g_task_get_source_tag (G_TASK (result)) == meta_display_init_x11);
+ 
+-  if (!g_task_propagate_boolean (G_TASK (result), error))
++  x11_services_started = g_task_propagate_boolean (G_TASK (result), error);
++  if (!x11_services_started)
+     {
+-      if (*error == NULL)
+-        g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Unknown error");
++#ifdef HAVE_ANLAND
++      MetaContext *context = meta_display_get_context (display);
++      MetaBackend *backend = meta_context_get_backend (context);
+ 
+-      return FALSE;
++      if (*error == NULL && META_IS_BACKEND_ANLAND (backend))
++        {
++          g_message ("Continuing without X11 session services on Anland");
++        }
++      else
++#endif
++        {
++          if (*error == NULL)
++            g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Unknown error");
++
++          return FALSE;
++        }
+     }
+ 
+   if (display->x11_display)
+diff --git a/src/core/meta-context-main.c b/src/core/meta-context-main.c
+index 886a1267aa..4fa4cdc95d 100644
+--- a/src/core/meta-context-main.c
++++ b/src/core/meta-context-main.c
+@@ -45,6 +45,10 @@
+ #include "backends/native/meta-backend-native-types.h"
+ #endif
+ 
++#ifdef HAVE_ANLAND
++#include "backends/anland/meta-backend-anland.h"
++#endif
++
+ #if defined (HAVE_X11) && defined (HAVE_WAYLAND)
+ #include "backends/x11/nested/meta-backend-x11-nested.h"
+ #endif
+@@ -76,6 +80,10 @@ typedef struct _MetaContextMainOptions
+   gboolean display_server;
+   gboolean headless;
+   GList *virtual_monitor_infos;
++#endif
++#ifdef HAVE_ANLAND
++  gboolean anland;
++  char *anland_socket;
+ #endif
+   char *trace_file;
+   gboolean debug_control;
+@@ -145,6 +153,41 @@ check_configuration (MetaContextMain  *context_main,
+     }
+ #endif /* HAVE_NATIVE_BACKEND */
+ 
++#ifdef HAVE_ANLAND
++  if (context_main->options.anland_socket &&
++      !context_main->options.anland)
++    {
++      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
++                   "--anland-socket requires --anland");
++      return FALSE;
++    }
++
++  if (context_main->options.anland &&
++      (context_main->options.display_server ||
++       context_main->options.headless))
++    {
++      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
++                   "Can't run Anland with display server or headless mode");
++      return FALSE;
++    }
++#ifdef HAVE_X11
++  if (context_main->options.anland && context_main->options.x11.force)
++    {
++      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
++                   "Can't run Anland with the X11 backend");
++      return FALSE;
++    }
++#endif /* HAVE_X11 */
++#ifdef HAVE_WAYLAND
++  if (context_main->options.anland && context_main->options.nested)
++    {
++      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
++                   "Can't run Anland as a nested compositor");
++      return FALSE;
++    }
++#endif /* HAVE_WAYLAND */
++#endif /* HAVE_ANLAND */
++
+   if (context_main->options.sm.save_file &&
+       context_main->options.sm.client_id)
+     {
+@@ -251,6 +294,9 @@ determine_compositor_type (MetaContextMain  *context_main,
+       context_main->options.display_server ||
+       context_main->options.headless ||
+ #endif /* HAVE_NATIVE_BACKEND */
++#ifdef HAVE_ANLAND
++      context_main->options.anland ||
++#endif /* HAVE_ANLAND */
+       context_main->options.nested)
+     return META_COMPOSITOR_TYPE_WAYLAND;
+ #endif /* HAVE_WAYLAND */
+@@ -281,10 +327,19 @@ meta_context_main_configure (MetaContext   *context,
+   MetaContextMain *context_main = META_CONTEXT_MAIN (context);
+   MetaContextClass *context_class =
+     META_CONTEXT_CLASS (meta_context_main_parent_class);
++#ifdef HAVE_ANLAND
++  const char *anland_socket;
++#endif
+ 
+   if (!context_class->configure (context, argc, argv, error))
+     return FALSE;
+ 
++#ifdef HAVE_ANLAND
++  anland_socket = g_getenv ("ANLAND_SOCKET");
++  if (anland_socket && *anland_socket)
++    context_main->options.anland = TRUE;
++#endif
++
+   if (!check_configuration (context_main, error))
+     return FALSE;
+ 
+@@ -431,6 +486,13 @@ meta_context_main_setup (MetaContext  *context,
+     return FALSE;
+ #endif
+ 
++#ifdef HAVE_ANLAND
++  if (context_main->options.anland &&
++      !meta_backend_anland_setup (
++        META_BACKEND_ANLAND (meta_context_get_backend (context)), error))
++    return FALSE;
++#endif
++
+   return TRUE;
+ }
+ 
+@@ -479,6 +541,31 @@ create_headless_backend (MetaContext  *context,
+                          NULL);
+ }
+ 
++#ifdef HAVE_ANLAND
++static MetaBackend *
++create_anland_backend (MetaContext  *context,
++                       GError      **error)
++{
++  MetaContextMain *context_main = META_CONTEXT_MAIN (context);
++
++  if (context_main->options.anland_socket)
++    {
++      return g_initable_new (META_TYPE_BACKEND_ANLAND,
++                             NULL, error,
++                             "context", context,
++                             "mode", META_BACKEND_NATIVE_MODE_HEADLESS,
++                             "anland-socket", context_main->options.anland_socket,
++                             NULL);
++    }
++
++  return g_initable_new (META_TYPE_BACKEND_ANLAND,
++                         NULL, error,
++                         "context", context,
++                         "mode", META_BACKEND_NATIVE_MODE_HEADLESS,
++                         NULL);
++}
++#endif
++
+ static MetaBackend *
+ create_native_backend (MetaContext  *context,
+                        GError      **error)
+@@ -514,6 +601,10 @@ meta_context_main_create_backend (MetaContext  *context,
+         return create_nested_backend (context, error);
+ #endif
+ #ifdef HAVE_NATIVE_BACKEND
++#ifdef HAVE_ANLAND
++      if (context_main->options.anland)
++        return create_anland_backend (context, error);
++#endif
+       if (context_main->options.headless)
+         return create_headless_backend (context, error);
+ 
+@@ -693,6 +784,19 @@ meta_context_main_add_option_entries (MetaContextMain *context_main)
+       &context_main->options.headless,
+       N_("Run as a headless display server")
+     },
++#ifdef HAVE_ANLAND
++    {
++      "anland", 0, 0, G_OPTION_ARG_NONE,
++      &context_main->options.anland,
++      N_("Run with the Anland display backend")
++    },
++    {
++      "anland-socket", 0, 0, G_OPTION_ARG_FILENAME,
++      &context_main->options.anland_socket,
++      N_("Specify Anland display daemon socket"),
++      "PATH"
++    },
++#endif
+     {
+       "virtual-monitor", 0, 0, G_OPTION_ARG_CALLBACK,
+       add_virtual_monitor_cb,
+@@ -750,6 +854,7 @@ meta_context_main_finalize (GObject *object)
+ #ifdef HAVE_NATIVE_BACKEND
+   MetaContextMain *context_main = META_CONTEXT_MAIN (object);
+ 
++  g_clear_pointer (&context_main->options.anland_socket, g_free);
+   g_list_free_full (context_main->persistent_virtual_monitors, g_object_unref);
+   context_main->persistent_virtual_monitors = NULL;
+ 
+diff --git a/src/meson.build b/src/meson.build
+index b0c103b0c7..28bcd61d2a 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -79,9 +79,14 @@ if have_libwacom
+   ]
+ endif
+ 
+-if have_remote_desktop
++if have_remote_desktop or have_anland
+   mutter_pkg_private_deps += [
+     libpipewire_dep,
++  ]
++endif
++
++if have_remote_desktop
++  mutter_pkg_private_deps += [
+     libeis_dep,
+   ]
+ endif
+@@ -901,6 +906,25 @@ if have_native_backend
+   ]
+ endif
+ 
++if have_anland
++  mutter_sources += [
++    'backends/anland/meta-backend-anland.c',
++    'backends/anland/meta-backend-anland.h',
++    'backends/anland/meta-anland-audio.c',
++    'backends/anland/meta-anland-audio.h',
++    'backends/anland/meta-anland-camera.c',
++    'backends/anland/meta-anland-camera.h',
++    'backends/anland/meta-anland-input.c',
++    'backends/anland/meta-anland-input.h',
++    'backends/anland/meta-anland-clipboard.c',
++    'backends/anland/meta-anland-clipboard.h',
++    'backends/anland/vendor/meta-anland-socket-utils.c',
++    'backends/anland/vendor/meta-anland-socket-utils.h',
++    'backends/anland/vendor/meta-anland-transport.c',
++    'backends/anland/vendor/meta-anland-transport.h',
++  ]
++endif
++
+ if have_wayland or have_native_backend
+   mutter_sources += [
+     'common/meta-cogl-drm-formats.c',
+diff --git a/src/tests/meson.build b/src/tests/meson.build
+index 99a7beaa69..4a5290c380 100644
+--- a/src/tests/meson.build
++++ b/src/tests/meson.build
+@@ -141,6 +141,24 @@ gnome.compile_schemas(
+   depend_files: 'org.gnome.mutter.test.gschema.xml',
+ )
+ 
++anland_transport_test = executable('mutter-anland-transport-tests',
++  sources: [
++    'anland-transport-tests.c',
++    '../backends/anland/vendor/meta-anland-socket-utils.c',
++    '../backends/anland/vendor/meta-anland-transport.c',
++  ],
++  include_directories: [
++    tests_includes,
++    include_directories('../backends/anland/vendor'),
++  ],
++  dependencies: glib_dep,
++  install: false,
++)
++
++test('anland-transport', anland_transport_test,
++  suite: ['core', 'mutter/anland'],
++)
++
+ if have_cogl_tests
+   subdir('cogl')
+ endif
+diff --git a/src/tests/wayland-unit-tests.c b/src/tests/wayland-unit-tests.c
+index 984e79f8df..ae3569dde0 100644
+--- a/src/tests/wayland-unit-tests.c
++++ b/src/tests/wayland-unit-tests.c
+@@ -1499,6 +1499,8 @@ toplevel_fixed_size_fullscreen (void)
+ 
+   while (!(window = find_client_window ("fixed-size-client")))
+     g_main_context_iteration (NULL, TRUE);
++  g_object_add_weak_pointer (G_OBJECT (window), (gpointer *) &window);
++
+   while (meta_window_is_hidden (window))
+     g_main_context_iteration (NULL, TRUE);
+   meta_wait_for_effects (window);
+@@ -1519,6 +1521,9 @@ toplevel_fixed_size_fullscreen (void)
+   meta_wayland_test_client_finish (wayland_test_client);
+ 
+   meta_cursor_tracker_set_pointer_visible (cursor_tracker, TRUE);
++
++  while (window)
++    g_main_context_iteration (NULL, TRUE);
+ }
+ 
+ static void
+@@ -1535,6 +1540,8 @@ toplevel_fixed_size_fullscreen_exceeds (void)
+ 
+   while (!(window = find_client_window ("fixed-size-client")))
+     g_main_context_iteration (NULL, TRUE);
++  g_object_add_weak_pointer (G_OBJECT (window), (gpointer *) &window);
++
+   while (meta_window_is_hidden (window))
+     g_main_context_iteration (NULL, TRUE);
+   meta_wait_for_effects (window);
+@@ -1550,6 +1557,9 @@ toplevel_fixed_size_fullscreen_exceeds (void)
+   meta_wayland_test_driver_terminate (test_driver);
+   meta_wayland_test_client_finish (wayland_test_client);
+   g_test_assert_expected_messages ();
++
++  while (window)
++    g_main_context_iteration (NULL, TRUE);
+ }
+ 
+ static void
+diff --git a/src/wayland/meta-wayland-text-input.c b/src/wayland/meta-wayland-text-input.c
+index b70d8c8c1c..02a52df031 100644
+--- a/src/wayland/meta-wayland-text-input.c
++++ b/src/wayland/meta-wayland-text-input.c
+@@ -23,6 +23,7 @@
+ 
+ #include <wayland-server.h>
+ 
++#include "clutter/clutter/clutter-input-focus.h"
+ #include "compositor/meta-surface-actor-wayland.h"
+ #include "wayland/meta-wayland-private.h"
+ #include "wayland/meta-wayland-seat.h"
+@@ -809,6 +810,22 @@ meta_wayland_text_input_destroy (MetaWaylandTextInput *text_input)
+   g_free (text_input);
+ }
+ 
++gboolean
++meta_wayland_text_input_commit_string (MetaWaylandTextInput *text_input,
++                                       const char           *text)
++{
++  if (!text_input || !text || !*text || !text_input->enabled ||
++      !text_input->surface ||
++      wl_list_empty (&text_input->focus_resource_list) ||
++      !clutter_input_focus_is_focused (text_input->input_focus))
++    return FALSE;
++
++  CLUTTER_INPUT_FOCUS_GET_CLASS (text_input->input_focus)->commit_text (
++    text_input->input_focus, text);
++  meta_wayland_text_input_focus_flush_done (text_input->input_focus);
++  return TRUE;
++}
++
+ static void
+ meta_wayland_text_input_create_new_resource (MetaWaylandTextInput *text_input,
+                                              struct wl_client     *client,
+diff --git a/src/wayland/meta-wayland-text-input.h b/src/wayland/meta-wayland-text-input.h
+index 458614c959..c28d0a0876 100644
+--- a/src/wayland/meta-wayland-text-input.h
++++ b/src/wayland/meta-wayland-text-input.h
+@@ -43,3 +43,6 @@ gboolean meta_wayland_text_input_update (MetaWaylandTextInput *text_input,
+ 
+ gboolean meta_wayland_text_input_handle_event (MetaWaylandTextInput *text_input,
+                                                const ClutterEvent   *event);
++
++gboolean meta_wayland_text_input_commit_string (MetaWaylandTextInput *text_input,
++                                                const char           *text);
+diff --git a/src/wayland/meta-xwayland.c b/src/wayland/meta-xwayland.c
+index e405161c1d..13bb20b9f4 100644
+--- a/src/wayland/meta-xwayland.c
++++ b/src/wayland/meta-xwayland.c
+@@ -47,6 +47,9 @@
+ 
+ #include "backends/meta-monitor-manager-private.h"
+ #include "backends/meta-settings-private.h"
++#ifdef HAVE_ANLAND
++#include "backends/anland/meta-backend-anland.h"
++#endif
+ #include "meta/main.h"
+ #include "meta/meta-backend.h"
+ #include "mtk/mtk-x11.h"
+@@ -510,7 +513,8 @@ meta_xwayland_override_display_number (int number)
+ }
+ 
+ static gboolean
+-ensure_x11_unix_perms (GError **error)
++ensure_x11_unix_perms (GError  **error,
++                       gboolean  allow_untrusted_owner)
+ {
+   /* Try to detect systems on which /tmp/.X11-unix is owned by neither root nor
+    * ourselves because in that case the owner can take over the socket we create
+@@ -542,7 +546,8 @@ ensure_x11_unix_perms (GError **error)
+   /* If the directory already exists, it should belong to the same
+    * user as /tmp or belong to ourselves ...
+    * (if /tmp is not owned by root or ourselves we're in deep trouble) */
+-  if (x11_tmp.st_uid != tmp.st_uid && x11_tmp.st_uid != getuid ())
++  if (!allow_untrusted_owner &&
++      x11_tmp.st_uid != tmp.st_uid && x11_tmp.st_uid != getuid ())
+     {
+       g_set_error (error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED,
+                    "Wrong ownership for directory \"%s\"",
+@@ -572,12 +577,13 @@ ensure_x11_unix_perms (GError **error)
+ }
+ 
+ static gboolean
+-ensure_x11_unix_dir (GError **error)
++ensure_x11_unix_dir (GError  **error,
++                     gboolean  allow_untrusted_owner)
+ {
+   if (mkdir (X11_TMP_UNIX_DIR, 01777) != 0)
+     {
+       if (errno == EEXIST)
+-        return ensure_x11_unix_perms (error);
++        return ensure_x11_unix_perms (error, allow_untrusted_owner);
+ 
+       g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno),
+                    "Failed to create directory \"%s\": %s",
+@@ -618,12 +624,13 @@ static gboolean
+ choose_xdisplay (MetaXWaylandManager     *manager,
+                  MetaXWaylandConnection  *connection,
+                  int                     *display,
++                 gboolean                 allow_untrusted_owner,
+                  GError                 **error)
+ {
+   int number_of_tries = 0;
+   char *lock_file = NULL;
+ 
+-  if (!ensure_x11_unix_dir (error))
++  if (!ensure_x11_unix_dir (error, allow_untrusted_owner))
+     return FALSE;
+ 
+   do
+@@ -757,12 +764,15 @@ on_displayfd_ready (int          fd,
+                     gpointer     user_data)
+ {
+   GTask *task = user_data;
++  char display_name[16];
++  ssize_t bytes_read;
+ 
+   /* The server writes its display name to the displayfd
+-   * socket when it's ready. We don't care about the data
+-   * in the socket, just that it wrote something, since
+-   * that means it's ready. */
+-  g_task_return_boolean (task, !!(condition & G_IO_IN));
++   * socket when it's ready. PRoot may only report G_IO_HUP
++   * after Xwayland writes and closes the socket, so check
++   * the pending data instead of relying on the condition. */
++  bytes_read = recv (fd, display_name, sizeof (display_name), MSG_DONTWAIT);
++  g_task_return_boolean (task, bytes_read > 0);
+   g_object_unref (task);
+ 
+   return G_SOURCE_REMOVE;
+@@ -1084,8 +1094,13 @@ meta_xwayland_init (MetaXWaylandManager    *manager,
+   MetaMonitorManager *monitor_manager =
+     meta_backend_get_monitor_manager (backend);
+   MetaX11DisplayPolicy policy;
++  gboolean allow_untrusted_owner = FALSE;
+   int display = 0;
+ 
++#ifdef HAVE_ANLAND
++  allow_untrusted_owner = META_IS_BACKEND_ANLAND (backend);
++#endif
++
+   if (display_number_override != -1)
+     display = display_number_override;
+   else if (g_getenv ("RUNNING_UNDER_GDM"))
+@@ -1093,11 +1108,13 @@ meta_xwayland_init (MetaXWaylandManager    *manager,
+ 
+   if (!manager->public_connection.name)
+     {
+-      if (!choose_xdisplay (manager, &manager->public_connection, &display, error))
++      if (!choose_xdisplay (manager, &manager->public_connection, &display,
++                            allow_untrusted_owner, error))
+         return FALSE;
+ 
+       display++;
+-      if (!choose_xdisplay (manager, &manager->private_connection, &display, error))
++      if (!choose_xdisplay (manager, &manager->private_connection, &display,
++                            allow_untrusted_owner, error))
+         return FALSE;
+ 
+       if (!prepare_auth_file (manager, error))

--- a/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-anland-audio.c
+++ b/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-anland-audio.c
@@ -1,0 +1,665 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#include "config.h"
+
+#include "backends/anland/meta-anland-audio.h"
+
+#include "backends/anland/vendor/meta-anland-protocol.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <glib.h>
+#include <pipewire/pipewire.h>
+#include <spa/param/audio/format-utils.h>
+#include <spa/pod/builder.h>
+#include <spa/utils/hook.h>
+
+#define DEFAULT_RATE          48000
+#define DEFAULT_PLAY_CHANNELS 2
+#define DEFAULT_CAP_CHANNELS  1
+#define MIC_RING_BYTES        (48000 * 2 * (int) sizeof (int16_t))
+#define MAX_DGRAM             (64 * 1024)
+#define RECONNECT_SECS        1
+#define MIN_AUDIO_RATE     8000
+#define MAX_AUDIO_RATE   384000
+#define MAX_AUDIO_CHANNELS     2
+#define MAX_AUDIO_QUANTUM  65536
+#define KEEPALIVE_FRAMES       480
+#define KEEPALIVE_BYTES        (KEEPALIVE_FRAMES * DEFAULT_PLAY_CHANNELS * (int) sizeof (int16_t))
+
+struct _MetaAnlandAudio
+{
+  struct pw_thread_loop *loop;
+  struct pw_context *context;
+  struct pw_core *core;
+  struct spa_hook core_listener;
+  struct spa_source *reconnect_timer;
+  bool pw_connected;
+
+  struct pw_stream *capture;
+  struct spa_hook capture_listener;
+  struct pw_stream *source;
+  struct spa_hook source_listener;
+
+  uint32_t play_rate;
+  uint32_t play_channels;
+  uint32_t cap_rate;
+  uint32_t cap_channels;
+  uint32_t play_quantum;
+  uint32_t cap_quantum;
+
+  int audio_fd;
+  struct spa_source *io;
+
+  uint8_t *ring;
+  size_t ring_size;
+  size_t ring_head;
+  size_t ring_tail;
+  size_t ring_fill;
+
+  uint8_t silence[KEEPALIVE_BYTES];
+
+  uint8_t rx[MAX_DGRAM];
+  bool loop_started;
+};
+
+static int connect_stream (struct pw_stream  *stream,
+                           enum spa_direction  direction,
+                           uint32_t            rate,
+                           uint32_t            channels,
+                           uint32_t            quantum);
+static const struct spa_pod * build_format (struct spa_pod_builder *builder,
+                                             uint32_t                rate,
+                                             uint32_t                channels);
+static void set_latency (struct pw_stream *stream,
+                         uint32_t          quantum,
+                         uint32_t          rate);
+
+static void
+ring_reset (MetaAnlandAudio *audio)
+{
+  audio->ring_head = audio->ring_tail = audio->ring_fill = 0;
+}
+
+static void
+ring_write (MetaAnlandAudio *audio,
+            const uint8_t   *data,
+            size_t           size)
+{
+  size_t first;
+
+  if (size > audio->ring_size)
+    {
+      data += size - audio->ring_size;
+      size = audio->ring_size;
+    }
+
+  if (audio->ring_fill + size > audio->ring_size)
+    {
+      size_t drop = audio->ring_fill + size - audio->ring_size;
+
+      audio->ring_tail = (audio->ring_tail + drop) % audio->ring_size;
+      audio->ring_fill -= drop;
+    }
+
+  first = MIN (audio->ring_size - audio->ring_head, size);
+  memcpy (audio->ring + audio->ring_head, data, first);
+  memcpy (audio->ring, data + first, size - first);
+  audio->ring_head = (audio->ring_head + size) % audio->ring_size;
+  audio->ring_fill += size;
+}
+
+static size_t
+ring_read (MetaAnlandAudio *audio,
+           uint8_t         *data,
+           size_t           size)
+{
+  size_t available = MIN (size, audio->ring_fill);
+  size_t first = MIN (audio->ring_size - audio->ring_tail, available);
+
+  memcpy (data, audio->ring + audio->ring_tail, first);
+  memcpy (data + first, audio->ring, available - first);
+  audio->ring_tail = (audio->ring_tail + available) % audio->ring_size;
+  audio->ring_fill -= available;
+  return available;
+}
+
+static void
+on_capture_process (void *user_data)
+{
+  MetaAnlandAudio *audio = user_data;
+  struct pw_buffer *buffer;
+  struct spa_data *data;
+
+  buffer = pw_stream_dequeue_buffer (audio->capture);
+  if (!buffer)
+    return;
+
+  data = &buffer->buffer->datas[0];
+  if (audio->audio_fd >= 0)
+    {
+      const uint8_t *payload = audio->silence;
+      size_t payload_size = sizeof (audio->silence);
+
+      if (data->data && data->chunk && data->chunk->size > 0)
+        {
+          payload = (uint8_t *) data->data + data->chunk->offset;
+          payload_size = data->chunk->size;
+        }
+
+      struct audio_msg header = {
+        .type = AUDIO_MSG_PCM,
+        .size = payload_size,
+      };
+      struct iovec iov[2] = {
+        { .iov_base = &header, .iov_len = sizeof (header) },
+        { .iov_base = (void *) payload, .iov_len = payload_size },
+      };
+      struct msghdr message = {
+        .msg_iov = iov,
+        .msg_iovlen = G_N_ELEMENTS (iov),
+      };
+
+      /* The PipeWire loop must not stall on a slow or disconnected consumer. */
+      sendmsg (audio->audio_fd, &message, MSG_DONTWAIT | MSG_NOSIGNAL);
+    }
+
+  pw_stream_queue_buffer (audio->capture, buffer);
+}
+
+static void
+on_source_process (void *user_data)
+{
+  MetaAnlandAudio *audio = user_data;
+  struct pw_buffer *buffer;
+  struct spa_data *data;
+  uint32_t stride;
+  uint32_t frames;
+  uint32_t size;
+  size_t available;
+
+  buffer = pw_stream_dequeue_buffer (audio->source);
+  if (!buffer)
+    return;
+
+  data = &buffer->buffer->datas[0];
+  if (!data->data || !data->chunk)
+    {
+      pw_stream_queue_buffer (audio->source, buffer);
+      return;
+    }
+
+  stride = sizeof (int16_t) * audio->cap_channels;
+  frames = data->maxsize / stride;
+  if (buffer->requested && buffer->requested < frames)
+    frames = buffer->requested;
+  size = frames * stride;
+
+  available = ring_read (audio, data->data, size);
+  if (available < size)
+    memset ((uint8_t *) data->data + available, 0, size - available);
+
+  data->chunk->offset = 0;
+  data->chunk->stride = stride;
+  data->chunk->size = size;
+  pw_stream_queue_buffer (audio->source, buffer);
+}
+
+static const struct pw_stream_events capture_events = {
+  PW_VERSION_STREAM_EVENTS,
+  .process = on_capture_process,
+};
+
+static const struct pw_stream_events source_events = {
+  PW_VERSION_STREAM_EVENTS,
+  .process = on_source_process,
+};
+
+static void
+apply_format (MetaAnlandAudio          *audio,
+              const struct audio_format *format)
+{
+  gboolean playback = format->role == AUDIO_ROLE_PLAYBACK;
+  uint32_t rate = format->rate ? format->rate : DEFAULT_RATE;
+  uint32_t channels = format->channels ? format->channels :
+    (playback ? DEFAULT_PLAY_CHANNELS : DEFAULT_CAP_CHANNELS);
+  uint32_t *current_rate = playback ? &audio->play_rate : &audio->cap_rate;
+  uint32_t *current_channels = playback ? &audio->play_channels :
+    &audio->cap_channels;
+  uint32_t *current_quantum = playback ? &audio->play_quantum :
+    &audio->cap_quantum;
+  struct pw_stream *stream = playback ? audio->capture : audio->source;
+  gboolean format_changed;
+  gboolean quantum_changed;
+
+  format_changed = rate != *current_rate || channels != *current_channels;
+  quantum_changed = format->quantum != *current_quantum;
+  if (!format_changed && !quantum_changed)
+    return;
+
+  *current_rate = rate;
+  *current_channels = channels;
+  *current_quantum = format->quantum;
+
+  if (!audio->pw_connected || !stream)
+    return;
+
+  if (format_changed)
+    {
+      uint8_t buffer[1024];
+      struct spa_pod_builder builder = SPA_POD_BUILDER_INIT (buffer,
+                                                              sizeof (buffer));
+      const struct spa_pod *params[1] = {
+        build_format (&builder, rate, channels),
+      };
+
+      set_latency (stream, format->quantum, rate);
+      pw_stream_update_params (stream, params, G_N_ELEMENTS (params));
+    }
+  else if (format->quantum > 0)
+    {
+      set_latency (stream, format->quantum, rate);
+    }
+}
+
+static bool
+valid_format (const struct audio_format *format)
+{
+  return (format->role == AUDIO_ROLE_PLAYBACK ||
+          format->role == AUDIO_ROLE_CAPTURE) &&
+         format->format == AUDIO_FORMAT_S16LE &&
+         format->rate >= MIN_AUDIO_RATE &&
+         format->rate <= MAX_AUDIO_RATE &&
+         format->channels > 0 &&
+         format->channels <= MAX_AUDIO_CHANNELS &&
+         format->quantum <= MAX_AUDIO_QUANTUM;
+}
+
+static void
+on_audio_readable (void     *user_data,
+                   int       fd,
+                   uint32_t  mask)
+{
+  MetaAnlandAudio *audio = user_data;
+
+  if (mask & (SPA_IO_ERR | SPA_IO_HUP) || !(mask & SPA_IO_IN))
+    return;
+
+  for (;;)
+    {
+      struct audio_msg header;
+      size_t available;
+      ssize_t received = recv (fd, audio->rx, sizeof (audio->rx),
+                               MSG_DONTWAIT | MSG_TRUNC);
+
+      if (received <= 0)
+        break;
+      if ((size_t) received > sizeof (audio->rx) ||
+          (size_t) received < sizeof (header))
+        continue;
+
+      memcpy (&header, audio->rx, sizeof (header));
+      available = (size_t) received - sizeof (header);
+      if (header.type == AUDIO_MSG_FORMAT)
+        {
+          struct audio_format format;
+
+          if (header.size != sizeof (format) || header.size != available)
+            continue;
+
+          memcpy (&format, audio->rx + sizeof (header), sizeof (format));
+          if (valid_format (&format))
+            apply_format (audio, &format);
+          continue;
+        }
+
+      if (header.type != AUDIO_MSG_PCM || header.size != available ||
+          header.size % (sizeof (int16_t) * audio->cap_channels) != 0)
+        continue;
+
+      ring_write (audio, audio->rx + sizeof (header), header.size);
+    }
+}
+
+static void
+arm_reconnect (MetaAnlandAudio *audio)
+{
+  struct timespec interval = { .tv_sec = RECONNECT_SECS, .tv_nsec = 0 };
+
+  pw_loop_update_timer (pw_thread_loop_get_loop (audio->loop),
+                        audio->reconnect_timer, &interval, NULL, false);
+}
+
+static void
+on_core_error (void        *user_data,
+               uint32_t     id,
+               int          seq,
+               int          result,
+               const char  *message)
+{
+  MetaAnlandAudio *audio = user_data;
+
+  (void) seq;
+  (void) message;
+
+  if (id != PW_ID_CORE || result != -EPIPE)
+    return;
+
+  audio->pw_connected = false;
+  arm_reconnect (audio);
+}
+
+static const struct pw_core_events core_events = {
+  PW_VERSION_CORE_EVENTS,
+  .error = on_core_error,
+};
+
+static const struct spa_pod *
+build_format (struct spa_pod_builder *builder,
+              uint32_t                rate,
+              uint32_t                channels)
+{
+  struct spa_audio_info_raw info = {
+    .format = SPA_AUDIO_FORMAT_S16_LE,
+    .rate = rate,
+    .channels = channels,
+  };
+
+  if (channels >= 2)
+    {
+      info.position[0] = SPA_AUDIO_CHANNEL_FL;
+      info.position[1] = SPA_AUDIO_CHANNEL_FR;
+    }
+  else
+    {
+      info.position[0] = SPA_AUDIO_CHANNEL_MONO;
+    }
+
+  return spa_format_audio_raw_build (builder, SPA_PARAM_EnumFormat, &info);
+}
+
+static void
+set_latency (struct pw_stream *stream,
+             uint32_t          quantum,
+             uint32_t          rate)
+{
+  char latency[32];
+  struct spa_dict_item items[] = {
+    SPA_DICT_ITEM_INIT (PW_KEY_NODE_LATENCY, latency),
+  };
+  struct spa_dict properties = SPA_DICT_INIT (items, G_N_ELEMENTS (items));
+
+  if (quantum == 0)
+    return;
+
+  g_snprintf (latency, sizeof (latency), "%u/%u", quantum, rate);
+  pw_stream_update_properties (stream, &properties);
+}
+
+static int
+connect_stream (struct pw_stream  *stream,
+                enum spa_direction  direction,
+                uint32_t            rate,
+                uint32_t            channels,
+                uint32_t            quantum)
+{
+  uint8_t buffer[1024];
+  struct spa_pod_builder builder = SPA_POD_BUILDER_INIT (buffer,
+                                                          sizeof (buffer));
+  const struct spa_pod *params[1] = {
+    build_format (&builder, rate, channels),
+  };
+
+  set_latency (stream, quantum, rate);
+  return pw_stream_connect (stream, direction, PW_ID_ANY,
+                            PW_STREAM_FLAG_AUTOCONNECT |
+                            PW_STREAM_FLAG_MAP_BUFFERS |
+                            PW_STREAM_FLAG_RT_PROCESS,
+                            params, G_N_ELEMENTS (params));
+}
+
+static void
+teardown_pw (MetaAnlandAudio *audio)
+{
+  if (audio->capture)
+    {
+      spa_hook_remove (&audio->capture_listener);
+      pw_stream_destroy (audio->capture);
+      audio->capture = NULL;
+    }
+
+  if (audio->source)
+    {
+      spa_hook_remove (&audio->source_listener);
+      pw_stream_destroy (audio->source);
+      audio->source = NULL;
+    }
+
+  if (audio->core)
+    {
+      spa_hook_remove (&audio->core_listener);
+      pw_core_disconnect (audio->core);
+      audio->core = NULL;
+    }
+}
+
+static int
+build_pw (MetaAnlandAudio *audio)
+{
+  audio->core = pw_context_connect (audio->context, NULL, 0);
+  if (!audio->core)
+    return -1;
+
+  pw_core_add_listener (audio->core, &audio->core_listener, &core_events, audio);
+
+  audio->capture = pw_stream_new (
+    audio->core, "anland-speaker",
+    pw_properties_new (PW_KEY_MEDIA_TYPE, "Audio",
+                       PW_KEY_MEDIA_CLASS, "Audio/Sink",
+                       PW_KEY_NODE_NAME, "anland-speaker",
+                       PW_KEY_NODE_DESCRIPTION, "Anland remote speaker",
+                       PW_KEY_PRIORITY_SESSION, "1010",
+                       PW_KEY_PRIORITY_DRIVER, "1010",
+                       PW_KEY_NODE_ALWAYS_PROCESS, "true",
+                       PW_KEY_NODE_PAUSE_ON_IDLE, "false",
+                       PW_KEY_NODE_SUSPEND_ON_IDLE, "false",
+                       "session.suspend-timeout-seconds", "0",
+                       NULL));
+  if (!audio->capture)
+    return -1;
+
+  pw_stream_add_listener (audio->capture, &audio->capture_listener,
+                          &capture_events, audio);
+
+  audio->source = pw_stream_new (
+    audio->core, "anland-mic",
+    pw_properties_new (PW_KEY_MEDIA_TYPE, "Audio",
+                       PW_KEY_MEDIA_CLASS, "Audio/Source",
+                       PW_KEY_NODE_NAME, "anland-mic",
+                       PW_KEY_NODE_DESCRIPTION, "Anland remote microphone",
+                       PW_KEY_PRIORITY_SESSION, "1010",
+                       PW_KEY_PRIORITY_DRIVER, "1010",
+                       NULL));
+  if (!audio->source)
+    return -1;
+
+  pw_stream_add_listener (audio->source, &audio->source_listener,
+                          &source_events, audio);
+
+  if (connect_stream (audio->capture, PW_DIRECTION_INPUT, audio->play_rate,
+                      audio->play_channels, audio->play_quantum) < 0 ||
+      connect_stream (audio->source, PW_DIRECTION_OUTPUT, audio->cap_rate,
+                      audio->cap_channels, audio->cap_quantum) < 0)
+    return -1;
+
+  return 0;
+}
+
+static void
+on_reconnect_timer (void     *user_data,
+                    uint64_t  expirations)
+{
+  MetaAnlandAudio *audio = user_data;
+
+  (void) expirations;
+
+  if (audio->pw_connected)
+    return;
+
+  teardown_pw (audio);
+  if (build_pw (audio) == 0)
+    {
+      audio->pw_connected = true;
+    }
+  else
+    {
+      teardown_pw (audio);
+      arm_reconnect (audio);
+    }
+}
+
+void
+meta_anland_audio_set_fd (MetaAnlandAudio *audio,
+                          int              fd)
+{
+  struct pw_loop *loop;
+  int owned_fd = -1;
+
+  if (!audio)
+    return;
+
+  if (fd >= 0)
+    {
+      owned_fd = fcntl (fd, F_DUPFD_CLOEXEC, 0);
+      if (owned_fd < 0)
+        g_warning ("Anland failed to duplicate audio fd: %s", strerror (errno));
+    }
+
+  pw_thread_loop_lock (audio->loop);
+
+  loop = pw_thread_loop_get_loop (audio->loop);
+  if (audio->io)
+    {
+      pw_loop_destroy_source (loop, audio->io);
+      audio->io = NULL;
+    }
+
+  if (audio->audio_fd >= 0)
+    close (audio->audio_fd);
+  audio->audio_fd = owned_fd;
+  ring_reset (audio);
+
+  if (owned_fd >= 0)
+    {
+      audio->io = pw_loop_add_io (loop, owned_fd, SPA_IO_IN, false,
+                                  on_audio_readable, audio);
+      if (!audio->io)
+        {
+          close (audio->audio_fd);
+          audio->audio_fd = -1;
+        }
+    }
+
+  pw_thread_loop_unlock (audio->loop);
+}
+
+MetaAnlandAudio *
+meta_anland_audio_new (void)
+{
+  MetaAnlandAudio *audio;
+
+  pw_init (NULL, NULL);
+
+  audio = g_new0 (MetaAnlandAudio, 1);
+  if (!audio)
+    goto fail_init;
+
+  audio->audio_fd = -1;
+  audio->play_rate = DEFAULT_RATE;
+  audio->play_channels = DEFAULT_PLAY_CHANNELS;
+  audio->cap_rate = DEFAULT_RATE;
+  audio->cap_channels = DEFAULT_CAP_CHANNELS;
+  audio->ring_size = MIC_RING_BYTES;
+  audio->ring = g_malloc (audio->ring_size);
+  if (!audio->ring)
+    goto fail;
+
+  audio->loop = pw_thread_loop_new ("anland-audio", NULL);
+  if (!audio->loop)
+    goto fail;
+
+  audio->context = pw_context_new (pw_thread_loop_get_loop (audio->loop),
+                                   NULL, 0);
+  if (!audio->context)
+    goto fail;
+
+  audio->reconnect_timer = pw_loop_add_timer (
+    pw_thread_loop_get_loop (audio->loop), on_reconnect_timer, audio);
+  if (!audio->reconnect_timer)
+    goto fail;
+
+  if (pw_thread_loop_start (audio->loop) < 0)
+    goto fail;
+  audio->loop_started = true;
+
+  pw_thread_loop_lock (audio->loop);
+  if (build_pw (audio) == 0)
+    {
+      audio->pw_connected = true;
+    }
+  else
+    {
+      teardown_pw (audio);
+      arm_reconnect (audio);
+    }
+  pw_thread_loop_unlock (audio->loop);
+
+  return audio;
+
+fail:
+  if (audio->loop_started)
+    pw_thread_loop_stop (audio->loop);
+  if (audio->reconnect_timer)
+    pw_loop_destroy_source (pw_thread_loop_get_loop (audio->loop),
+                            audio->reconnect_timer);
+  if (audio->context)
+    pw_context_destroy (audio->context);
+  if (audio->loop)
+    pw_thread_loop_destroy (audio->loop);
+  g_free (audio->ring);
+  g_free (audio);
+fail_init:
+  return NULL;
+}
+
+void
+meta_anland_audio_free (MetaAnlandAudio *audio)
+{
+  if (!audio)
+    return;
+
+  if (audio->loop_started)
+    pw_thread_loop_stop (audio->loop);
+  teardown_pw (audio);
+  if (audio->io)
+    pw_loop_destroy_source (pw_thread_loop_get_loop (audio->loop), audio->io);
+  if (audio->reconnect_timer)
+    pw_loop_destroy_source (pw_thread_loop_get_loop (audio->loop),
+                            audio->reconnect_timer);
+  if (audio->audio_fd >= 0)
+    close (audio->audio_fd);
+  if (audio->context)
+    pw_context_destroy (audio->context);
+  if (audio->loop)
+    pw_thread_loop_destroy (audio->loop);
+  g_free (audio->ring);
+  g_free (audio);
+}

--- a/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-anland-audio.h
+++ b/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-anland-audio.h
@@ -1,0 +1,11 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#pragma once
+
+typedef struct _MetaAnlandAudio MetaAnlandAudio;
+
+MetaAnlandAudio * meta_anland_audio_new (void);
+void meta_anland_audio_free (MetaAnlandAudio *audio);
+
+void meta_anland_audio_set_fd (MetaAnlandAudio *audio,
+                               int              fd);

--- a/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-anland-camera.c
+++ b/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-anland-camera.c
@@ -1,0 +1,1036 @@
+#include "config.h"
+
+#include "backends/anland/meta-anland-camera.h"
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <sys/mman.h>
+
+#include <pipewire/pipewire.h>
+#include <glib.h>
+#include <spa/param/video/format-utils.h>
+#include <spa/param/buffers.h>
+#include <spa/pod/builder.h>
+#include <spa/utils/hook.h>
+
+/*
+ * Control-channel protocol + stream/shm protocol. MUST stay in sync with the
+ * consumer's camera_service.h.
+ */
+struct camera_ctrl_msg {
+    uint8_t  type;
+    uint8_t  reserved;
+    uint16_t len;
+    uint8_t  payload[];
+} __attribute__((packed));
+
+#define CAMERA_CTRL_GET_INFO     0x01
+#define CAMERA_CTRL_START_RECORD 0x02   /* payload: id(1B) w(2B,LE) h(2B,LE) */
+#define CAMERA_CTRL_STOP_RECORD  0x03   /* payload: id(1B) */
+#define CAMERA_CTRL_INFO_REPLY   0x81
+
+/* stream_fd control protocol (SEQPACKET). Frame pixels travel through shared memory;
+ * this only carries the shm hand-off and the READY/DONE pacing. */
+#define CAMERA_SLOTS 2
+struct cam_stream_msg {
+    uint8_t  type;
+    uint8_t  slot;
+    uint16_t fmt;   /* READY: CAM_FMT_*; else 0 */
+    uint32_t a;     /* SHM_OFFER: slot_bytes; READY: width  */
+    uint32_t b;     /* READY: height                        */
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct camera_ctrl_msg) == 4,
+               "camera control header must match Anland 5.13");
+_Static_assert(sizeof(struct cam_stream_msg) == 12,
+               "camera stream message must match Anland 5.13");
+
+#define CAM_STREAM_GET_SHM   1
+#define CAM_STREAM_SHM_OFFER 2
+#define CAM_STREAM_READY     3
+#define CAM_STREAM_DONE      4
+
+/* Pixel layout in a slot (matches consumer camera_service.h). All are w*h*3/2 bytes,
+ * single block, Y-stride = w, so only the announced SPA format differs. */
+#define CAM_FMT_I420 0
+#define CAM_FMT_NV12 1
+#define CAM_FMT_NV21 2
+
+/* Default resolution we advertise + request before anything is negotiated. The node
+ * format then FOLLOWS whatever the consumer actually delivers (every READY carries the
+ * real w/h): if the device's CameraX picks a different size, the first frame triggers a
+ * re-negotiation so the node always matches the real frames -- no garbage, no truncation. */
+#define CAM_DEF_W   1280
+#define CAM_DEF_H   720
+#define CAM_FPS     30
+
+#define MAX_CAMERAS 8
+#define RECONNECT_SECS 1
+#define MAX_CAMERA_FRAME_BYTES (256U * 1024U * 1024U)
+
+struct cam {
+    struct anland_camera *owner;
+    int                   index;        /* camera id, for ctrl messages */
+
+    /* Persistent virtual webcam node -- created when a camera first appears, kept
+     * alive across consumer disconnects (blank frames keep flowing), destroyed only
+     * when the camera count shrinks or the engine stops. */
+    struct pw_stream     *node;
+    struct spa_hook       listener;
+    bool                  streaming;    /* an app is consuming this node */
+    bool                  recording;    /* we've told the consumer to START on ctrl */
+    bool                  process_seen; /* one-shot debug: on_process was called */
+
+    /* Current negotiated node format. The node always advertises exactly this, and we
+     * re-negotiate it to match the resolution + pixel layout the consumer actually sends. */
+    uint32_t              fmt_w, fmt_h;
+    int                   fmt_code;   /* CAM_FMT_* currently announced */
+
+    /* Hot-swapped per (re)connect. -1 while detached -> the node emits blank frames. */
+    int                   stream_fd;
+    struct spa_source    *io;
+
+    /* Per-camera shared-memory double buffer, offered by the consumer over stream_fd.
+     * On READY we copy the named slot out into our own `frame` (so the consumer can
+     * reuse the slot immediately) and DONE it; on_process emits `frame` at app pace. */
+    int                   shm_fd;       /* owned dup of the consumer's ashmem, -1 none */
+    uint8_t              *shm;          /* mmap (PROT_READ), CAMERA_SLOTS*slot_bytes    */
+    size_t                shm_bytes;
+    size_t                slot_bytes;
+    bool                  shm_requested;
+
+    /* Producer-owned copy of the latest frame (loop thread only). */
+    uint8_t              *frame;
+    size_t                frame_cap;
+    size_t                frame_size;
+    bool                  have_frame;
+};
+
+struct anland_camera {
+    struct pw_thread_loop *loop;
+    struct pw_context     *context;
+    struct pw_core        *core;
+    struct spa_hook        core_listener;
+    struct spa_source     *reconnect_timer;
+    bool                   pw_connected;
+    bool                   loop_started;
+
+    int                    ctrl_fd;     /* owned; shared control socket, -1 when none */
+    struct spa_source     *ctrl_io;
+    uint8_t                ctrl_buffer[sizeof(struct camera_ctrl_msg) +
+                                       1 + MAX_CAMERAS * 4];
+    size_t                 ctrl_buffer_len;
+    bool                   info_pending;
+    int                    num_cameras; /* number of live nodes */
+    struct cam             cams[MAX_CAMERAS];
+};
+
+static int  build_pw(struct anland_camera *c);
+static void teardown_pw(struct anland_camera *c);
+static void create_nodes(struct anland_camera *c);
+static void destroy_nodes(struct anland_camera *c);
+static void attach_fd(struct cam *cam, int fd);
+static void detach_fd(struct cam *cam);
+static void clear_resources_locked(struct anland_camera *c);
+static void renegotiate_format(struct cam *cam, uint32_t w, uint32_t h,
+                               int fmt_code);
+static const struct spa_pod *build_video_format(struct spa_pod_builder *b,
+                                                uint32_t w, uint32_t h, int fmt_code);
+
+static bool camera_frame_size(uint32_t width, uint32_t height, size_t *size)
+{
+    size_t pixels;
+
+    if (width == 0 || height == 0 || width > UINT16_MAX ||
+        height > UINT16_MAX || width > SIZE_MAX / height)
+        return false;
+    pixels = (size_t)width * height;
+    if (pixels > SIZE_MAX - pixels / 2 ||
+        pixels + pixels / 2 > MAX_CAMERA_FRAME_BYTES)
+        return false;
+    *size = pixels + pixels / 2;
+    return true;
+}
+
+static bool valid_camera_format(int format)
+{
+    return format == CAM_FMT_I420 || format == CAM_FMT_NV12 ||
+           format == CAM_FMT_NV21;
+}
+
+/* ---- control channel ---- */
+
+static void send_ctrl(struct anland_camera *c, uint8_t type,
+                      const uint8_t *payload, uint16_t len)
+{
+    if (c->ctrl_fd < 0)
+        return;
+    uint8_t buf[sizeof(struct camera_ctrl_msg) + 8];
+    if (len > sizeof(buf) - sizeof(struct camera_ctrl_msg))
+        return;
+    struct camera_ctrl_msg *h = (struct camera_ctrl_msg *)buf;
+    h->type = type;
+    h->reserved = 0;
+    h->len = GUINT16_TO_LE(len);
+    if (len)
+        memcpy(buf + sizeof(*h), payload, len);
+    send(c->ctrl_fd, buf, sizeof(*h) + len, MSG_NOSIGNAL | MSG_DONTWAIT);
+}
+
+static bool
+handle_camera_info(struct anland_camera *c,
+                   const uint8_t       *payload,
+                   size_t               payload_size)
+{
+    uint8_t n_cameras;
+
+    if (payload_size < 1)
+        return false;
+
+    n_cameras = payload[0];
+    if (n_cameras != c->num_cameras ||
+        payload_size != 1 + (size_t) n_cameras * 4)
+        return false;
+
+    for (int i = 0; i < n_cameras; i++) {
+        struct cam *cam = &c->cams[i];
+        uint16_t wire_width;
+        uint16_t wire_height;
+        uint32_t width;
+        uint32_t height;
+        size_t frame_size;
+
+        memcpy(&wire_width, payload + 1 + (size_t) i * 4,
+               sizeof(wire_width));
+        memcpy(&wire_height, payload + 1 + (size_t) i * 4 + 2,
+               sizeof(wire_height));
+        width = GUINT16_FROM_LE(wire_width);
+        height = GUINT16_FROM_LE(wire_height);
+        if (!camera_frame_size(width, height, &frame_size))
+            return false;
+
+        if (!cam->node) {
+            cam->fmt_w = width;
+            cam->fmt_h = height;
+        } else if (!cam->have_frame &&
+                   (cam->fmt_w != width || cam->fmt_h != height)) {
+            renegotiate_format(cam, width, height, cam->fmt_code);
+        }
+    }
+
+    return true;
+}
+
+static bool
+consume_control_messages(struct anland_camera *c)
+{
+    while (c->ctrl_buffer_len >= sizeof(struct camera_ctrl_msg)) {
+        struct camera_ctrl_msg header;
+        size_t message_size;
+
+        memcpy(&header, c->ctrl_buffer, sizeof(header));
+        header.len = GUINT16_FROM_LE(header.len);
+        if (header.len > sizeof(c->ctrl_buffer) - sizeof(header))
+            return false;
+
+        message_size = sizeof(header) + header.len;
+        if (c->ctrl_buffer_len < message_size)
+            return true;
+
+        if (!c->info_pending ||
+            header.type != CAMERA_CTRL_INFO_REPLY || header.reserved != 0 ||
+            !handle_camera_info(c, c->ctrl_buffer + sizeof(header), header.len))
+            return false;
+
+        c->info_pending = false;
+        c->ctrl_buffer_len -= message_size;
+        memmove(c->ctrl_buffer, c->ctrl_buffer + message_size,
+                c->ctrl_buffer_len);
+    }
+
+    return true;
+}
+
+static void
+on_control_readable(void *data,
+                    int   fd,
+                    uint32_t mask)
+{
+    struct anland_camera *c = data;
+
+    if (mask & (SPA_IO_ERR | SPA_IO_HUP)) {
+        clear_resources_locked(c);
+        return;
+    }
+
+    while (mask & SPA_IO_IN) {
+        ssize_t n;
+
+        if (c->ctrl_buffer_len == sizeof(c->ctrl_buffer) || fd != c->ctrl_fd) {
+            clear_resources_locked(c);
+            return;
+        }
+
+        n = recv(fd, c->ctrl_buffer + c->ctrl_buffer_len,
+                 sizeof(c->ctrl_buffer) - c->ctrl_buffer_len, MSG_DONTWAIT);
+        if (n > 0) {
+            c->ctrl_buffer_len += (size_t) n;
+            if (!consume_control_messages(c)) {
+                g_warning("Anland camera control channel sent an invalid reply");
+                clear_resources_locked(c);
+                return;
+            }
+            continue;
+        }
+        if (n == 0) {
+            clear_resources_locked(c);
+            return;
+        }
+        if (errno == EINTR)
+            continue;
+        if (errno == EAGAIN)
+            return;
+#if EWOULDBLOCK != EAGAIN
+        if (errno == EWOULDBLOCK)
+            return;
+#endif
+        clear_resources_locked(c);
+        return;
+    }
+}
+
+static void
+request_camera_info(struct anland_camera *c)
+{
+    struct camera_ctrl_msg request = {
+        .type = CAMERA_CTRL_GET_INFO,
+        .reserved = 0,
+        .len = 0,
+    };
+
+    if (c->ctrl_fd < 0)
+        return;
+
+    if (send(c->ctrl_fd, &request, sizeof(request),
+             MSG_NOSIGNAL | MSG_DONTWAIT) == (ssize_t) sizeof(request))
+        c->info_pending = true;
+}
+
+/* Send a fixed stream-control message (GET_SHM / DONE) on a camera's stream socket. */
+static void send_stream(struct cam *cam, uint8_t type, uint8_t slot)
+{
+    if (cam->stream_fd < 0)
+        return;
+    struct cam_stream_msg m = { .type = type, .slot = slot };
+    send(cam->stream_fd, &m, sizeof(m), MSG_NOSIGNAL | MSG_DONTWAIT);
+}
+
+/* Ask the consumer to hand over the shm fd (once per (re)attach, while streaming). */
+static void request_shm(struct cam *cam)
+{
+    if (!cam->streaming || cam->stream_fd < 0 || cam->shm || cam->shm_requested)
+        return;
+    cam->shm_requested = true;
+    send_stream(cam, CAM_STREAM_GET_SHM, 0);
+}
+
+/* Reconcile the "should the consumer be recording?" state with what we've told it.
+ * Recording is wanted when an app is consuming the node AND we have a live control
+ * socket + stream fd. Requests the consumer at the node's current format. */
+static void update_recording(struct cam *cam)
+{
+    const bool want = cam->streaming && cam->stream_fd >= 0 && cam->owner->ctrl_fd >= 0;
+    if (want == cam->recording)
+        return;
+    if (want) {
+        uint8_t p[5];
+        uint16_t w = GUINT16_TO_LE((uint16_t)cam->fmt_w);
+        uint16_t h = GUINT16_TO_LE((uint16_t)cam->fmt_h);
+        p[0] = (uint8_t)cam->index;
+        memcpy(p + 1, &w, sizeof(w));
+        memcpy(p + 3, &h, sizeof(h));
+        send_ctrl(cam->owner, CAMERA_CTRL_START_RECORD, p, sizeof(p));
+        g_debug("anland-camera: start camera %d at %ux%u\n",
+                   cam->index, cam->fmt_w, cam->fmt_h);
+        request_shm(cam);   /* pull the shm fd so frames can flow */
+    } else if (cam->owner->ctrl_fd >= 0) {
+        uint8_t id = (uint8_t)cam->index;
+        send_ctrl(cam->owner, CAMERA_CTRL_STOP_RECORD, &id, 1);
+        g_debug("anland-camera: stop camera %d\n", cam->index);
+    }
+    cam->recording = want;
+}
+
+/* ---- frame emission ---- */
+
+/* The graph calls this whenever the consuming app needs a frame. Emit the latest
+ * received frame, or neutral gray while detached / before the first frame arrives, so
+ * a consuming app always gets a feed. Runs on the loop thread, same as the stream-
+ * socket reader, so cam->frame needs no lock. */
+static void on_process(void *data)
+{
+    struct cam *cam = data;
+    if (!cam->node)
+        return;
+
+    struct pw_buffer *pwb = pw_stream_dequeue_buffer(cam->node);
+    if (!cam->process_seen) {
+        cam->process_seen = true;
+    }
+    if (!pwb)
+        return;
+    struct spa_data *d = &pwb->buffer->datas[0];
+    if (d->data && d->chunk) {
+        const bool live = cam->have_frame && cam->stream_fd >= 0;
+        size_t fmt_bytes = 0;
+        size_t avail;
+        uint32_t copy;
+
+        if (!camera_frame_size(cam->fmt_w, cam->fmt_h, &fmt_bytes)) {
+            pw_stream_queue_buffer(cam->node, pwb);
+            return;
+        }
+        avail = live ? cam->frame_size : fmt_bytes;
+        copy = avail < d->maxsize ? (uint32_t)avail : d->maxsize;
+        if (live)
+            memcpy(d->data, cam->frame, copy);
+        else
+            memset(d->data, 128, copy);   /* neutral gray: valid I420 at any size */
+        d->chunk->offset = 0;
+        d->chunk->stride = cam->fmt_w;   /* I420 Y-plane stride */
+        d->chunk->size = copy;
+    }
+    pw_stream_queue_buffer(cam->node, pwb);
+}
+
+/* Re-announce the node's format to match what the consumer is actually sending (size
+ * AND pixel layout), so the advertised caps always equal the real frames. The app
+ * renegotiates and on_param_changed resizes the buffer pool. fmt_* are updated
+ * optimistically so this doesn't re-fire on every subsequent frame. */
+static void renegotiate_format(struct cam *cam, uint32_t w, uint32_t h, int fmt_code)
+{
+    size_t frame_size;
+
+    if (!cam->node || !valid_camera_format(fmt_code) ||
+        !camera_frame_size(w, h, &frame_size))
+        return;
+    g_debug("anland-camera: camera %d format %ux%u/%d -> %ux%u/%d\n",
+               cam->index, cam->fmt_w, cam->fmt_h, cam->fmt_code,
+               w, h, fmt_code);
+    cam->fmt_w = w;
+    cam->fmt_h = h;
+    cam->fmt_code = fmt_code;
+    uint8_t buffer[1024];
+    struct spa_pod_builder b = SPA_POD_BUILDER_INIT(buffer, sizeof(buffer));
+    const struct spa_pod *params[1] = { build_video_format(&b, w, h, fmt_code) };
+    pw_stream_update_params(cam->node, params, 1);
+}
+
+/* ---- stream socket: shm hand-off + READY/DONE pacing ---- */
+
+static void unmap_shm(struct cam *cam)
+{
+    if (cam->shm) {
+        munmap(cam->shm, cam->shm_bytes);
+        cam->shm = NULL;
+    }
+    if (cam->shm_fd >= 0) {
+        close(cam->shm_fd);
+        cam->shm_fd = -1;
+    }
+    cam->shm_bytes = cam->slot_bytes = 0;
+    cam->shm_requested = false;
+}
+
+static void handle_stream_msg(struct cam *cam, const struct cam_stream_msg *m, int rfd)
+{
+    switch (m->type) {
+    case CAM_STREAM_SHM_OFFER: {
+        size_t slot_bytes = m->a;
+        size_t total;
+
+        if (rfd < 0 || slot_bytes == 0 ||
+            slot_bytes > MAX_CAMERA_FRAME_BYTES ||
+            slot_bytes > SIZE_MAX / CAMERA_SLOTS) {
+            if (rfd >= 0)
+                close(rfd);
+            return;
+        }
+        total = (size_t)CAMERA_SLOTS * slot_bytes;
+        if (cam->shm)
+            munmap(cam->shm, cam->shm_bytes);
+        if (cam->shm_fd >= 0)
+            close(cam->shm_fd);
+        cam->shm_fd = rfd;
+        cam->slot_bytes = slot_bytes;
+        cam->shm_bytes = total;
+        cam->shm = mmap(NULL, total, PROT_READ, MAP_SHARED, rfd, 0);
+        if (cam->shm == MAP_FAILED) {
+            cam->shm = NULL;
+            close(rfd);
+            cam->shm_fd = -1;
+            cam->shm_bytes = cam->slot_bytes = 0;
+            return;
+        }
+        g_debug("anland-camera: camera %d mapped %zu bytes per slot\n",
+                   cam->index, slot_bytes);
+        break;
+    }
+    case CAM_STREAM_READY: {
+        if (rfd >= 0)
+            close(rfd);   /* READY carries no fd */
+        uint8_t slot = m->slot;
+        uint32_t w = m->a, h = m->b;
+        int fmt = m->fmt;
+        size_t bytes;
+        bool valid = valid_camera_format(fmt) &&
+                     camera_frame_size(w, h, &bytes);
+        if (cam->shm && slot < CAMERA_SLOTS && valid &&
+            bytes <= cam->slot_bytes) {
+            if (cam->frame_cap < bytes) {
+                uint8_t *nb = realloc(cam->frame, bytes);
+                if (nb) {
+                    cam->frame = nb;
+                    cam->frame_cap = bytes;
+                }
+            }
+            if (cam->frame_cap >= bytes && bytes > 0) {
+                /* Copy out of the slot promptly so the consumer can reuse it. */
+                memcpy(cam->frame, cam->shm + (size_t)slot * cam->slot_bytes, bytes);
+                cam->frame_size = bytes;
+                cam->have_frame = true;
+            }
+        }
+        /* Release the slot (even if we couldn't read, so the consumer never wedges). */
+        send_stream(cam, CAM_STREAM_DONE, slot);
+        if (valid && (w != cam->fmt_w || h != cam->fmt_h ||
+                      fmt != cam->fmt_code))
+            renegotiate_format(cam, w, h, fmt);
+        break;
+    }
+    default:
+        if (rfd >= 0)
+            close(rfd);
+        break;
+    }
+}
+
+static void on_stream_readable(void *data, int fd, uint32_t mask)
+{
+    struct cam *cam = data;
+    if (mask & (SPA_IO_ERR | SPA_IO_HUP))
+        return;
+    if (!(mask & SPA_IO_IN))
+        return;
+
+    for (;;) {
+        struct cam_stream_msg m;
+        int rfd = -1;
+        struct iovec iov = { .iov_base = &m, .iov_len = sizeof(m) };
+        union {
+            char buf[CMSG_SPACE(sizeof(int))];
+            struct cmsghdr align;
+        } cmsg;
+        struct msghdr msg = { .msg_iov = &iov, .msg_iovlen = 1,
+                              .msg_control = cmsg.buf, .msg_controllen = sizeof(cmsg.buf) };
+        ssize_t n = recvmsg(fd, &msg, MSG_DONTWAIT);
+        if (n <= 0)
+            break;
+        if (msg.msg_flags & MSG_CTRUNC)
+            continue;
+        for (struct cmsghdr *c = CMSG_FIRSTHDR(&msg); c;
+             c = CMSG_NXTHDR(&msg, c)) {
+            if (c->cmsg_level != SOL_SOCKET || c->cmsg_type != SCM_RIGHTS ||
+                c->cmsg_len < CMSG_LEN(sizeof(int)))
+                continue;
+            memcpy(&rfd, CMSG_DATA(c), sizeof(rfd));
+            break;
+        }
+        if (n == (ssize_t)sizeof(m))
+            handle_stream_msg(cam, &m, rfd);
+        else if (rfd >= 0)
+            close(rfd);
+    }
+}
+
+/* Point a camera at a fresh stream socket (or -1 to detach). Drops the old shm mapping
+ * (the new connection re-offers it) so a stale region never bleeds into the new one. */
+static void attach_fd(struct cam *cam, int fd)
+{
+    struct pw_loop *loop = pw_thread_loop_get_loop(cam->owner->loop);
+    if (cam->io) {
+        pw_loop_destroy_source(loop, cam->io);
+        cam->io = NULL;
+    }
+    if (cam->stream_fd >= 0)
+        close(cam->stream_fd);
+    cam->stream_fd = fd;
+    unmap_shm(cam);                   /* re-requested on the new connection */
+    cam->have_frame = false;          /* show blank until a fresh frame arrives */
+    if (fd >= 0)
+        cam->io = pw_loop_add_io(loop, fd, SPA_IO_IN, false, on_stream_readable, cam);
+    if (fd >= 0 && !cam->io) {
+        close(cam->stream_fd);
+        cam->stream_fd = -1;
+    }
+    update_recording(cam);            /* START + GET_SHM if an app is consuming */
+    request_shm(cam);                 /* also (re)request if already streaming */
+}
+
+static void detach_fd(struct cam *cam)
+{
+    attach_fd(cam, -1);
+}
+
+/* ---- Video/Source node ---- */
+
+static uint32_t spa_video_fmt(int code)
+{
+    switch (code) {
+    case CAM_FMT_NV12: return SPA_VIDEO_FORMAT_NV12;
+    case CAM_FMT_NV21: return SPA_VIDEO_FORMAT_NV21;
+    default:           return SPA_VIDEO_FORMAT_I420;
+    }
+}
+
+static const struct spa_pod *build_video_format(struct spa_pod_builder *b,
+                                                uint32_t w, uint32_t h, int fmt_code)
+{
+    struct spa_video_info_raw info;
+    spa_zero(info);
+    info.format = spa_video_fmt(fmt_code);
+    info.size = SPA_RECTANGLE(w, h);
+    info.framerate = SPA_FRACTION(CAM_FPS, 1);
+    return spa_format_video_raw_build(b, SPA_PARAM_EnumFormat, &info);
+}
+
+static void on_stream_state_changed(void *data, enum pw_stream_state old,
+                                    enum pw_stream_state state, const char *error)
+{
+    struct cam *cam = data;
+    (void)error;
+    (void)old;
+    const bool streaming = (state == PW_STREAM_STATE_STREAMING);
+    if (streaming == cam->streaming)
+        return;
+    cam->streaming = streaming;
+    update_recording(cam);
+}
+
+/* The format was negotiated: parse it and declare a buffer pool of the matching size.
+ * Without this PipeWire never allocates correctly-sized buffers and
+ * pw_stream_dequeue_buffer() returns NULL forever, so on_process can never emit. */
+static void on_param_changed(void *data, uint32_t id, const struct spa_pod *param)
+{
+    struct cam *cam = data;
+    if (!param || id != SPA_PARAM_Format)
+        return;
+
+    uint32_t mtype, msubtype;
+    if (spa_format_parse(param, &mtype, &msubtype) < 0 ||
+        mtype != SPA_MEDIA_TYPE_video || msubtype != SPA_MEDIA_SUBTYPE_raw)
+        return;
+
+    struct spa_video_info_raw raw;
+    spa_zero(raw);
+    if (spa_format_video_raw_parse(param, &raw) < 0)
+        return;
+    if (raw.size.width)
+        cam->fmt_w = raw.size.width;
+    if (raw.size.height)
+        cam->fmt_h = raw.size.height;
+
+    size_t frame_size;
+    if (!camera_frame_size(cam->fmt_w, cam->fmt_h, &frame_size) ||
+        frame_size > INT32_MAX)
+        return;
+
+    uint8_t buffer[512];
+    struct spa_pod_builder b = SPA_POD_BUILDER_INIT(buffer, sizeof(buffer));
+    const struct spa_pod *params[1];
+    params[0] = spa_pod_builder_add_object(&b,
+        SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,
+        SPA_PARAM_BUFFERS_buffers,  SPA_POD_CHOICE_RANGE_Int(4, 2, 8),
+        SPA_PARAM_BUFFERS_blocks,   SPA_POD_Int(1),
+        SPA_PARAM_BUFFERS_size,     SPA_POD_Int((int)frame_size),
+        SPA_PARAM_BUFFERS_stride,   SPA_POD_Int((int)cam->fmt_w),
+        SPA_PARAM_BUFFERS_dataType, SPA_POD_CHOICE_FLAGS_Int(
+            (1 << SPA_DATA_MemPtr) | (1 << SPA_DATA_MemFd)));
+    pw_stream_update_params(cam->node, params, 1);
+}
+
+static const struct pw_stream_events stream_events = {
+    PW_VERSION_STREAM_EVENTS,
+    .state_changed = on_stream_state_changed,
+    .param_changed = on_param_changed,
+    .process = on_process,
+};
+
+static int connect_node(struct cam *cam)
+{
+    char name[32], desc[48];
+    snprintf(name, sizeof(name), "anland-camera-%d", cam->index);
+    snprintf(desc, sizeof(desc), "Anland remote camera %d", cam->index);
+
+    cam->node = pw_stream_new(cam->owner->core, name,
+        pw_properties_new(
+            PW_KEY_MEDIA_TYPE, "Video",
+            PW_KEY_MEDIA_CATEGORY, "Capture",
+            PW_KEY_MEDIA_CLASS, "Video/Source",
+            PW_KEY_MEDIA_ROLE, "Camera",
+            PW_KEY_NODE_NAME, name,
+            PW_KEY_NODE_DESCRIPTION, desc,
+            NULL));
+    if (!cam->node)
+        return -1;
+    pw_stream_add_listener(cam->node, &cam->listener, &stream_events, cam);
+
+    uint8_t buffer[1024];
+    struct spa_pod_builder b = SPA_POD_BUILDER_INIT(buffer, sizeof(buffer));
+    const struct spa_pod *params[1] = {
+        build_video_format(&b, cam->fmt_w, cam->fmt_h, cam->fmt_code) };
+
+    /* No DRIVER flag: the consuming app (graph) drives, so PipeWire calls on_process
+     * on demand. No RT_PROCESS either, so on_process runs on the same loop thread as
+     * the stream-socket reader and shares cam->frame without a lock. */
+    int ret = pw_stream_connect(cam->node, PW_DIRECTION_OUTPUT, PW_ID_ANY,
+                                PW_STREAM_FLAG_MAP_BUFFERS, params, 1);
+    if (ret < 0) {
+        spa_hook_remove(&cam->listener);
+        pw_stream_destroy(cam->node);
+        cam->node = NULL;
+    }
+    return ret;
+}
+
+/* Create the node for one camera slot (no fd attached yet). PipeWire drives its
+ * .process whenever an app consumes it. */
+static int create_node(struct cam *cam)
+{
+    if (cam->node)
+        return 0;
+    cam->streaming = false;
+    cam->recording = false;
+    cam->process_seen = false;
+    if (cam->fmt_w == 0 || cam->fmt_h == 0) {
+        cam->fmt_w = CAM_DEF_W;
+        cam->fmt_h = CAM_DEF_H;
+    }
+    /* The consumer always delivers NV21, so advertise it from the start -- no live
+     * format switch (which crashes downstream gst). Only resolution ever renegotiates. */
+    cam->fmt_code = CAM_FMT_NV21;
+    return connect_node(cam);
+}
+
+/* (Re)create nodes for the current camera count, e.g. after a PipeWire reconnect.
+ * The stream fds in cam->stream_fd are preserved, so readers are re-armed. */
+static void create_nodes(struct anland_camera *c)
+{
+    if (!c->pw_connected || !c->core)
+        return;
+    struct pw_loop *loop = pw_thread_loop_get_loop(c->loop);
+    for (int i = 0; i < c->num_cameras; i++) {
+        struct cam *cam = &c->cams[i];
+        if (cam->node)
+            continue;
+        create_node(cam);
+        if (cam->stream_fd >= 0 && !cam->io)
+            cam->io = pw_loop_add_io(loop, cam->stream_fd, SPA_IO_IN, false,
+                                     on_stream_readable, cam);
+    }
+}
+
+/* Destroy one camera's node and reader. Keeps stream_fd (caller decides). */
+static void destroy_node(struct cam *cam)
+{
+    struct pw_loop *loop = cam->owner && cam->owner->loop
+                               ? pw_thread_loop_get_loop(cam->owner->loop) : NULL;
+    if (cam->node) {
+        spa_hook_remove(&cam->listener);
+        pw_stream_destroy(cam->node);
+        cam->node = NULL;
+    }
+    if (cam->io && loop) {
+        pw_loop_destroy_source(loop, cam->io);
+        cam->io = NULL;
+    }
+    cam->streaming = false;
+    cam->recording = false;
+}
+
+static void destroy_nodes(struct anland_camera *c)
+{
+    for (int i = 0; i < MAX_CAMERAS; i++)
+        destroy_node(&c->cams[i]);
+}
+
+/* ---- PipeWire connection lifecycle (mirrors the audio engine) ---- */
+
+static void arm_reconnect(struct anland_camera *c)
+{
+    struct timespec val = { .tv_sec = RECONNECT_SECS, .tv_nsec = 0 };
+    pw_loop_update_timer(pw_thread_loop_get_loop(c->loop), c->reconnect_timer,
+                         &val, NULL, false);
+}
+
+static void on_core_error(void *data, uint32_t id, int seq, int res, const char *message)
+{
+    struct anland_camera *c = data;
+    (void)seq;
+    (void)message;
+    if (id == PW_ID_CORE && res == -EPIPE) {
+        c->pw_connected = false;
+        arm_reconnect(c);
+    }
+}
+
+static const struct pw_core_events core_events = {
+    PW_VERSION_CORE_EVENTS,
+    .error = on_core_error,
+};
+
+static int build_pw(struct anland_camera *c)
+{
+    c->core = pw_context_connect(c->context, NULL, 0);
+    if (!c->core)
+        return -1;
+    pw_core_add_listener(c->core, &c->core_listener, &core_events, c);
+    return 0;
+}
+
+static void teardown_pw(struct anland_camera *c)
+{
+    destroy_nodes(c);
+    if (c->core) {
+        spa_hook_remove(&c->core_listener);
+        pw_core_disconnect(c->core);
+        c->core = NULL;
+    }
+}
+
+static void on_reconnect_timer(void *data, uint64_t expirations)
+{
+    struct anland_camera *c = data;
+    (void)expirations;
+    if (c->pw_connected)
+        return;
+
+    teardown_pw(c);
+    if (build_pw(c) == 0) {
+        c->pw_connected = true;
+        create_nodes(c);   /* rebuild nodes from the still-valid stream fds */
+    } else {
+        teardown_pw(c);
+        arm_reconnect(c);
+    }
+}
+
+/* ---- public API ---- */
+
+static void close_resource_set(int ctrl_fd, const int *stream_fds, int num_cameras)
+{
+    if (ctrl_fd >= 0)
+        close(ctrl_fd);
+    if (!stream_fds)
+        return;
+    for (int i = 0; i < num_cameras; i++)
+        if (stream_fds[i] >= 0)
+            close(stream_fds[i]);
+}
+
+void meta_anland_camera_set_resources(struct anland_camera *c, int ctrl_fd,
+                                 const int *stream_fds, int num_cameras)
+{
+    if (!c || !stream_fds || num_cameras < 0) {
+        close_resource_set(ctrl_fd, stream_fds,
+                           num_cameras > 0 ? num_cameras : 0);
+        return;
+    }
+
+    int accepted = num_cameras < MAX_CAMERAS ? num_cameras : MAX_CAMERAS;
+    for (int i = accepted; i < num_cameras; i++) {
+        if (stream_fds[i] >= 0)
+            close(stream_fds[i]);
+    }
+
+    pw_thread_loop_lock(c->loop);
+
+    /* Swap in the new control socket. */
+    if (c->ctrl_io) {
+        pw_loop_destroy_source(pw_thread_loop_get_loop(c->loop), c->ctrl_io);
+        c->ctrl_io = NULL;
+    }
+    if (c->ctrl_fd >= 0)
+        close(c->ctrl_fd);
+    c->ctrl_fd = ctrl_fd;
+    c->ctrl_buffer_len = 0;
+    c->info_pending = false;
+    if (c->ctrl_fd >= 0) {
+        c->ctrl_io = pw_loop_add_io(pw_thread_loop_get_loop(c->loop), c->ctrl_fd,
+                                    SPA_IO_IN, false, on_control_readable, c);
+        if (!c->ctrl_io) {
+            g_warning("Failed to monitor the Anland camera control channel");
+            clear_resources_locked(c);
+            pw_thread_loop_unlock(c->loop);
+            return;
+        }
+    }
+
+    /* Pop excess cameras if the new connection exposes fewer than before. */
+    for (int i = accepted; i < c->num_cameras; i++) {
+        destroy_node(&c->cams[i]);
+        detach_fd(&c->cams[i]);   /* closes the now-stale stream fd */
+    }
+
+    /* Create any newly-appeared cameras, then (re)attach every live one's stream fd.
+     * Existing nodes are kept (apply-in-place, like the audio engine hot-swaps its
+     * socket) so consuming apps never see the webcam disappear across a reconnect. */
+    c->num_cameras = accepted;
+    for (int i = 0; i < accepted; i++) {
+        struct cam *cam = &c->cams[i];
+        cam->owner = c;
+        cam->index = i;
+        if (c->pw_connected && c->core)
+            create_node(cam);
+        attach_fd(cam, stream_fds[i]);
+    }
+
+    /* The reply is parsed by the PipeWire loop, so a missing consumer response cannot
+     * stall Mutter's main context. It also confirms that the resource fd count and
+     * advertised physical cameras agree. */
+    request_camera_info(c);
+
+    pw_thread_loop_unlock(c->loop);
+}
+
+static void clear_resources_locked(struct anland_camera *c)
+{
+    /* Consumer is gone: drop the control socket and detach every camera's stream fd.
+     * The nodes stay alive and keep emitting blank frames, so PipeWire and any
+     * capturing app never see the cameras disappear -- the audio engine's detach
+     * behaviour. */
+    for (int i = 0; i < c->num_cameras; i++) {
+        struct cam *cam = &c->cams[i];
+        if (cam->recording && c->ctrl_fd >= 0) {
+            uint8_t id = (uint8_t)cam->index;
+            send_ctrl(c, CAMERA_CTRL_STOP_RECORD, &id, 1);
+        }
+        cam->recording = false;
+    }
+    if (c->ctrl_io) {
+        pw_loop_destroy_source(pw_thread_loop_get_loop(c->loop), c->ctrl_io);
+        c->ctrl_io = NULL;
+    }
+    if (c->ctrl_fd >= 0) {
+        close(c->ctrl_fd);
+        c->ctrl_fd = -1;
+    }
+    c->ctrl_buffer_len = 0;
+    c->info_pending = false;
+    for (int i = 0; i < c->num_cameras; i++)
+        detach_fd(&c->cams[i]);
+}
+
+void meta_anland_camera_clear(struct anland_camera *c)
+{
+    if (!c)
+        return;
+    pw_thread_loop_lock(c->loop);
+    clear_resources_locked(c);
+    pw_thread_loop_unlock(c->loop);
+}
+
+struct anland_camera *meta_anland_camera_new(void)
+{
+    pw_init(NULL, NULL);
+
+    struct anland_camera *c = calloc(1, sizeof(*c));
+    if (!c) {
+        return NULL;
+    }
+    c->ctrl_fd = -1;
+    for (int i = 0; i < MAX_CAMERAS; i++) {
+        c->cams[i].owner = c;
+        c->cams[i].index = i;
+        c->cams[i].stream_fd = -1;
+        c->cams[i].shm_fd = -1;
+    }
+
+    c->loop = pw_thread_loop_new("anland-camera", NULL);
+    if (!c->loop)
+        goto fail;
+
+    c->context = pw_context_new(pw_thread_loop_get_loop(c->loop), NULL, 0);
+    if (!c->context)
+        goto fail;
+
+    c->reconnect_timer = pw_loop_add_timer(pw_thread_loop_get_loop(c->loop),
+                                           on_reconnect_timer, c);
+    if (!c->reconnect_timer)
+        goto fail;
+
+    if (pw_thread_loop_start(c->loop) < 0)
+        goto fail;
+    c->loop_started = true;
+
+    pw_thread_loop_lock(c->loop);
+    if (build_pw(c) == 0) {
+        c->pw_connected = true;
+    } else {
+        teardown_pw(c);
+        arm_reconnect(c);
+    }
+    pw_thread_loop_unlock(c->loop);
+
+    return c;
+
+fail:
+    if (c->loop_started)
+        pw_thread_loop_stop(c->loop);
+    if (c->reconnect_timer)
+        pw_loop_destroy_source(pw_thread_loop_get_loop(c->loop),
+                               c->reconnect_timer);
+    if (c->context)
+        pw_context_destroy(c->context);
+    if (c->loop)
+        pw_thread_loop_destroy(c->loop);
+    free(c);
+    return NULL;
+}
+
+void meta_anland_camera_free(struct anland_camera *c)
+{
+    if (!c)
+        return;
+
+    if (c->loop_started)
+        pw_thread_loop_lock(c->loop);
+    clear_resources_locked(c);
+    teardown_pw(c);
+    for (int i = 0; i < MAX_CAMERAS; i++) {
+        struct cam *cam = &c->cams[i];
+        unmap_shm(cam);
+        free(cam->frame);
+        cam->frame = NULL;
+    }
+    if (c->reconnect_timer)
+        pw_loop_destroy_source(pw_thread_loop_get_loop(c->loop), c->reconnect_timer);
+    if (c->loop_started)
+        pw_thread_loop_unlock(c->loop);
+
+    if (c->loop_started)
+        pw_thread_loop_stop(c->loop);
+    if (c->context)
+        pw_context_destroy(c->context);
+    if (c->loop)
+        pw_thread_loop_destroy(c->loop);
+    free(c);
+}

--- a/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-anland-camera.h
+++ b/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-anland-camera.h
@@ -1,0 +1,14 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#pragma once
+
+typedef struct anland_camera MetaAnlandCamera;
+
+MetaAnlandCamera * meta_anland_camera_new (void);
+void meta_anland_camera_free (MetaAnlandCamera *camera);
+
+void meta_anland_camera_set_resources (MetaAnlandCamera *camera,
+                                       int               control_fd,
+                                       const int        *stream_fds,
+                                       int               n_stream_fds);
+void meta_anland_camera_clear (MetaAnlandCamera *camera);

--- a/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-anland-clipboard.c
+++ b/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-anland-clipboard.c
@@ -1,0 +1,321 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#include "config.h"
+
+#include "backends/anland/meta-anland-clipboard.h"
+
+#include "backends/anland/vendor/meta-anland-transport.h"
+#include "meta/display.h"
+#include "meta/meta-backend.h"
+#include "meta/meta-context.h"
+#include "meta/meta-selection.h"
+#include "meta/meta-selection-source-memory.h"
+
+#include <string.h>
+
+#define ANLAND_CLIPBOARD_LIMIT (1024 * 1024)
+
+typedef struct
+{
+  MetaAnlandClipboard *clipboard;
+  guint generation;
+  GOutputStream *output;
+} ClipboardTransfer;
+
+struct _MetaAnlandClipboard
+{
+  int ref_count;
+  MetaSelection *selection;
+  MetaSelectionSource *source;
+  MetaAnlandTransport *transport;
+  GCancellable *transfer_cancellable;
+  GBytes *cached_contents;
+  guint generation;
+  gulong owner_changed_id;
+  gboolean disposed;
+};
+
+static MetaAnlandClipboard *
+meta_anland_clipboard_ref (MetaAnlandClipboard *clipboard)
+{
+  clipboard->ref_count++;
+  return clipboard;
+}
+
+static void
+meta_anland_clipboard_unref (MetaAnlandClipboard *clipboard)
+{
+  if (--clipboard->ref_count != 0)
+    return;
+
+  g_clear_object (&clipboard->transfer_cancellable);
+  g_clear_object (&clipboard->source);
+  g_clear_pointer (&clipboard->cached_contents, g_bytes_unref);
+  g_clear_object (&clipboard->selection);
+  g_free (clipboard);
+}
+
+static gboolean
+contents_are_valid (GBytes *contents)
+{
+  const char *data;
+  gsize size;
+
+  data = g_bytes_get_data (contents, &size);
+  if (size == 0)
+    return TRUE;
+
+  return size <= ANLAND_CLIPBOARD_LIMIT &&
+         !memchr (data, '\0', size) &&
+         g_utf8_validate (data, size, NULL);
+}
+
+static gboolean
+contents_equal (GBytes *a,
+                GBytes *b)
+{
+  return a && b && g_bytes_equal (a, b);
+}
+
+static void
+send_contents (MetaAnlandClipboard *clipboard,
+               GBytes              *contents)
+{
+  struct OutputEvent event = {
+    .type = OUTPUT_TYPE_CLIPBOARD,
+  };
+  const void *data;
+  gsize size;
+
+  if (!clipboard->transport ||
+      meta_anland_transport_is_fallback (clipboard->transport))
+    return;
+
+  data = g_bytes_get_data (contents, &size);
+  event.clipboard.size = size;
+  meta_anland_transport_send_output_event (clipboard->transport, &event,
+                                           data, size);
+}
+
+static void
+set_cached_contents (MetaAnlandClipboard *clipboard,
+                     GBytes              *contents)
+{
+  if (contents_equal (clipboard->cached_contents, contents))
+    return;
+
+  g_clear_pointer (&clipboard->cached_contents, g_bytes_unref);
+  clipboard->cached_contents = g_bytes_ref (contents);
+}
+
+static void
+clipboard_transfer_free (ClipboardTransfer *transfer)
+{
+  g_clear_object (&transfer->output);
+  meta_anland_clipboard_unref (transfer->clipboard);
+  g_free (transfer);
+}
+
+static void
+on_selection_transfer_complete (MetaSelection *selection,
+                                GAsyncResult  *result,
+                                gpointer       user_data)
+{
+  ClipboardTransfer *transfer = user_data;
+  MetaAnlandClipboard *clipboard = transfer->clipboard;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GBytes) contents = NULL;
+
+  if (!meta_selection_transfer_finish (selection, result, &error))
+    {
+      if (!error || !g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+        g_warning ("Anland failed to transfer clipboard: %s",
+                   error ? error->message : "unknown error");
+      goto out;
+    }
+
+  if (clipboard->disposed || transfer->generation != clipboard->generation)
+    goto out;
+
+  g_output_stream_close (transfer->output, NULL, NULL);
+  contents = g_memory_output_stream_steal_as_bytes (
+    G_MEMORY_OUTPUT_STREAM (transfer->output));
+  if (!contents_are_valid (contents))
+    {
+      g_warning ("Anland ignored invalid or oversized clipboard contents");
+      goto out;
+    }
+
+  set_cached_contents (clipboard, contents);
+  send_contents (clipboard, contents);
+
+out:
+  clipboard_transfer_free (transfer);
+}
+
+static const char *
+choose_mimetype (MetaSelection *selection)
+{
+  GList *mimetypes;
+  GList *l;
+  const char *chosen = NULL;
+
+  mimetypes = meta_selection_get_mimetypes (selection,
+                                            META_SELECTION_CLIPBOARD);
+  for (l = mimetypes; l; l = l->next)
+    {
+      if (g_str_equal (l->data, "text/plain;charset=utf-8"))
+        {
+          chosen = "text/plain;charset=utf-8";
+          break;
+        }
+
+      if (!chosen && g_str_equal (l->data, "text/plain"))
+        chosen = "text/plain";
+    }
+  g_list_free_full (mimetypes, g_free);
+
+  return chosen;
+}
+
+static void
+cancel_selection_transfer (MetaAnlandClipboard *clipboard)
+{
+  if (clipboard->transfer_cancellable)
+    g_cancellable_cancel (clipboard->transfer_cancellable);
+  g_clear_object (&clipboard->transfer_cancellable);
+}
+
+static void
+on_selection_owner_changed (MetaSelection       *selection,
+                            MetaSelectionType    selection_type,
+                            MetaSelectionSource *owner,
+                            MetaAnlandClipboard *clipboard)
+{
+  ClipboardTransfer *transfer;
+  const char *mimetype;
+  GOutputStream *output;
+
+  if (selection_type != META_SELECTION_CLIPBOARD || clipboard->disposed)
+    return;
+
+  cancel_selection_transfer (clipboard);
+  clipboard->generation++;
+
+  if (owner == clipboard->source)
+    return;
+
+  g_clear_object (&clipboard->source);
+  if (!owner)
+    {
+      g_autoptr (GBytes) empty = g_bytes_new_static ("", 0);
+
+      set_cached_contents (clipboard, empty);
+      send_contents (clipboard, empty);
+      return;
+    }
+
+  mimetype = choose_mimetype (selection);
+  if (!mimetype)
+    return;
+
+  output = g_memory_output_stream_new_resizable ();
+  clipboard->transfer_cancellable = g_cancellable_new ();
+  transfer = g_new0 (ClipboardTransfer, 1);
+  transfer->clipboard = meta_anland_clipboard_ref (clipboard);
+  transfer->generation = clipboard->generation;
+  transfer->output = g_object_ref (output);
+  meta_selection_transfer_async (selection, META_SELECTION_CLIPBOARD, mimetype,
+                                 ANLAND_CLIPBOARD_LIMIT, output,
+                                 clipboard->transfer_cancellable,
+                                 (GAsyncReadyCallback) on_selection_transfer_complete,
+                                 transfer);
+  g_object_unref (output);
+}
+
+MetaAnlandClipboard *
+meta_anland_clipboard_new (MetaBackend *backend)
+{
+  MetaAnlandClipboard *clipboard;
+  MetaContext *context;
+  MetaDisplay *display;
+
+  context = meta_backend_get_context (backend);
+  display = meta_context_get_display (context);
+  if (!display)
+    return NULL;
+
+  clipboard = g_new0 (MetaAnlandClipboard, 1);
+  clipboard->ref_count = 1;
+  clipboard->selection = g_object_ref (meta_display_get_selection (display));
+  clipboard->owner_changed_id = g_signal_connect_after (
+    clipboard->selection, "owner-changed",
+    G_CALLBACK (on_selection_owner_changed), clipboard);
+  return clipboard;
+}
+
+void
+meta_anland_clipboard_free (MetaAnlandClipboard *clipboard)
+{
+  if (!clipboard)
+    return;
+
+  clipboard->disposed = TRUE;
+  meta_anland_clipboard_set_transport (clipboard, NULL);
+  if (clipboard->owner_changed_id)
+    {
+      g_signal_handler_disconnect (clipboard->selection,
+                                   clipboard->owner_changed_id);
+      clipboard->owner_changed_id = 0;
+    }
+  meta_anland_clipboard_unref (clipboard);
+}
+
+void
+meta_anland_clipboard_set_transport (MetaAnlandClipboard *clipboard,
+                                     MetaAnlandTransport *transport)
+{
+  if (!clipboard || clipboard->transport == transport)
+    return;
+
+  clipboard->generation++;
+  cancel_selection_transfer (clipboard);
+  clipboard->transport = transport;
+
+  /*
+   * The consumer reads the Android clipboard as part of its reconnect path.
+   * Do not race that initial sync by replaying cached compositor contents here:
+   * when the app was in the background, doing so can overwrite a newer Android
+   * clipboard before it has a chance to send it to Mutter.
+   */
+}
+
+gboolean
+meta_anland_clipboard_set_from_consumer (MetaAnlandClipboard *clipboard,
+                                         GBytes              *contents)
+{
+  g_autoptr (GError) error = NULL;
+  g_autoptr (MetaSelectionSource) source = NULL;
+
+  if (!clipboard || !contents_are_valid (contents))
+    return FALSE;
+
+  if (contents_equal (clipboard->cached_contents, contents))
+    return TRUE;
+
+  source = meta_selection_source_memory_new ("text/plain;charset=utf-8",
+                                              contents, &error);
+  if (!source)
+    {
+      g_warning ("Anland failed to create clipboard source: %s", error->message);
+      return FALSE;
+    }
+
+  cancel_selection_transfer (clipboard);
+  clipboard->generation++;
+  set_cached_contents (clipboard, contents);
+  g_set_object (&clipboard->source, source);
+  meta_selection_set_owner (clipboard->selection, META_SELECTION_CLIPBOARD,
+                            source);
+  return TRUE;
+}

--- a/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-anland-clipboard.h
+++ b/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-anland-clipboard.h
@@ -1,0 +1,18 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#pragma once
+
+#include <gio/gio.h>
+
+typedef struct _MetaAnlandClipboard MetaAnlandClipboard;
+typedef struct _MetaAnlandTransport MetaAnlandTransport;
+typedef struct _MetaBackend MetaBackend;
+
+MetaAnlandClipboard * meta_anland_clipboard_new (MetaBackend *backend);
+void meta_anland_clipboard_free (MetaAnlandClipboard *clipboard);
+
+void meta_anland_clipboard_set_transport (MetaAnlandClipboard *clipboard,
+                                          MetaAnlandTransport *transport);
+
+gboolean meta_anland_clipboard_set_from_consumer (MetaAnlandClipboard *clipboard,
+                                                   GBytes              *contents);

--- a/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-anland-input.c
+++ b/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-anland-input.c
@@ -1,0 +1,582 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#include "config.h"
+
+#include "backends/anland/meta-anland-input.h"
+
+#include "backends/meta-backend-private.h"
+#include "backends/meta-logical-monitor.h"
+#include "backends/meta-monitor-manager-private.h"
+#include "backends/native/meta-virtual-input-device-native.h"
+
+#include <linux/input.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define ANLAND_MAX_TOUCH_BATCH_EVENTS 128
+#define ANLAND_TOUCH_BATCH_TIMEOUT_MS 100
+
+struct _MetaAnlandInput
+{
+  MetaBackend *backend;
+  ClutterVirtualInputDevice *pointer;
+  ClutterVirtualInputDevice *keyboard;
+  ClutterVirtualInputDevice *touchscreen;
+  gboolean pressed_keys[KEY_CNT];
+  gboolean pressed_buttons[KEY_CNT];
+  GHashTable *touch_slots;
+  gboolean active_touch_slots[CLUTTER_VIRTUAL_INPUT_DEVICE_MAX_TOUCH_SLOTS];
+  GArray *touch_batch;
+  guint touch_batch_timeout_id;
+
+  MetaAnlandInputRefreshFunc refresh_func;
+  gpointer refresh_user_data;
+};
+
+static void
+map_input_coordinates (MetaAnlandInput *input,
+                       uint32_t         input_width,
+                       uint32_t         input_height,
+                       float            x,
+                       float            y,
+                       gboolean         is_delta,
+                       float           *mapped_x,
+                       float           *mapped_y)
+{
+  MetaMonitorManager *monitor_manager;
+  MetaLogicalMonitor *logical_monitor;
+  MtkRectangle layout;
+
+  *mapped_x = x;
+  *mapped_y = y;
+
+  if (input_width == 0 || input_height == 0)
+    return;
+
+  monitor_manager = meta_backend_get_monitor_manager (input->backend);
+  logical_monitor =
+    meta_monitor_manager_get_primary_logical_monitor (monitor_manager);
+  if (!logical_monitor)
+    return;
+
+  layout = meta_logical_monitor_get_layout (logical_monitor);
+
+  /* Anland reports buffer pixels, while Clutter uses the logical layout. */
+  *mapped_x = x * layout.width / input_width;
+  *mapped_y = y * layout.height / input_height;
+
+  if (!is_delta)
+    {
+      *mapped_x += layout.x;
+      *mapped_y += layout.y;
+    }
+}
+
+static gboolean
+is_finite_pair (float x,
+                float y)
+{
+  return isfinite (x) && isfinite (y);
+}
+
+static void
+clear_touch_slot (MetaAnlandInput *input,
+                  int              slot)
+{
+  GHashTableIter iter;
+  gpointer key;
+  gpointer value;
+
+  g_hash_table_iter_init (&iter, input->touch_slots);
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    {
+      if (GPOINTER_TO_UINT (value) == (guint) slot + 1)
+        {
+          g_hash_table_iter_remove (&iter);
+          break;
+        }
+    }
+  input->active_touch_slots[slot] = FALSE;
+}
+
+static void
+cancel_touches (MetaAnlandInput *input)
+{
+  MetaVirtualTouchEvent events[CLUTTER_VIRTUAL_INPUT_DEVICE_MAX_TOUCH_SLOTS];
+  guint n_events = 0;
+  guint slot;
+
+  if (!input->touchscreen)
+    return;
+
+  for (slot = 0; slot < G_N_ELEMENTS (input->active_touch_slots); slot++)
+    {
+      if (!input->active_touch_slots[slot])
+        continue;
+
+      events[n_events++] = (MetaVirtualTouchEvent) {
+        .type = META_VIRTUAL_TOUCH_EVENT_CANCEL,
+        .slot = slot,
+      };
+    }
+
+  if (n_events > 0)
+    meta_virtual_input_device_native_notify_touch_events (
+      META_VIRTUAL_INPUT_DEVICE_NATIVE (input->touchscreen),
+      g_get_monotonic_time (), events, n_events);
+
+  if (input->touch_slots)
+    g_hash_table_remove_all (input->touch_slots);
+  memset (input->active_touch_slots, 0, sizeof (input->active_touch_slots));
+}
+
+static gboolean
+touch_batch_timeout_cb (gpointer user_data)
+{
+  MetaAnlandInput *input = user_data;
+
+  input->touch_batch_timeout_id = 0;
+  if (input->touch_batch->len > 0)
+    {
+      g_warning ("Anland input dropped an incomplete touch frame");
+      cancel_touches (input);
+      g_array_set_size (input->touch_batch, 0);
+    }
+
+  return G_SOURCE_REMOVE;
+}
+
+static void
+schedule_touch_batch_timeout (MetaAnlandInput *input)
+{
+  if (!input->touch_batch_timeout_id)
+    input->touch_batch_timeout_id =
+      g_timeout_add (ANLAND_TOUCH_BATCH_TIMEOUT_MS,
+                     touch_batch_timeout_cb, input);
+}
+
+static int
+allocate_touch_slot (MetaAnlandInput *input)
+{
+  guint slot;
+
+  for (slot = 0; slot < G_N_ELEMENTS (input->active_touch_slots); slot++)
+    {
+      if (!input->active_touch_slots[slot])
+        return slot;
+    }
+
+  return -1;
+}
+
+static void
+flush_touch_batch (MetaAnlandInput *input)
+{
+  guint i;
+
+  if (input->touch_batch_timeout_id)
+    {
+      g_source_remove (input->touch_batch_timeout_id);
+      input->touch_batch_timeout_id = 0;
+    }
+
+  if (input->touch_batch->len == 0)
+    return;
+
+  meta_virtual_input_device_native_notify_touch_events (
+    META_VIRTUAL_INPUT_DEVICE_NATIVE (input->touchscreen),
+    g_get_monotonic_time (), (const MetaVirtualTouchEvent *) input->touch_batch->data,
+    input->touch_batch->len);
+
+  for (i = 0; i < input->touch_batch->len; i++)
+    {
+      const MetaVirtualTouchEvent *event =
+        &g_array_index (input->touch_batch, MetaVirtualTouchEvent, i);
+
+      if (event->type == META_VIRTUAL_TOUCH_EVENT_UP)
+        clear_touch_slot (input, event->slot);
+    }
+  g_array_set_size (input->touch_batch, 0);
+}
+
+static void
+handle_pointer_motion (MetaAnlandInput         *input,
+                       const struct InputEvent *event,
+                       uint32_t                 input_width,
+                       uint32_t                 input_height)
+{
+  float x, y, dx, dy;
+
+  if (!is_finite_pair (event->pointer_motion.x, event->pointer_motion.y) ||
+      !is_finite_pair (event->pointer_motion.dx, event->pointer_motion.dy))
+    return;
+
+  map_input_coordinates (input, input_width, input_height,
+                         event->pointer_motion.x, event->pointer_motion.y,
+                         FALSE, &x, &y);
+  map_input_coordinates (input, input_width, input_height,
+                         event->pointer_motion.dx, event->pointer_motion.dy,
+                         TRUE, &dx, &dy);
+
+  meta_virtual_input_device_native_notify_absolute_relative_motion (
+    META_VIRTUAL_INPUT_DEVICE_NATIVE (input->pointer), g_get_monotonic_time (),
+    x, y, dx, dy);
+}
+
+static void
+handle_pointer_button (MetaAnlandInput         *input,
+                       const struct InputEvent *event)
+{
+  uint32_t button = event->pointer_button.button;
+  gboolean pressed = event->pointer_button.pressed != 0;
+
+  if (button >= KEY_CNT || button < BTN_LEFT || button > BTN_GEAR_UP ||
+      input->pressed_buttons[button] == pressed)
+    return;
+
+  input->pressed_buttons[button] = pressed;
+  clutter_virtual_input_device_notify_button (
+    input->pointer, g_get_monotonic_time (), meta_evdev_button_to_clutter (button),
+    pressed ? CLUTTER_BUTTON_STATE_PRESSED : CLUTTER_BUTTON_STATE_RELEASED);
+}
+
+static void
+handle_pointer_axis (MetaAnlandInput         *input,
+                     const struct InputEvent *event)
+{
+  ClutterScrollDirection direction;
+  double dx = 0.0;
+  double dy = 0.0;
+  int64_t discrete = event->pointer_axis.discrete;
+  int steps;
+
+  if (!isfinite (event->pointer_axis.value))
+    return;
+
+  switch (event->pointer_axis.axis)
+    {
+    case 0:
+      dy = event->pointer_axis.value;
+      direction = discrete >= 0 ? CLUTTER_SCROLL_DOWN : CLUTTER_SCROLL_UP;
+      break;
+    case 1:
+      dx = event->pointer_axis.value;
+      direction = discrete >= 0 ? CLUTTER_SCROLL_RIGHT : CLUTTER_SCROLL_LEFT;
+      break;
+    default:
+      g_warning ("Anland input ignored invalid scroll axis %u",
+                 event->pointer_axis.axis);
+      return;
+    }
+
+  if (dx != 0.0 || dy != 0.0)
+    clutter_virtual_input_device_notify_scroll_continuous (
+      input->pointer, g_get_monotonic_time (), dx, dy,
+      CLUTTER_SCROLL_SOURCE_WHEEL, CLUTTER_SCROLL_FINISHED_NONE);
+
+  steps = MIN (llabs (discrete), 120);
+  while (steps-- > 0)
+    clutter_virtual_input_device_notify_discrete_scroll (
+      input->pointer, g_get_monotonic_time (), direction,
+      CLUTTER_SCROLL_SOURCE_WHEEL);
+}
+
+static void
+handle_key (MetaAnlandInput         *input,
+            const struct InputEvent *event)
+{
+  uint32_t keycode = event->key.keycode;
+  gboolean pressed;
+
+  if (keycode >= KEY_CNT ||
+      (event->key.action != INPUT_ACTION_DOWN &&
+       event->key.action != INPUT_ACTION_UP))
+    return;
+
+  pressed = event->key.action == INPUT_ACTION_DOWN;
+  if (input->pressed_keys[keycode] == pressed)
+    return;
+
+  input->pressed_keys[keycode] = pressed;
+  clutter_virtual_input_device_notify_key (
+    input->keyboard, g_get_monotonic_time (), keycode,
+    pressed ? CLUTTER_KEY_STATE_PRESSED : CLUTTER_KEY_STATE_RELEASED);
+}
+
+static void
+handle_touch (MetaAnlandInput         *input,
+              const struct InputEvent *event,
+              uint32_t                 input_width,
+              uint32_t                 input_height)
+{
+  gpointer value;
+  int slot;
+  MetaVirtualTouchEvent touch_event;
+  float x, y;
+
+  if ((event->touch.action == INPUT_ACTION_DOWN ||
+       event->touch.action == INPUT_ACTION_MOVE) &&
+      !is_finite_pair (event->touch.x, event->touch.y))
+    return;
+
+  if (event->touch.action == INPUT_ACTION_DOWN ||
+      event->touch.action == INPUT_ACTION_MOVE)
+    map_input_coordinates (input, input_width, input_height,
+                           event->touch.x, event->touch.y,
+                           FALSE, &x, &y);
+
+  value = g_hash_table_lookup (input->touch_slots,
+                               GINT_TO_POINTER (event->touch.pointer_id));
+  switch (event->touch.action)
+    {
+    case INPUT_ACTION_DOWN:
+      if (value)
+        return;
+
+      slot = allocate_touch_slot (input);
+      if (slot < 0)
+        {
+          g_warning ("Anland input ran out of touch slots");
+          return;
+        }
+      input->active_touch_slots[slot] = TRUE;
+      g_hash_table_insert (input->touch_slots,
+                           GINT_TO_POINTER (event->touch.pointer_id),
+                           GUINT_TO_POINTER (slot + 1));
+      touch_event = (MetaVirtualTouchEvent) {
+        .type = META_VIRTUAL_TOUCH_EVENT_DOWN,
+        .slot = slot,
+        .x = x,
+        .y = y,
+      };
+      break;
+    case INPUT_ACTION_MOVE:
+      if (!value)
+        return;
+      touch_event = (MetaVirtualTouchEvent) {
+        .type = META_VIRTUAL_TOUCH_EVENT_MOTION,
+        .slot = GPOINTER_TO_UINT (value) - 1,
+        .x = x,
+        .y = y,
+      };
+      break;
+    case INPUT_ACTION_UP:
+      if (!value)
+        return;
+      touch_event = (MetaVirtualTouchEvent) {
+        .type = META_VIRTUAL_TOUCH_EVENT_UP,
+        .slot = GPOINTER_TO_UINT (value) - 1,
+      };
+      break;
+    default:
+      return;
+    }
+
+  if (input->touch_batch->len >= ANLAND_MAX_TOUCH_BATCH_EVENTS)
+    {
+      g_warning ("Anland input dropped an oversized touch frame");
+      cancel_touches (input);
+      g_array_set_size (input->touch_batch, 0);
+      return;
+    }
+
+  g_array_append_val (input->touch_batch, touch_event);
+  schedule_touch_batch_timeout (input);
+}
+
+MetaAnlandInput *
+meta_anland_input_new (MetaBackend               *backend,
+                       MetaAnlandInputRefreshFunc  refresh_func,
+                       gpointer                    user_data,
+                       GError                    **error)
+{
+  MetaAnlandInput *input;
+  ClutterSeat *seat;
+
+  seat = meta_backend_get_default_seat (backend);
+  if (!seat)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Anland backend has no default input seat");
+      return NULL;
+    }
+
+  input = g_new0 (MetaAnlandInput, 1);
+  input->backend = backend;
+  input->touch_slots = g_hash_table_new (g_direct_hash, g_direct_equal);
+  input->touch_batch = g_array_new (FALSE, FALSE, sizeof (MetaVirtualTouchEvent));
+  input->pointer = clutter_seat_create_virtual_device (seat,
+                                                        CLUTTER_POINTER_DEVICE);
+  input->keyboard = clutter_seat_create_virtual_device (seat,
+                                                         CLUTTER_KEYBOARD_DEVICE);
+  input->touchscreen = clutter_seat_create_virtual_device (seat,
+                                                            CLUTTER_TOUCHSCREEN_DEVICE);
+  if (!input->pointer || !input->keyboard || !input->touchscreen)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Failed to create Anland virtual input devices");
+      meta_anland_input_free (input);
+      return NULL;
+    }
+
+  input->refresh_func = refresh_func;
+  input->refresh_user_data = user_data;
+  return input;
+}
+
+void
+meta_anland_input_free (MetaAnlandInput *input)
+{
+  if (!input)
+    return;
+
+  if (input->touch_batch_timeout_id)
+    {
+      g_source_remove (input->touch_batch_timeout_id);
+      input->touch_batch_timeout_id = 0;
+    }
+  meta_anland_input_reset (input);
+  g_clear_object (&input->pointer);
+  g_clear_object (&input->keyboard);
+  g_clear_object (&input->touchscreen);
+  g_clear_pointer (&input->touch_slots, g_hash_table_unref);
+  g_clear_pointer (&input->touch_batch, g_array_unref);
+  g_free (input);
+}
+
+MetaAnlandInputEventResult
+meta_anland_input_handle_event (MetaAnlandInput         *input,
+                                MetaAnlandTransport     *transport,
+                                const struct InputEvent *event,
+                                uint32_t                 input_width,
+                                uint32_t                 input_height)
+{
+  switch (event->type)
+    {
+    case INPUT_TYPE_POINTER_MOTION:
+      handle_pointer_motion (input, event, input_width, input_height);
+      break;
+    case INPUT_TYPE_POINTER_BUTTON:
+      handle_pointer_button (input, event);
+      break;
+    case INPUT_TYPE_POINTER_AXIS:
+      handle_pointer_axis (input, event);
+      break;
+    case INPUT_TYPE_KEY:
+      handle_key (input, event);
+      break;
+    case INPUT_TYPE_TOUCH:
+      handle_touch (input, event, input_width, input_height);
+      break;
+    case INPUT_TYPE_TOUCH_FRAME:
+      flush_touch_batch (input);
+      break;
+    case INPUT_TYPE_DISPLAY_REFRESH:
+      if (event->display.refresh_mhz >= 1000 &&
+          event->display.refresh_mhz <= 1000000 && input->refresh_func)
+        input->refresh_func (event->display.refresh_mhz,
+                             input->refresh_user_data);
+      break;
+    case INPUT_TYPE_CLIPBOARD:
+    case INPUT_TYPE_TEXT_INPUT:
+      return META_ANLAND_INPUT_EVENT_NEEDS_PAYLOAD;
+    case INPUT_TYPE_RESOURCE:
+      return META_ANLAND_INPUT_EVENT_NEEDS_RESOURCE_FDS;
+    case INPUT_TYPE_ACTION:
+      break;
+    default:
+      g_warning ("Anland input ignored unknown event type %u", event->type);
+      break;
+    }
+
+  return META_ANLAND_INPUT_EVENT_HANDLED;
+}
+
+gboolean
+meta_anland_input_inject_text (MetaAnlandInput *input,
+                               const char      *text)
+{
+  const char *cursor = text;
+  gboolean injected = FALSE;
+
+  if (!input || !input->keyboard || !text)
+    return FALSE;
+
+  while (*cursor)
+    {
+      gunichar keyval;
+
+      keyval = g_utf8_get_char_validated (cursor, -1);
+      if (keyval == (gunichar) -1 || keyval == (gunichar) -2)
+        return FALSE;
+
+      switch (keyval)
+        {
+        case '\n':
+        case '\r':
+          keyval = CLUTTER_KEY_Return;
+          break;
+        case '\t':
+          keyval = CLUTTER_KEY_Tab;
+          break;
+        case '\b':
+          keyval = CLUTTER_KEY_BackSpace;
+          break;
+        default:
+          break;
+        }
+
+      clutter_virtual_input_device_notify_keyval (
+        input->keyboard, g_get_monotonic_time (), keyval,
+        CLUTTER_KEY_STATE_PRESSED);
+      clutter_virtual_input_device_notify_keyval (
+        input->keyboard, g_get_monotonic_time (), keyval,
+        CLUTTER_KEY_STATE_RELEASED);
+      cursor = g_utf8_next_char (cursor);
+      injected = TRUE;
+    }
+
+  return injected;
+}
+
+void
+meta_anland_input_reset (MetaAnlandInput *input)
+{
+  guint code;
+
+  if (!input)
+    return;
+
+  if (input->touch_batch_timeout_id)
+    {
+      g_source_remove (input->touch_batch_timeout_id);
+      input->touch_batch_timeout_id = 0;
+    }
+
+  for (code = 0; code < G_N_ELEMENTS (input->pressed_keys); code++)
+    {
+      if (!input->pressed_keys[code])
+        continue;
+
+      clutter_virtual_input_device_notify_key (
+        input->keyboard, g_get_monotonic_time (), code,
+        CLUTTER_KEY_STATE_RELEASED);
+      input->pressed_keys[code] = FALSE;
+    }
+
+  for (code = BTN_LEFT; code < G_N_ELEMENTS (input->pressed_buttons); code++)
+    {
+      if (!input->pressed_buttons[code])
+        continue;
+
+      clutter_virtual_input_device_notify_button (
+        input->pointer, g_get_monotonic_time (),
+        meta_evdev_button_to_clutter (code), CLUTTER_BUTTON_STATE_RELEASED);
+      input->pressed_buttons[code] = FALSE;
+    }
+
+  cancel_touches (input);
+  g_array_set_size (input->touch_batch, 0);
+}

--- a/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-anland-input.h
+++ b/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-anland-input.h
@@ -1,0 +1,37 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#pragma once
+
+#include <glib.h>
+
+#include "backends/anland/vendor/meta-anland-transport.h"
+#include "backends/meta-backend-types.h"
+
+typedef struct _MetaAnlandInput MetaAnlandInput;
+
+typedef enum
+{
+  META_ANLAND_INPUT_EVENT_HANDLED,
+  META_ANLAND_INPUT_EVENT_NEEDS_PAYLOAD,
+  META_ANLAND_INPUT_EVENT_NEEDS_RESOURCE_FDS,
+  META_ANLAND_INPUT_EVENT_ERROR,
+} MetaAnlandInputEventResult;
+
+typedef void (* MetaAnlandInputRefreshFunc) (uint32_t refresh_mhz,
+                                              gpointer user_data);
+
+MetaAnlandInput * meta_anland_input_new (MetaBackend                *backend,
+                                         MetaAnlandInputRefreshFunc   refresh_func,
+                                         gpointer                     user_data,
+                                         GError                     **error);
+void meta_anland_input_free (MetaAnlandInput *input);
+
+MetaAnlandInputEventResult
+meta_anland_input_handle_event (MetaAnlandInput          *input,
+                                MetaAnlandTransport      *transport,
+                                const struct InputEvent  *event,
+                                uint32_t                  input_width,
+                                uint32_t                  input_height);
+gboolean meta_anland_input_inject_text (MetaAnlandInput *input,
+                                        const char      *text);
+void meta_anland_input_reset (MetaAnlandInput *input);

--- a/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-backend-anland.c
+++ b/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-backend-anland.c
@@ -1,0 +1,1066 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#include "config.h"
+
+#include "backends/anland/meta-backend-anland.h"
+
+#include "backends/anland/meta-anland-audio.h"
+#include "backends/anland/meta-anland-camera.h"
+#include "backends/anland/meta-anland-clipboard.h"
+#include "backends/anland/meta-anland-input.h"
+#include "backends/anland/vendor/meta-anland-transport.h"
+#include "backends/meta-backend-private.h"
+#include "backends/meta-fd-source.h"
+#include "backends/meta-monitor-manager-private.h"
+#include "backends/meta-renderer.h"
+#include "backends/meta-renderer-view.h"
+#include "backends/meta-stage-view-private.h"
+#include "backends/meta-virtual-monitor.h"
+#include "backends/native/meta-renderer-native-private.h"
+#include "meta/meta-backend.h"
+#include "meta/meta-context.h"
+#include "meta/meta-wayland-compositor.h"
+#include "wayland/meta-wayland.h"
+
+#include <drm_fourcc.h>
+#include <fcntl.h>
+#include <math.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define ANLAND_RECONNECT_INTERVAL_MS 200
+#define ANLAND_PROTOCOL_FORMAT_RGBA_8888 1
+#define ANLAND_MAX_RESOURCE_FDS 64
+
+enum
+{
+  PROP_0,
+
+  PROP_ANLAND_SOCKET,
+};
+
+struct _MetaBackendAnland
+{
+  MetaBackendNative parent;
+
+  char *socket_path;
+  MetaAnlandTransport *transport;
+  MetaVirtualMonitor *virtual_monitor;
+  struct screen_info screen_info;
+  guint reconnect_source_id;
+  MetaAnlandAudio *audio;
+  MetaAnlandCamera *camera;
+  MetaAnlandInput *input;
+  MetaAnlandClipboard *clipboard;
+
+  GSource *buffer_ready_source;
+  GSource *input_source;
+  MetaStageView *stage_view;
+  CoglFramebuffer *placeholder_framebuffer;
+  CoglFramebuffer *buffer_framebuffers[MAX_BUFS];
+  int current_buffer;
+  gboolean consumer_active;
+  gboolean frame_clock_inhibited;
+  gboolean frame_pending;
+  gboolean warned_sync_fallback;
+  int64_t pending_global_frame_counter;
+  int64_t pending_view_frame_counter;
+  unsigned int presentation_sequence;
+};
+
+G_DEFINE_TYPE (MetaBackendAnland, meta_backend_anland, META_TYPE_BACKEND_NATIVE)
+
+static void deactivate_consumer (MetaBackendAnland *backend);
+static void release_stage_view (MetaBackendAnland *backend);
+static void schedule_reconnect (MetaBackendAnland *backend);
+
+static void
+on_context_started (MetaContext        *context,
+                    MetaBackendAnland *backend)
+{
+  backend->clipboard = meta_anland_clipboard_new (META_BACKEND (backend));
+  if (!backend->clipboard)
+    g_warning ("Failed to initialize Anland clipboard bridge");
+}
+
+static gboolean
+read_text_payload (MetaBackendAnland  *backend,
+                   uint32_t            size,
+                   const char         *name,
+                   GBytes            **contents)
+{
+  g_autofree char *text = NULL;
+
+  *contents = NULL;
+  if (size > META_ANLAND_MAX_PAYLOAD_SIZE)
+    {
+      g_warning ("Anland rejected oversized %s payload", name);
+      return FALSE;
+    }
+
+  text = g_malloc (size + 1);
+  if (meta_anland_transport_read_input_payload (backend->transport, text,
+                                                size, 100) != 1)
+    return FALSE;
+  text[size] = '\0';
+
+  if (memchr (text, '\0', size) || !g_utf8_validate (text, size, NULL))
+    {
+      g_warning ("Anland ignored invalid UTF-8 %s payload", name);
+      return TRUE;
+    }
+
+  *contents = g_bytes_new (text, size);
+  return TRUE;
+}
+
+static gboolean
+handle_extended_input (MetaBackendAnland       *backend,
+                       const struct InputEvent *event)
+{
+  g_autoptr (GBytes) contents = NULL;
+  g_autofree char *input_text = NULL;
+  const char *text;
+  guint size;
+
+  switch (event->type)
+    {
+    case INPUT_TYPE_CLIPBOARD:
+      if (!read_text_payload (backend, event->clipboard.size, "clipboard",
+                              &contents))
+        return FALSE;
+      break;
+    case INPUT_TYPE_TEXT_INPUT:
+      if (!read_text_payload (backend, event->text_input.size, "text input",
+                              &contents))
+        return FALSE;
+      break;
+    default:
+      return FALSE;
+    }
+
+  if (!contents)
+    return TRUE;
+
+  size = g_bytes_get_size (contents);
+  if (size == 0)
+    return TRUE;
+
+  text = g_bytes_get_data (contents, NULL);
+  if (event->type == INPUT_TYPE_CLIPBOARD)
+    return meta_anland_clipboard_set_from_consumer (backend->clipboard,
+                                                    contents);
+
+  input_text = g_strndup (text, size);
+
+  {
+    MetaContext *context = meta_backend_get_context (META_BACKEND (backend));
+    MetaWaylandCompositor *compositor =
+      meta_context_get_wayland_compositor (context);
+
+    if (compositor && meta_wayland_text_input_commit_string (
+          meta_wayland_compositor_get_text_input (compositor), input_text))
+      return TRUE;
+  }
+
+  return meta_anland_input_inject_text (backend->input, input_text);
+}
+
+static void
+close_resource_fds (int *fds,
+                    int  n_fds)
+{
+  int i;
+
+  for (i = 0; i < n_fds; i++)
+    {
+      if (fds[i] >= 0)
+        close (fds[i]);
+    }
+}
+
+static gboolean
+set_resource_fds_cloexec (int *fds,
+                          int  n_fds)
+{
+  int i;
+
+  for (i = 0; i < n_fds; i++)
+    {
+      int flags = fcntl (fds[i], F_GETFD);
+
+      if (flags < 0 || fcntl (fds[i], F_SETFD, flags | FD_CLOEXEC) < 0)
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+handle_resource_input (MetaBackendAnland       *backend,
+                       const struct InputEvent *event)
+{
+  int fds[ANLAND_MAX_RESOURCE_FDS];
+  int n_fds = 0;
+
+  if (event->resource.fdnum == 0 ||
+      event->resource.fdnum > G_N_ELEMENTS (fds) ||
+      meta_anland_transport_read_input_fds (backend->transport, fds,
+                                            G_N_ELEMENTS (fds), &n_fds, 100) != 1 ||
+      n_fds != (int) event->resource.fdnum)
+    {
+      close_resource_fds (fds, n_fds);
+      return FALSE;
+    }
+
+  if (!set_resource_fds_cloexec (fds, n_fds))
+    {
+      close_resource_fds (fds, n_fds);
+      return FALSE;
+    }
+
+  if (event->resource.type == SERVICE_TYPE_CAMERA && backend->camera)
+    {
+      meta_anland_camera_set_resources (backend->camera, fds[0], &fds[1],
+                                        n_fds - 1);
+      return TRUE;
+    }
+
+  close_resource_fds (fds, n_fds);
+  return TRUE;
+}
+
+static void
+request_camera_resources (MetaBackendAnland *backend)
+{
+  struct OutputEvent event = {
+    .type = OUTPUT_TYPE_RESOURCES_REQUEST,
+    .resources_request.type = SERVICE_TYPE_CAMERA,
+  };
+
+  if (!backend->camera)
+    return;
+
+  meta_anland_transport_send_output_event (backend->transport, &event,
+                                           NULL, 0);
+}
+
+static char *
+get_default_socket_path (void)
+{
+  const char *socket_path = g_getenv ("ANLAND_SOCKET");
+  const char *tmpdir;
+  const char *prefix;
+
+  if (socket_path && *socket_path)
+    return g_strdup (socket_path);
+
+  tmpdir = g_getenv ("TMPDIR");
+  if (tmpdir && *tmpdir)
+    return g_build_filename (tmpdir, "anland", "display_daemon.sock", NULL);
+
+  prefix = g_getenv ("PREFIX");
+  if (prefix && g_str_has_prefix (prefix, "/data/data/com.termux/"))
+    return g_strdup ("/data/data/com.termux/files/usr/tmp/anland/display_daemon.sock");
+
+  return g_strdup ("/tmp/anland/display_daemon.sock");
+}
+
+static gboolean
+validate_screen_info (const struct screen_info  *screen_info,
+                      GError                   **error)
+{
+  if (screen_info->width == 0 || screen_info->height == 0 ||
+      screen_info->width > G_MAXINT || screen_info->height > G_MAXINT ||
+      (screen_info->refresh != 0 && screen_info->refresh < 1000) ||
+      screen_info->refresh > 1000000)
+    {
+      if (error)
+        g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+                     "Anland daemon provided invalid screen information");
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static void
+clear_transport (MetaBackendAnland *backend)
+{
+  deactivate_consumer (backend);
+
+  if (backend->transport)
+    meta_anland_transport_disconnect (backend->transport);
+  backend->transport = NULL;
+}
+
+static gboolean
+connect_transport (MetaBackendAnland  *backend,
+                   GError            **error)
+{
+  struct screen_info screen_info;
+
+  if (backend->transport)
+    return TRUE;
+
+  if (meta_anland_transport_connect (&backend->transport,
+                                     backend->socket_path) < 0)
+    {
+      if (error)
+        g_set_error (error, G_IO_ERROR, G_IO_ERROR_CONNECTION_REFUSED,
+                     "Failed to connect to Anland daemon at %s",
+                     backend->socket_path);
+      return FALSE;
+    }
+
+  if (!meta_anland_transport_get_screen_info (backend->transport, &screen_info) ||
+      !validate_screen_info (&screen_info, error))
+    {
+      clear_transport (backend);
+      return FALSE;
+    }
+
+  backend->screen_info = screen_info;
+  return TRUE;
+}
+
+static gboolean
+update_virtual_monitor (MetaBackendAnland  *backend,
+                        GError            **error)
+{
+  MetaMonitorManager *monitor_manager;
+  float refresh_rate;
+
+  if (!backend->transport)
+    return FALSE;
+
+  monitor_manager = meta_backend_get_monitor_manager (META_BACKEND (backend));
+  refresh_rate = backend->screen_info.refresh > 0 ?
+    backend->screen_info.refresh / 1000.0f : 60.0f;
+
+  if (backend->virtual_monitor)
+    {
+      release_stage_view (backend);
+      meta_virtual_monitor_set_mode (backend->virtual_monitor,
+                                     backend->screen_info.width,
+                                     backend->screen_info.height,
+                                     refresh_rate);
+      meta_monitor_manager_reload (monitor_manager);
+      return TRUE;
+    }
+
+  g_autoptr (MetaVirtualMonitorInfo) info =
+    meta_virtual_monitor_info_new (backend->screen_info.width,
+                                   backend->screen_info.height,
+                                   refresh_rate,
+                                   "Anland", "Anland-1", "Anland-1");
+  backend->virtual_monitor =
+    meta_monitor_manager_create_virtual_monitor (monitor_manager, info, error);
+  if (!backend->virtual_monitor)
+    return FALSE;
+
+  meta_monitor_manager_reload (monitor_manager);
+  return TRUE;
+}
+
+static void
+inhibit_frame_clock (MetaBackendAnland *backend)
+{
+  if (!backend->stage_view || backend->frame_clock_inhibited)
+    return;
+
+  clutter_frame_clock_inhibit (
+    clutter_stage_view_get_frame_clock (CLUTTER_STAGE_VIEW (backend->stage_view)));
+  backend->frame_clock_inhibited = TRUE;
+}
+
+static void
+uninhibit_frame_clock (MetaBackendAnland *backend)
+{
+  if (!backend->stage_view || !backend->frame_clock_inhibited)
+    return;
+
+  clutter_frame_clock_uninhibit (
+    clutter_stage_view_get_frame_clock (CLUTTER_STAGE_VIEW (backend->stage_view)));
+  backend->frame_clock_inhibited = FALSE;
+}
+
+static void
+release_stage_view (MetaBackendAnland *backend)
+{
+  if (!backend->stage_view)
+    return;
+
+  g_return_if_fail (!backend->consumer_active);
+  g_return_if_fail (!backend->frame_pending);
+
+  uninhibit_frame_clock (backend);
+  g_clear_object (&backend->placeholder_framebuffer);
+  g_clear_object (&backend->stage_view);
+}
+
+static MetaStageView *
+find_stage_view (MetaBackendAnland *backend)
+{
+  MetaRenderer *renderer;
+  MetaCrtc *crtc;
+  MetaRendererView *renderer_view;
+
+  if (!backend->virtual_monitor)
+    return NULL;
+
+  renderer = meta_backend_get_renderer (META_BACKEND (backend));
+  crtc = meta_virtual_monitor_get_crtc (backend->virtual_monitor);
+  renderer_view = meta_renderer_get_view_for_crtc (renderer, crtc);
+
+  return renderer_view ? META_STAGE_VIEW (renderer_view) : NULL;
+}
+
+static gboolean
+ensure_stage_view (MetaBackendAnland  *backend,
+                   GError            **error)
+{
+  MetaStageView *stage_view = find_stage_view (backend);
+
+  if (!stage_view)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Anland virtual monitor does not have a renderer view yet");
+      return FALSE;
+    }
+
+  if (backend->stage_view == stage_view)
+    return TRUE;
+
+  if (backend->consumer_active || backend->frame_pending)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_BUSY,
+                   "Anland renderer view changed while a consumer was active");
+      return FALSE;
+    }
+
+  if (backend->frame_clock_inhibited)
+    uninhibit_frame_clock (backend);
+
+  g_set_object (&backend->stage_view, stage_view);
+  g_set_object (&backend->placeholder_framebuffer,
+                clutter_stage_view_get_onscreen (CLUTTER_STAGE_VIEW (stage_view)));
+  return TRUE;
+}
+
+static gboolean
+validate_buffer_info (const struct buf_info  *buffer_info,
+                      int                     fd,
+                      GError                **error)
+{
+  struct stat stat_buf;
+  uint64_t required_size;
+
+  if (buffer_info->format != ANLAND_PROTOCOL_FORMAT_RGBA_8888 ||
+      buffer_info->modifier != DRM_FORMAT_MOD_LINEAR ||
+      buffer_info->width > G_MAXUINT32 / 4u ||
+      buffer_info->stride < buffer_info->width * 4u ||
+      buffer_info->height > G_MAXUINT64 / buffer_info->stride ||
+      buffer_info->offset > G_MAXUINT64 -
+        (uint64_t) buffer_info->stride * buffer_info->height)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+                   "Anland daemon provided an invalid dma-buf description");
+      return FALSE;
+    }
+
+  required_size = buffer_info->offset +
+    (uint64_t) buffer_info->stride * buffer_info->height;
+  if (fstat (fd, &stat_buf) == 0 && stat_buf.st_size > 0 &&
+      required_size > (uint64_t) stat_buf.st_size)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+                   "Anland dma-buf is smaller than its advertised layout");
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static void
+complete_pending_frame (MetaBackendAnland *backend)
+{
+  ClutterFrameInfo frame_info;
+
+  if (!backend->stage_view || !backend->frame_pending)
+    return;
+
+  frame_info = (ClutterFrameInfo) {
+    .global_frame_counter = backend->pending_global_frame_counter,
+    .view_frame_counter = backend->pending_view_frame_counter,
+    .refresh_rate = clutter_stage_view_get_refresh_rate (
+      CLUTTER_STAGE_VIEW (backend->stage_view)),
+    .presentation_time = g_get_monotonic_time (),
+    .flags = CLUTTER_FRAME_INFO_FLAG_NONE,
+    .sequence = ++backend->presentation_sequence,
+  };
+  clutter_stage_view_notify_presented (CLUTTER_STAGE_VIEW (backend->stage_view),
+                                       &frame_info);
+  backend->frame_pending = FALSE;
+}
+
+static void
+deactivate_consumer (MetaBackendAnland *backend)
+{
+  meta_anland_audio_set_fd (backend->audio, -1);
+  meta_anland_camera_clear (backend->camera);
+  meta_anland_clipboard_set_transport (backend->clipboard, NULL);
+
+  if (backend->input_source)
+    {
+      g_source_destroy (backend->input_source);
+      g_clear_pointer (&backend->input_source, g_source_unref);
+    }
+
+  if (backend->input)
+    meta_anland_input_reset (backend->input);
+
+  if (backend->buffer_ready_source)
+    {
+      g_source_destroy (backend->buffer_ready_source);
+      g_clear_pointer (&backend->buffer_ready_source, g_source_unref);
+    }
+
+  if (backend->stage_view)
+    {
+      clutter_stage_view_set_present_func (
+        CLUTTER_STAGE_VIEW (backend->stage_view), NULL, NULL);
+
+      if (backend->current_buffer >= 0 &&
+          backend->placeholder_framebuffer &&
+          clutter_stage_view_get_onscreen (CLUTTER_STAGE_VIEW (backend->stage_view)) ==
+            backend->buffer_framebuffers[backend->current_buffer])
+        clutter_stage_view_replace_framebuffer (
+          CLUTTER_STAGE_VIEW (backend->stage_view),
+          backend->placeholder_framebuffer);
+
+      if (backend->frame_pending)
+        clutter_stage_view_notify_ready (CLUTTER_STAGE_VIEW (backend->stage_view));
+    }
+
+  for (int i = 0; i < MAX_BUFS; i++)
+    g_clear_object (&backend->buffer_framebuffers[i]);
+
+  backend->consumer_active = FALSE;
+  backend->current_buffer = -1;
+  backend->frame_pending = FALSE;
+  inhibit_frame_clock (backend);
+}
+
+static gboolean
+on_stage_view_present (ClutterStageView *stage_view,
+                       ClutterFrame     *frame,
+                       int64_t           global_frame_counter,
+                       gpointer          user_data)
+{
+  MetaBackendAnland *backend = user_data;
+  CoglFramebuffer *framebuffer;
+  CoglContext *cogl_context;
+  int fence_fd = -1;
+
+  if (!backend->consumer_active || !backend->transport ||
+      meta_anland_transport_is_fallback (backend->transport))
+    return FALSE;
+
+  framebuffer = clutter_stage_view_get_onscreen (stage_view);
+  cogl_context = cogl_framebuffer_get_context (framebuffer);
+  cogl_framebuffer_flush (framebuffer);
+
+  if (cogl_context_has_feature (cogl_context, COGL_FEATURE_ID_SYNC_FD))
+    fence_fd = cogl_context_get_latest_sync_fd (cogl_context);
+  else
+    {
+      if (!backend->warned_sync_fallback)
+        {
+          g_warning ("Anland backend has no native fence support; using synchronous rendering");
+          backend->warned_sync_fallback = TRUE;
+        }
+      cogl_framebuffer_finish (framebuffer);
+    }
+
+  meta_anland_transport_set_render_fence (backend->transport, fence_fd);
+  if (!meta_anland_transport_notify_frame_done (backend->transport))
+    {
+      clutter_frame_set_result (frame, CLUTTER_FRAME_RESULT_IDLE);
+      return TRUE;
+    }
+
+  backend->pending_global_frame_counter = global_frame_counter;
+  backend->pending_view_frame_counter = clutter_frame_get_count (frame);
+  backend->frame_pending = TRUE;
+  inhibit_frame_clock (backend);
+  clutter_frame_set_result (frame, CLUTTER_FRAME_RESULT_PENDING_PRESENTED);
+  return TRUE;
+}
+
+static gboolean
+input_source_prepare (gpointer user_data)
+{
+  return FALSE;
+}
+
+static gboolean
+input_source_dispatch (gpointer user_data)
+{
+  MetaBackendAnland *backend = META_BACKEND_ANLAND (user_data);
+  struct InputEvent event;
+  int result;
+
+  if (!backend->consumer_active || !backend->transport || !backend->input ||
+      meta_anland_transport_is_fallback (backend->transport))
+    return G_SOURCE_REMOVE;
+
+  while ((result = meta_anland_transport_poll_input_event (
+             backend->transport, &event, 0)) > 0)
+    {
+      MetaAnlandInputEventResult input_result;
+
+      input_result = meta_anland_input_handle_event (backend->input,
+                                                      backend->transport,
+                                                      &event,
+                                                      backend->screen_info.width,
+                                                      backend->screen_info.height);
+      if (input_result == META_ANLAND_INPUT_EVENT_NEEDS_PAYLOAD)
+        {
+          if (!handle_extended_input (backend, &event))
+            {
+              meta_anland_transport_enter_fallback (backend->transport);
+              return G_SOURCE_REMOVE;
+            }
+        }
+      else if (input_result == META_ANLAND_INPUT_EVENT_NEEDS_RESOURCE_FDS)
+        {
+          if (!handle_resource_input (backend, &event))
+            {
+              meta_anland_transport_enter_fallback (backend->transport);
+              return G_SOURCE_REMOVE;
+            }
+        }
+      else if (input_result == META_ANLAND_INPUT_EVENT_ERROR)
+        {
+          meta_anland_transport_enter_fallback (backend->transport);
+          return G_SOURCE_REMOVE;
+        }
+
+      if (!backend->consumer_active)
+        return G_SOURCE_REMOVE;
+    }
+
+  return result < 0 ? G_SOURCE_REMOVE : G_SOURCE_CONTINUE;
+}
+
+static gboolean
+buffer_ready_source_prepare (gpointer user_data)
+{
+  return FALSE;
+}
+
+static gboolean
+buffer_ready_source_dispatch (gpointer user_data)
+{
+  MetaBackendAnland *backend = META_BACKEND_ANLAND (user_data);
+  eventfd_t count;
+  int buffer_ready_fd;
+  int selected_buffer;
+
+  if (!backend->consumer_active || !backend->transport ||
+      meta_anland_transport_is_fallback (backend->transport))
+    return G_SOURCE_REMOVE;
+
+  buffer_ready_fd = meta_anland_transport_get_buffer_ready_fd (backend->transport);
+  if (buffer_ready_fd < 0 || eventfd_read (buffer_ready_fd, &count) < 0 ||
+      count != 1)
+    {
+      meta_anland_transport_enter_fallback (backend->transport);
+      return G_SOURCE_REMOVE;
+    }
+
+  selected_buffer = meta_anland_transport_get_selected_buffer (backend->transport);
+  if (selected_buffer < 0 || selected_buffer >= MAX_BUFS ||
+      !backend->buffer_framebuffers[selected_buffer])
+    {
+      meta_anland_transport_enter_fallback (backend->transport);
+      return G_SOURCE_REMOVE;
+    }
+
+  complete_pending_frame (backend);
+
+  if (backend->current_buffer != selected_buffer)
+    {
+      clutter_stage_view_replace_framebuffer (
+        CLUTTER_STAGE_VIEW (backend->stage_view),
+        backend->buffer_framebuffers[selected_buffer]);
+      backend->current_buffer = selected_buffer;
+    }
+
+  clutter_stage_view_add_redraw_clip (CLUTTER_STAGE_VIEW (backend->stage_view),
+                                      NULL);
+  uninhibit_frame_clock (backend);
+  clutter_stage_view_schedule_update_now (CLUTTER_STAGE_VIEW (backend->stage_view));
+  return G_SOURCE_CONTINUE;
+}
+
+static gboolean
+activate_consumer (MetaBackendAnland *backend)
+{
+  MetaRenderer *renderer = meta_backend_get_renderer (META_BACKEND (backend));
+  MetaRendererNative *renderer_native = META_RENDERER_NATIVE (renderer);
+  CoglFramebuffer *framebuffers[MAX_BUFS] = { NULL, };
+  struct buf_info buffer_info;
+  int n_buffers;
+  int buffer_ready_fd;
+  int buffer_ready_source_fd = -1;
+  int input_fd;
+  int input_source_fd = -1;
+  int i;
+  g_autoptr (GError) error = NULL;
+
+  n_buffers = meta_anland_transport_get_buffer_count (backend->transport);
+  if (n_buffers < 1 || n_buffers > MAX_BUFS ||
+      !meta_anland_transport_get_buffer_info (backend->transport, 0,
+                                              &buffer_info))
+    goto failed;
+
+  if (buffer_info.width != backend->screen_info.width ||
+      buffer_info.height != backend->screen_info.height)
+    {
+      backend->screen_info.width = buffer_info.width;
+      backend->screen_info.height = buffer_info.height;
+      if (!update_virtual_monitor (backend, &error))
+        g_warning ("Failed to update the Anland virtual monitor: %s",
+                   error->message);
+      return FALSE;
+    }
+
+  if (!ensure_stage_view (backend, &error))
+    return FALSE;
+
+  if (!backend->clipboard)
+    {
+      g_set_error (&error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Anland clipboard bridge is unavailable");
+      goto failed;
+    }
+
+  if (cogl_framebuffer_get_width (backend->placeholder_framebuffer) !=
+        (int) buffer_info.width ||
+      cogl_framebuffer_get_height (backend->placeholder_framebuffer) !=
+        (int) buffer_info.height)
+    return FALSE;
+
+  if (backend->screen_info.refresh > 0 &&
+      fabsf (clutter_stage_view_get_refresh_rate (
+               CLUTTER_STAGE_VIEW (backend->stage_view)) -
+             backend->screen_info.refresh / 1000.0f) > 0.01f)
+    return FALSE;
+
+  for (i = 0; i < n_buffers; i++)
+    {
+      int fd;
+      uint32_t stride;
+      uint32_t offset;
+      uint64_t modifier;
+
+      if (!meta_anland_transport_get_buffer_info (backend->transport, i,
+                                                  &buffer_info))
+        goto failed;
+
+      fd = meta_anland_transport_get_buffer_fd (backend->transport, i);
+      if (fd < 0 || !validate_buffer_info (&buffer_info, fd, &error))
+        goto failed;
+
+      stride = buffer_info.stride;
+      offset = buffer_info.offset;
+      modifier = buffer_info.modifier;
+      framebuffers[i] = meta_renderer_native_create_dma_buf_framebuffer (
+        renderer_native, buffer_info.width, buffer_info.height,
+        DRM_FORMAT_ABGR8888, 1, &fd, &stride, &offset, &modifier, &error);
+      if (!framebuffers[i])
+        {
+          g_prefix_error (&error,
+                          "Failed to import Anland buffer %d "
+                          "(%ux%u, stride %u, offset %u, "
+                          "modifier %" G_GUINT64_FORMAT "): ",
+                          i, buffer_info.width, buffer_info.height,
+                          buffer_info.stride, buffer_info.offset,
+                          buffer_info.modifier);
+          goto failed;
+        }
+    }
+
+  buffer_ready_fd = meta_anland_transport_get_buffer_ready_fd (backend->transport);
+  buffer_ready_source_fd = fcntl (buffer_ready_fd, F_DUPFD_CLOEXEC, 3);
+  if (buffer_ready_source_fd < 0)
+    {
+      g_set_error (&error, G_IO_ERROR, g_io_error_from_errno (errno),
+                   "Failed to duplicate Anland buffer-ready eventfd");
+      goto failed;
+    }
+
+  input_fd = meta_anland_transport_get_data_fd (backend->transport);
+  input_source_fd = fcntl (input_fd, F_DUPFD_CLOEXEC, 3);
+  if (input_source_fd < 0)
+    {
+      g_set_error (&error, G_IO_ERROR, g_io_error_from_errno (errno),
+                   "Failed to duplicate Anland data fd");
+      goto failed;
+    }
+
+  for (i = 0; i < n_buffers; i++)
+    backend->buffer_framebuffers[i] = framebuffers[i];
+  backend->consumer_active = TRUE;
+  meta_anland_clipboard_set_transport (backend->clipboard, backend->transport);
+  backend->current_buffer = -1;
+  inhibit_frame_clock (backend);
+  clutter_stage_view_set_present_func (CLUTTER_STAGE_VIEW (backend->stage_view),
+                                       on_stage_view_present, backend);
+  backend->buffer_ready_source = meta_create_fd_source (
+    buffer_ready_source_fd, "[mutter] Anland buffer ready",
+    buffer_ready_source_prepare, buffer_ready_source_dispatch, backend, NULL);
+  g_source_attach (backend->buffer_ready_source, NULL);
+  backend->input_source = meta_create_fd_source (
+    input_source_fd, "[mutter] Anland input",
+    input_source_prepare, input_source_dispatch, backend, NULL);
+  g_source_attach (backend->input_source, NULL);
+  meta_anland_audio_set_fd (backend->audio,
+                            meta_anland_transport_get_audio_fd (
+                              backend->transport));
+  request_camera_resources (backend);
+  return TRUE;
+
+failed:
+  g_warning ("Failed to activate Anland consumer buffers: %s",
+             error ? error->message : "invalid transport state");
+  for (i = 0; i < MAX_BUFS; i++)
+    g_clear_object (&framebuffers[i]);
+  if (buffer_ready_source_fd >= 0)
+    close (buffer_ready_source_fd);
+  if (input_source_fd >= 0)
+    close (input_source_fd);
+  meta_anland_transport_enter_fallback (backend->transport);
+  return FALSE;
+}
+
+static gboolean reconnect_cb (gpointer user_data);
+
+static void
+schedule_reconnect (MetaBackendAnland *backend)
+{
+  if (backend->reconnect_source_id)
+    return;
+
+  backend->reconnect_source_id =
+    g_timeout_add (ANLAND_RECONNECT_INTERVAL_MS, reconnect_cb, backend);
+}
+
+static void
+on_transport_fallback (void *user_data)
+{
+  MetaBackendAnland *backend = user_data;
+
+  deactivate_consumer (backend);
+  schedule_reconnect (backend);
+}
+
+static void
+on_input_display_refresh (uint32_t refresh_mhz,
+                          gpointer user_data)
+{
+  MetaBackendAnland *backend = META_BACKEND_ANLAND (user_data);
+
+  if (backend->screen_info.refresh == refresh_mhz)
+    return;
+
+  backend->screen_info.refresh = refresh_mhz;
+  deactivate_consumer (backend);
+  if (!update_virtual_monitor (backend, NULL))
+    {
+      clear_transport (backend);
+      return;
+    }
+
+  schedule_reconnect (backend);
+}
+
+static gboolean
+reconnect_cb (gpointer user_data)
+{
+  MetaBackendAnland *backend = META_BACKEND_ANLAND (user_data);
+  MetaAnlandTransportPickupResult pickup_result;
+
+  if (!backend->transport)
+    {
+      if (!connect_transport (backend, NULL))
+        return G_SOURCE_CONTINUE;
+      if (!update_virtual_monitor (backend, NULL))
+        {
+          clear_transport (backend);
+          return G_SOURCE_CONTINUE;
+        }
+      meta_anland_transport_set_fallback_callback (backend->transport,
+                                                    on_transport_fallback,
+                                                    backend);
+    }
+
+  pickup_result = meta_anland_transport_try_pickup (backend->transport);
+  switch (pickup_result)
+    {
+    case META_ANLAND_TRANSPORT_PICKUP_READY:
+      if (!activate_consumer (backend))
+        return G_SOURCE_CONTINUE;
+      backend->reconnect_source_id = 0;
+      return G_SOURCE_REMOVE;
+    case META_ANLAND_TRANSPORT_PICKUP_NO_CONSUMER:
+      return G_SOURCE_CONTINUE;
+    case META_ANLAND_TRANSPORT_PICKUP_DAEMON_LOST:
+    case META_ANLAND_TRANSPORT_PICKUP_PROTOCOL_ERROR:
+      clear_transport (backend);
+      return G_SOURCE_CONTINUE;
+    }
+
+  g_assert_not_reached ();
+}
+
+static gboolean
+meta_backend_anland_init_post (MetaBackend  *backend,
+                               GError      **error)
+{
+  MetaBackendClass *parent_class =
+    META_BACKEND_CLASS (meta_backend_anland_parent_class);
+  MetaBackendAnland *backend_anland = META_BACKEND_ANLAND (backend);
+
+  if (!parent_class->init_post (backend, error))
+    return FALSE;
+
+  backend_anland->input = meta_anland_input_new (
+    backend, on_input_display_refresh, backend_anland, error);
+  if (!backend_anland->input)
+    return FALSE;
+
+  backend_anland->audio = meta_anland_audio_new ();
+  if (!backend_anland->audio)
+    g_warning ("Failed to initialize Anland audio bridge");
+
+  backend_anland->camera = meta_anland_camera_new ();
+  if (!backend_anland->camera)
+    g_warning ("Failed to initialize Anland camera bridge");
+
+  g_signal_connect_object (meta_backend_get_context (backend), "started",
+                           G_CALLBACK (on_context_started), backend, 0);
+
+  if (!connect_transport (backend_anland, error))
+    return FALSE;
+
+  meta_anland_transport_set_fallback_callback (backend_anland->transport,
+                                                on_transport_fallback,
+                                                backend_anland);
+  return TRUE;
+}
+
+static void
+meta_backend_anland_update_stage (MetaBackend *backend)
+{
+  MetaBackendAnland *backend_anland = META_BACKEND_ANLAND (backend);
+  MetaBackendClass *parent_class =
+    META_BACKEND_CLASS (meta_backend_anland_parent_class);
+  gboolean had_stage_view = backend_anland->stage_view != NULL;
+
+  if (backend_anland->consumer_active)
+    deactivate_consumer (backend_anland);
+  release_stage_view (backend_anland);
+
+  parent_class->update_stage (backend);
+
+  if (had_stage_view && backend_anland->transport)
+    schedule_reconnect (backend_anland);
+}
+
+static void
+meta_backend_anland_set_property (GObject      *object,
+                                  guint         prop_id,
+                                  const GValue *value,
+                                  GParamSpec   *pspec)
+{
+  MetaBackendAnland *backend = META_BACKEND_ANLAND (object);
+
+  switch (prop_id)
+    {
+    case PROP_ANLAND_SOCKET:
+      if (g_value_get_string (value))
+        {
+          g_free (backend->socket_path);
+          backend->socket_path = g_value_dup_string (value);
+        }
+      break;
+    default:
+      G_OBJECT_CLASS (meta_backend_anland_parent_class)->set_property (object,
+                                                                        prop_id,
+                                                                        value,
+                                                                        pspec);
+      break;
+    }
+}
+
+static void
+meta_backend_anland_dispose (GObject *object)
+{
+  MetaBackendAnland *backend = META_BACKEND_ANLAND (object);
+
+  g_clear_handle_id (&backend->reconnect_source_id, g_source_remove);
+  clear_transport (backend);
+  uninhibit_frame_clock (backend);
+  g_clear_pointer (&backend->audio, meta_anland_audio_free);
+  g_clear_pointer (&backend->camera, meta_anland_camera_free);
+  g_clear_pointer (&backend->clipboard, meta_anland_clipboard_free);
+  g_clear_pointer (&backend->input, meta_anland_input_free);
+  g_clear_object (&backend->placeholder_framebuffer);
+  g_clear_object (&backend->stage_view);
+  g_clear_object (&backend->virtual_monitor);
+  g_clear_pointer (&backend->socket_path, g_free);
+
+  G_OBJECT_CLASS (meta_backend_anland_parent_class)->dispose (object);
+}
+
+static void
+meta_backend_anland_class_init (MetaBackendAnlandClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  MetaBackendClass *backend_class = META_BACKEND_CLASS (klass);
+
+  object_class->set_property = meta_backend_anland_set_property;
+  object_class->dispose = meta_backend_anland_dispose;
+  backend_class->init_post = meta_backend_anland_init_post;
+  backend_class->update_stage = meta_backend_anland_update_stage;
+
+  g_object_class_install_property (
+    object_class, PROP_ANLAND_SOCKET,
+    g_param_spec_string ("anland-socket", NULL, NULL, NULL,
+                         G_PARAM_WRITABLE |
+                         G_PARAM_CONSTRUCT_ONLY |
+                         G_PARAM_STATIC_STRINGS));
+}
+
+static void
+meta_backend_anland_init (MetaBackendAnland *backend_anland)
+{
+  backend_anland->socket_path = get_default_socket_path ();
+  backend_anland->current_buffer = -1;
+}
+
+gboolean
+meta_backend_anland_setup (MetaBackendAnland  *backend,
+                           GError            **error)
+{
+  if (!update_virtual_monitor (backend, error))
+    return FALSE;
+
+  schedule_reconnect (backend);
+  return TRUE;
+}

--- a/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-backend-anland.h
+++ b/producers/gnome/Debian13_v5/mutter/src/backends/anland/meta-backend-anland.h
@@ -1,0 +1,14 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#pragma once
+
+#include "backends/native/meta-backend-native-private.h"
+
+#define META_TYPE_BACKEND_ANLAND (meta_backend_anland_get_type ())
+G_DECLARE_FINAL_TYPE (MetaBackendAnland,
+                      meta_backend_anland,
+                      META, BACKEND_ANLAND,
+                      MetaBackendNative)
+
+gboolean meta_backend_anland_setup (MetaBackendAnland  *backend,
+                                    GError            **error);

--- a/producers/gnome/Debian13_v5/mutter/src/backends/anland/vendor/meta-anland-protocol.h
+++ b/producers/gnome/Debian13_v5/mutter/src/backends/anland/vendor/meta-anland-protocol.h
@@ -1,0 +1,183 @@
+#ifndef META_ANLAND_PROTOCOL_H
+#define META_ANLAND_PROTOCOL_H
+
+#include <stdint.h>
+
+#define CTRL_MSG_CONSUMER_HELLO 1
+#define CTRL_MSG_PRODUCER_HELLO 2
+#define CTRL_MSG_SCREEN_INFO 7
+#define CTRL_MSG_REJECT 8
+#define CTRL_MSG_PICKUP_FDS 9
+#define CTRL_MSG_FDS_READY 10
+
+#define DATA_MSG_BUF_READY 100
+#define DATA_MSG_REFRESH_DONE 101
+#define DATA_MSG_INPUT_EVENT 102
+#define DATA_MSG_OUTPUT_EVENT 103
+#define DATA_MSG_INPUT_EXTEND_FDS 104
+#define DATA_MSG_BUFS_READY 200
+
+#define MAX_BUFS 8
+
+struct ctrl_msg
+{
+  uint32_t type;
+  uint32_t size;
+  uint8_t payload[];
+} __attribute__ ((packed));
+
+struct data_msg
+{
+  uint32_t type;
+  uint32_t size;
+  uint8_t payload[];
+} __attribute__ ((packed));
+
+struct screen_info
+{
+  uint32_t width;
+  uint32_t height;
+  uint32_t format;
+  uint32_t refresh;
+} __attribute__ ((packed));
+
+struct buf_info
+{
+  uint32_t stride;
+  uint32_t width;
+  uint32_t height;
+  uint32_t format;
+  uint64_t modifier;
+  uint32_t offset;
+} __attribute__ ((packed));
+
+#define INPUT_TYPE_TOUCH 1
+#define INPUT_TYPE_KEY 2
+#define INPUT_TYPE_POINTER_MOTION 3
+#define INPUT_TYPE_POINTER_BUTTON 4
+#define INPUT_TYPE_POINTER_AXIS 5
+#define INPUT_TYPE_TOUCH_FRAME 6
+#define INPUT_TYPE_DISPLAY_REFRESH 7
+#define INPUT_TYPE_CLIPBOARD 8
+#define INPUT_TYPE_TEXT_INPUT 9
+#define INPUT_TYPE_ACTION 10
+#define INPUT_TYPE_RESOURCE 11
+
+#define SERVICE_TYPE_CAMERA 1
+
+#define INPUT_ACTION_DOWN 0
+#define INPUT_ACTION_UP 1
+#define INPUT_ACTION_MOVE 2
+
+#define OUTPUT_TYPE_CLIPBOARD 1
+#define OUTPUT_TYPE_RESOURCES_REQUEST 2
+
+struct InputEvent
+{
+  uint32_t type;
+  union
+  {
+    struct
+    {
+      int32_t action;
+      float x;
+      float y;
+      int32_t pointer_id;
+    } touch;
+    struct
+    {
+      int32_t action;
+      int32_t keycode;
+    } key;
+    struct
+    {
+      float x;
+      float y;
+      float dx;
+      float dy;
+    } pointer_motion;
+    struct
+    {
+      uint32_t button;
+      int32_t pressed;
+    } pointer_button;
+    struct
+    {
+      uint32_t axis;
+      float value;
+      int32_t discrete;
+    } pointer_axis;
+    struct
+    {
+      uint32_t refresh_mhz;
+    } display;
+    struct
+    {
+      uint32_t size;
+    } clipboard;
+    struct
+    {
+      uint32_t size;
+    } text_input;
+    struct
+    {
+      uint32_t action;
+      int32_t value;
+    } input_action;
+    struct
+    {
+      uint32_t type;
+      uint32_t fdnum;
+    } resource;
+    struct
+    {
+      uint32_t padding[4];
+    };
+  };
+} __attribute__ ((packed));
+
+struct OutputEvent
+{
+  uint32_t type;
+  union
+  {
+    struct
+    {
+      uint32_t size;
+    } clipboard;
+    struct
+    {
+      uint32_t type;
+      uint32_t args[3];
+    } resources_request;
+    struct
+    {
+      uint32_t padding[4];
+    };
+  };
+} __attribute__ ((packed));
+
+#define AUDIO_MSG_FORMAT 1
+#define AUDIO_MSG_PCM 2
+
+#define AUDIO_FORMAT_S16LE 0
+
+#define AUDIO_ROLE_PLAYBACK 0
+#define AUDIO_ROLE_CAPTURE 1
+
+struct audio_format
+{
+  uint32_t rate;
+  uint32_t channels;
+  uint32_t format;
+  uint32_t role;
+  uint32_t quantum;
+} __attribute__ ((packed));
+
+struct audio_msg
+{
+  uint32_t type;
+  uint32_t size;
+} __attribute__ ((packed));
+
+#endif /* META_ANLAND_PROTOCOL_H */

--- a/producers/gnome/Debian13_v5/mutter/src/backends/anland/vendor/meta-anland-socket-utils.c
+++ b/producers/gnome/Debian13_v5/mutter/src/backends/anland/vendor/meta-anland-socket-utils.c
@@ -1,0 +1,210 @@
+#include "meta-anland-socket-utils.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+int
+meta_anland_connect_unix (const char *path)
+{
+  struct sockaddr_un address = { 0 };
+  int fd;
+
+  if (!path || strlen (path) >= sizeof (address.sun_path))
+    {
+      errno = ENAMETOOLONG;
+      return -1;
+    }
+
+  fd = socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd < 0)
+    return -1;
+
+  address.sun_family = AF_UNIX;
+  strcpy (address.sun_path, path);
+  if (connect (fd, (struct sockaddr *) &address, sizeof (address)) < 0)
+    {
+      close (fd);
+      return -1;
+    }
+
+  return fd;
+}
+
+int
+meta_anland_send_all (int         fd,
+                      const void *buffer,
+                      size_t      length)
+{
+  const uint8_t *data = buffer;
+  size_t sent = 0;
+
+  while (sent < length)
+    {
+      ssize_t n = send (fd, data + sent, length - sent, MSG_NOSIGNAL);
+
+      if (n > 0)
+        {
+          sent += n;
+          continue;
+        }
+      if (n < 0 && errno == EINTR)
+        continue;
+
+      return -1;
+    }
+
+  return 0;
+}
+
+int
+meta_anland_recv_all (int    fd,
+                      void  *buffer,
+                      size_t length)
+{
+  uint8_t *data = buffer;
+  size_t received = 0;
+
+  while (received < length)
+    {
+      ssize_t n = recv (fd, data + received, length - received, 0);
+
+      if (n > 0)
+        {
+          received += n;
+          continue;
+        }
+      if (n < 0 && errno == EINTR)
+        continue;
+
+      return -1;
+    }
+
+  return 0;
+}
+
+int
+meta_anland_send_fds (int         fd,
+                      const void *buffer,
+                      size_t      length,
+                      const int  *fds,
+                      int         n_fds)
+{
+  struct iovec iov = { .iov_base = (void *) buffer, .iov_len = length };
+  struct msghdr message = { .msg_iov = &iov, .msg_iovlen = 1 };
+  struct cmsghdr *cmsg;
+  size_t control_length;
+  char *control;
+  ssize_t n;
+
+  if (!buffer || length == 0 || !fds || n_fds <= 0)
+    {
+      errno = EINVAL;
+      return -1;
+    }
+
+  control_length = CMSG_SPACE (sizeof (int) * (size_t) n_fds);
+  control = calloc (1, control_length);
+  if (!control)
+    return -1;
+
+  message.msg_control = control;
+  message.msg_controllen = control_length;
+  cmsg = CMSG_FIRSTHDR (&message);
+  cmsg->cmsg_level = SOL_SOCKET;
+  cmsg->cmsg_type = SCM_RIGHTS;
+  cmsg->cmsg_len = CMSG_LEN (sizeof (int) * (size_t) n_fds);
+  memcpy (CMSG_DATA (cmsg), fds, sizeof (int) * (size_t) n_fds);
+
+  do
+    n = sendmsg (fd, &message, MSG_NOSIGNAL);
+  while (n < 0 && errno == EINTR);
+
+  free (control);
+  return n == (ssize_t) length ? 0 : -1;
+}
+
+int
+meta_anland_recv_fds (int    fd,
+                      void  *buffer,
+                      size_t length,
+                      int   *fds,
+                      int    max_fds,
+                      int   *n_fds)
+{
+  struct iovec iov = { .iov_base = buffer, .iov_len = length };
+  struct msghdr message = { .msg_iov = &iov, .msg_iovlen = 1 };
+  size_t control_length;
+  char *control;
+  ssize_t n;
+
+  if (!buffer || length == 0 || !fds || max_fds <= 0 || !n_fds)
+    {
+      errno = EINVAL;
+      return -1;
+    }
+
+  *n_fds = 0;
+  control_length = CMSG_SPACE (sizeof (int) * (size_t) max_fds);
+  control = calloc (1, control_length);
+  if (!control)
+    return -1;
+
+  message.msg_control = control;
+  message.msg_controllen = control_length;
+  do
+    n = recvmsg (fd, &message, MSG_CMSG_CLOEXEC);
+  while (n < 0 && errno == EINTR);
+
+  if (n <= 0)
+    goto fail;
+
+  for (struct cmsghdr *cmsg = CMSG_FIRSTHDR (&message);
+       cmsg;
+       cmsg = CMSG_NXTHDR (&message, cmsg))
+    {
+      int count;
+      int available;
+      int copy_count;
+
+      if (cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_RIGHTS)
+        continue;
+      if (cmsg->cmsg_len < CMSG_LEN (0) ||
+          (cmsg->cmsg_len - CMSG_LEN (0)) % sizeof (int) != 0)
+        goto fail;
+
+      count = (int) ((cmsg->cmsg_len - CMSG_LEN (0)) / sizeof (int));
+      available = max_fds - *n_fds;
+      copy_count = count < available ? count : available;
+      memcpy (fds + *n_fds, CMSG_DATA (cmsg),
+              sizeof (int) * (size_t) copy_count);
+      *n_fds += copy_count;
+      for (int i = copy_count; i < count; i++)
+        {
+          int received_fd;
+
+          memcpy (&received_fd, (int *) CMSG_DATA (cmsg) + i,
+                  sizeof (received_fd));
+          close (received_fd);
+        }
+    }
+
+  if (!(message.msg_flags & MSG_CTRUNC))
+    {
+      free (control);
+      return (int) n;
+    }
+
+  errno = EMSGSIZE;
+
+fail:
+  for (int i = 0; i < *n_fds; i++)
+    close (fds[i]);
+  *n_fds = 0;
+  free (control);
+  return -1;
+}

--- a/producers/gnome/Debian13_v5/mutter/src/backends/anland/vendor/meta-anland-socket-utils.h
+++ b/producers/gnome/Debian13_v5/mutter/src/backends/anland/vendor/meta-anland-socket-utils.h
@@ -1,0 +1,27 @@
+#ifndef META_ANLAND_SOCKET_UTILS_H
+#define META_ANLAND_SOCKET_UTILS_H
+
+#include <stddef.h>
+
+int meta_anland_connect_unix (const char *path);
+
+int meta_anland_send_all (int          fd,
+                          const void  *buffer,
+                          size_t       length);
+int meta_anland_recv_all (int    fd,
+                          void  *buffer,
+                          size_t length);
+
+int meta_anland_send_fds (int          fd,
+                          const void  *buffer,
+                          size_t       length,
+                          const int   *fds,
+                          int          n_fds);
+int meta_anland_recv_fds (int    fd,
+                          void  *buffer,
+                          size_t length,
+                          int   *fds,
+                          int    max_fds,
+                          int   *n_fds);
+
+#endif /* META_ANLAND_SOCKET_UTILS_H */

--- a/producers/gnome/Debian13_v5/mutter/src/backends/anland/vendor/meta-anland-transport.c
+++ b/producers/gnome/Debian13_v5/mutter/src/backends/anland/vendor/meta-anland-transport.c
@@ -1,0 +1,721 @@
+#include "meta-anland-transport.h"
+
+#include "meta-anland-socket-utils.h"
+
+#include <errno.h>
+#include <poll.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define HANDSHAKE_TIMEOUT_MS 100
+#define INITIAL_HANDSHAKE_TIMEOUT_MS 5000
+#define INPUT_TIMEOUT_MS 100
+
+struct _MetaAnlandTransport
+{
+  int control_fd;
+  int data_fd;
+  int buffer_ready_fd;
+  int fence_fd;
+  int shm_fd;
+  int audio_fd;
+  int pending_render_fence_fd;
+  volatile uint32_t *selected_buffer;
+
+  struct screen_info screen_info;
+  int buffer_fds[MAX_BUFS];
+  struct buf_info buffer_infos[MAX_BUFS];
+  int n_buffers;
+  bool fallback;
+
+  void (*fallback_callback) (void *user_data);
+  void *fallback_user_data;
+};
+
+static void
+close_fds (int *fds,
+           int  n_fds)
+{
+  for (int i = 0; i < n_fds; i++)
+    {
+      if (fds[i] >= 0)
+        close (fds[i]);
+    }
+}
+
+static void
+release_consumer_resources (MetaAnlandTransport *transport)
+{
+  for (int i = 0; i < transport->n_buffers; i++)
+    {
+      if (transport->buffer_fds[i] >= 0)
+        {
+          close (transport->buffer_fds[i]);
+          transport->buffer_fds[i] = -1;
+        }
+    }
+  transport->n_buffers = 0;
+
+  if (transport->selected_buffer)
+    {
+      munmap ((void *) transport->selected_buffer, sizeof (uint32_t));
+      transport->selected_buffer = NULL;
+    }
+
+  if (transport->data_fd >= 0)
+    close (transport->data_fd);
+  if (transport->buffer_ready_fd >= 0)
+    close (transport->buffer_ready_fd);
+  if (transport->fence_fd >= 0)
+    close (transport->fence_fd);
+  if (transport->shm_fd >= 0)
+    close (transport->shm_fd);
+  if (transport->audio_fd >= 0)
+    close (transport->audio_fd);
+  if (transport->pending_render_fence_fd >= 0)
+    close (transport->pending_render_fence_fd);
+
+  transport->data_fd = -1;
+  transport->buffer_ready_fd = -1;
+  transport->fence_fd = -1;
+  transport->shm_fd = -1;
+  transport->audio_fd = -1;
+  transport->pending_render_fence_fd = -1;
+}
+
+static void
+enter_fallback (MetaAnlandTransport *transport)
+{
+  if (transport->fallback)
+    return;
+
+  transport->fallback = true;
+  if (transport->fallback_callback)
+    transport->fallback_callback (transport->fallback_user_data);
+  release_consumer_resources (transport);
+}
+
+static int
+wait_for_fd (int fd,
+             short events,
+             int timeout_ms)
+{
+  struct pollfd poll_fd = { .fd = fd, .events = events };
+  int result;
+
+  do
+    result = poll (&poll_fd, 1, timeout_ms);
+  while (result < 0 && errno == EINTR);
+
+  if (result <= 0)
+    return result;
+  if (poll_fd.revents & (POLLERR | POLLHUP | POLLNVAL))
+    return -1;
+  return poll_fd.revents & events ? 1 : -1;
+}
+
+static int
+recv_all_timeout (int    fd,
+                  void  *buffer,
+                  size_t size,
+                  int    timeout_ms)
+{
+  uint8_t *data = buffer;
+  size_t received = 0;
+
+  while (received < size)
+    {
+      ssize_t n = recv (fd, data + received, size - received, MSG_DONTWAIT);
+
+      if (n > 0)
+        {
+          received += n;
+          continue;
+        }
+      if (n == 0)
+        return -1;
+      if (errno == EINTR)
+        continue;
+      if (errno != EAGAIN)
+        return -1;
+      if (wait_for_fd (fd, POLLIN, timeout_ms) != 1)
+        return -1;
+    }
+
+  return 0;
+}
+
+static int
+send_all_timeout (int         fd,
+                  const void *buffer,
+                  size_t      size,
+                  int         timeout_ms)
+{
+  const uint8_t *data = buffer;
+  size_t sent = 0;
+
+  while (sent < size)
+    {
+      ssize_t n = send (fd, data + sent, size - sent,
+                        MSG_NOSIGNAL | MSG_DONTWAIT);
+
+      if (n > 0)
+        {
+          sent += n;
+          continue;
+        }
+      if (n < 0 && errno == EINTR)
+        continue;
+      if (n < 0 && errno == EAGAIN &&
+          wait_for_fd (fd, POLLOUT, timeout_ms) == 1)
+        continue;
+
+      return -1;
+    }
+
+  return 0;
+}
+
+static int
+recv_fds_exact (int    fd,
+                void  *buffer,
+                size_t size,
+                int   *fds,
+                int    max_fds,
+                int   *n_fds)
+{
+  int received;
+
+  received = meta_anland_recv_fds (fd, buffer, size, fds, max_fds, n_fds);
+  if (received < 0)
+    return -1;
+  if ((size_t) received < size &&
+      meta_anland_recv_all (fd, (uint8_t *) buffer + received,
+                            size - (size_t) received) < 0)
+    return -1;
+
+  return 0;
+}
+
+static int
+discard_data_payload (MetaAnlandTransport *transport,
+                      uint32_t             size)
+{
+  uint8_t buffer[4096];
+
+  if (size > META_ANLAND_MAX_PAYLOAD_SIZE)
+    return -1;
+
+  while (size > 0)
+    {
+      size_t chunk = size < sizeof (buffer) ? size : sizeof (buffer);
+
+      if (recv_all_timeout (transport->data_fd, buffer, chunk,
+                            INPUT_TIMEOUT_MS) < 0)
+        return -1;
+      size -= (uint32_t) chunk;
+    }
+
+  return 0;
+}
+
+static MetaAnlandTransportPickupResult
+pickup_fds (MetaAnlandTransport *transport)
+{
+  struct ctrl_msg request = { .type = CTRL_MSG_PICKUP_FDS, .size = 0 };
+  struct ctrl_msg response;
+  int fds[5] = { -1, -1, -1, -1, -1 };
+  int n_fds = 0;
+  int wait_result;
+
+  if (meta_anland_send_all (transport->control_fd, &request,
+                            sizeof (request)) < 0)
+    return META_ANLAND_TRANSPORT_PICKUP_DAEMON_LOST;
+
+  wait_result = wait_for_fd (transport->control_fd, POLLIN,
+                             HANDSHAKE_TIMEOUT_MS);
+  if (wait_result == 0)
+    return META_ANLAND_TRANSPORT_PICKUP_NO_CONSUMER;
+  if (wait_result < 0 ||
+      recv_fds_exact (transport->control_fd, &response, sizeof (response),
+                      fds, 5, &n_fds) < 0)
+    {
+      close_fds (fds, n_fds);
+      return META_ANLAND_TRANSPORT_PICKUP_DAEMON_LOST;
+    }
+
+  if (response.type != CTRL_MSG_FDS_READY || response.size != 0 || n_fds != 5)
+    {
+      close_fds (fds, n_fds);
+      return META_ANLAND_TRANSPORT_PICKUP_PROTOCOL_ERROR;
+    }
+
+  transport->buffer_ready_fd = fds[0];
+  transport->fence_fd = fds[1];
+  transport->data_fd = fds[2];
+  transport->shm_fd = fds[3];
+  transport->audio_fd = fds[4];
+  transport->selected_buffer = mmap (NULL, sizeof (uint32_t), PROT_READ,
+                                     MAP_SHARED, transport->shm_fd, 0);
+  if (transport->selected_buffer == MAP_FAILED)
+    {
+      transport->selected_buffer = NULL;
+      return META_ANLAND_TRANSPORT_PICKUP_PROTOCOL_ERROR;
+    }
+
+  return META_ANLAND_TRANSPORT_PICKUP_READY;
+}
+
+static MetaAnlandTransportPickupResult
+receive_buffers (MetaAnlandTransport *transport)
+{
+  struct data_msg header;
+  struct buf_info buffer_infos[MAX_BUFS];
+  int fds[MAX_BUFS] = { -1, -1, -1, -1, -1, -1, -1, -1 };
+  int n_fds = 0;
+  int n_buffers;
+
+  if (wait_for_fd (transport->data_fd, POLLIN, HANDSHAKE_TIMEOUT_MS) != 1 ||
+      recv_fds_exact (transport->data_fd, &header, sizeof (header),
+                      fds, MAX_BUFS, &n_fds) < 0)
+    {
+      close_fds (fds, n_fds);
+      return META_ANLAND_TRANSPORT_PICKUP_NO_CONSUMER;
+    }
+
+  if (header.type != DATA_MSG_BUFS_READY || header.size == 0 ||
+      header.size % sizeof (struct buf_info) != 0)
+    goto protocol_error;
+
+  n_buffers = (int) (header.size / sizeof (struct buf_info));
+  if (n_buffers != n_fds || n_buffers < 1 || n_buffers > MAX_BUFS ||
+      meta_anland_recv_all (transport->data_fd, buffer_infos,
+                            header.size) < 0)
+    goto protocol_error;
+
+  for (int i = 0; i < n_buffers; i++)
+    {
+      if (buffer_infos[i].width == 0 || buffer_infos[i].height == 0 ||
+          buffer_infos[i].stride == 0 ||
+          (i > 0 && (buffer_infos[i].width != buffer_infos[0].width ||
+                     buffer_infos[i].height != buffer_infos[0].height ||
+                     buffer_infos[i].format != buffer_infos[0].format)))
+        goto protocol_error;
+    }
+
+  for (int i = 0; i < n_buffers; i++)
+    {
+      transport->buffer_fds[i] = fds[i];
+      transport->buffer_infos[i] = buffer_infos[i];
+    }
+  transport->n_buffers = n_buffers;
+  return META_ANLAND_TRANSPORT_PICKUP_READY;
+
+protocol_error:
+  close_fds (fds, n_fds);
+  return META_ANLAND_TRANSPORT_PICKUP_PROTOCOL_ERROR;
+}
+
+int
+meta_anland_transport_connect (MetaAnlandTransport **out_transport,
+                               const char           *socket_path)
+{
+  MetaAnlandTransport *transport;
+  struct ctrl_msg request = { .type = CTRL_MSG_PRODUCER_HELLO, .size = 0 };
+  struct ctrl_msg response;
+  struct screen_info screen_info;
+  int wait_result;
+
+  if (!out_transport || !socket_path)
+    return -1;
+
+  *out_transport = NULL;
+  transport = calloc (1, sizeof (*transport));
+  if (!transport)
+    return -1;
+
+  transport->control_fd = -1;
+  transport->data_fd = -1;
+  transport->buffer_ready_fd = -1;
+  transport->fence_fd = -1;
+  transport->shm_fd = -1;
+  transport->audio_fd = -1;
+  transport->pending_render_fence_fd = -1;
+  transport->fallback = true;
+  for (int i = 0; i < MAX_BUFS; i++)
+    transport->buffer_fds[i] = -1;
+
+  transport->control_fd = meta_anland_connect_unix (socket_path);
+  if (transport->control_fd < 0 ||
+      meta_anland_send_all (transport->control_fd, &request,
+                            sizeof (request)) < 0)
+    goto failed;
+
+  wait_result = wait_for_fd (transport->control_fd, POLLIN,
+                             INITIAL_HANDSHAKE_TIMEOUT_MS);
+  if (wait_result != 1 ||
+      recv_all_timeout (transport->control_fd, &response, sizeof (response),
+                        INITIAL_HANDSHAKE_TIMEOUT_MS) < 0 ||
+      response.type != CTRL_MSG_SCREEN_INFO ||
+      response.size != sizeof (screen_info) ||
+      recv_all_timeout (transport->control_fd, &screen_info,
+                        sizeof (screen_info), INITIAL_HANDSHAKE_TIMEOUT_MS) < 0)
+    goto failed;
+
+  transport->screen_info = screen_info;
+  *out_transport = transport;
+  return 0;
+
+failed:
+  if (transport->control_fd >= 0)
+    close (transport->control_fd);
+  free (transport);
+  return -1;
+}
+
+void
+meta_anland_transport_disconnect (MetaAnlandTransport *transport)
+{
+  if (!transport)
+    return;
+
+  release_consumer_resources (transport);
+  if (transport->control_fd >= 0)
+    close (transport->control_fd);
+  free (transport);
+}
+
+bool
+meta_anland_transport_get_screen_info (MetaAnlandTransport *transport,
+                                       struct screen_info   *screen_info)
+{
+  if (!transport || !screen_info)
+    return false;
+
+  *screen_info = transport->screen_info;
+  return true;
+}
+
+MetaAnlandTransportPickupResult
+meta_anland_transport_try_pickup (MetaAnlandTransport *transport)
+{
+  MetaAnlandTransportPickupResult result;
+
+  if (!transport)
+    return META_ANLAND_TRANSPORT_PICKUP_PROTOCOL_ERROR;
+  if (!transport->fallback)
+    return META_ANLAND_TRANSPORT_PICKUP_READY;
+
+  result = pickup_fds (transport);
+  if (result != META_ANLAND_TRANSPORT_PICKUP_READY)
+    {
+      release_consumer_resources (transport);
+      return result;
+    }
+
+  result = receive_buffers (transport);
+  if (result != META_ANLAND_TRANSPORT_PICKUP_READY)
+    {
+      release_consumer_resources (transport);
+      return result;
+    }
+
+  transport->fallback = false;
+  return META_ANLAND_TRANSPORT_PICKUP_READY;
+}
+
+bool
+meta_anland_transport_is_fallback (MetaAnlandTransport *transport)
+{
+  return !transport || transport->fallback;
+}
+
+void
+meta_anland_transport_enter_fallback (MetaAnlandTransport *transport)
+{
+  if (transport)
+    enter_fallback (transport);
+}
+
+void
+meta_anland_transport_set_fallback_callback (MetaAnlandTransport *transport,
+                                             void                 (*callback) (void *user_data),
+                                             void                  *user_data)
+{
+  transport->fallback_callback = callback;
+  transport->fallback_user_data = user_data;
+}
+
+int
+meta_anland_transport_get_buffer_ready_fd (MetaAnlandTransport *transport)
+{
+  return transport && !transport->fallback ? transport->buffer_ready_fd : -1;
+}
+
+int
+meta_anland_transport_get_data_fd (MetaAnlandTransport *transport)
+{
+  return transport && !transport->fallback ? transport->data_fd : -1;
+}
+
+int
+meta_anland_transport_get_audio_fd (MetaAnlandTransport *transport)
+{
+  return transport && !transport->fallback ? transport->audio_fd : -1;
+}
+
+int
+meta_anland_transport_get_buffer_count (MetaAnlandTransport *transport)
+{
+  return transport && !transport->fallback ? transport->n_buffers : 0;
+}
+
+int
+meta_anland_transport_get_selected_buffer (MetaAnlandTransport *transport)
+{
+  uint32_t selected;
+
+  if (!transport || transport->fallback || !transport->selected_buffer)
+    return -1;
+
+  selected = *transport->selected_buffer;
+  return selected < (uint32_t) transport->n_buffers ? (int) selected : -1;
+}
+
+int
+meta_anland_transport_get_buffer_fd (MetaAnlandTransport *transport,
+                                     int                   index)
+{
+  if (!transport || transport->fallback || index < 0 ||
+      index >= transport->n_buffers)
+    return -1;
+
+  return transport->buffer_fds[index];
+}
+
+bool
+meta_anland_transport_get_buffer_info (MetaAnlandTransport *transport,
+                                       int                   index,
+                                       struct buf_info      *buffer_info)
+{
+  if (!transport || !buffer_info || transport->fallback || index < 0 ||
+      index >= transport->n_buffers)
+    return false;
+
+  *buffer_info = transport->buffer_infos[index];
+  return true;
+}
+
+void
+meta_anland_transport_set_render_fence (MetaAnlandTransport *transport,
+                                        int                   fence_fd)
+{
+  if (!transport)
+    {
+      if (fence_fd >= 0)
+        close (fence_fd);
+      return;
+    }
+
+  if (transport->pending_render_fence_fd >= 0)
+    close (transport->pending_render_fence_fd);
+  transport->pending_render_fence_fd = fence_fd;
+}
+
+bool
+meta_anland_transport_notify_frame_done (MetaAnlandTransport *transport)
+{
+  struct iovec iov;
+  struct msghdr message = { 0 };
+  char byte = 0;
+  union
+  {
+    char bytes[CMSG_SPACE (sizeof (int))];
+    struct cmsghdr align;
+  } control = { 0 };
+  ssize_t n;
+
+  if (!transport)
+    return false;
+  if (transport->fallback)
+    {
+      if (transport->pending_render_fence_fd >= 0)
+        close (transport->pending_render_fence_fd);
+      transport->pending_render_fence_fd = -1;
+      return false;
+    }
+
+  iov.iov_base = &byte;
+  iov.iov_len = sizeof (byte);
+  message.msg_iov = &iov;
+  message.msg_iovlen = 1;
+  if (transport->pending_render_fence_fd >= 0)
+    {
+      struct cmsghdr *cmsg;
+
+      message.msg_control = control.bytes;
+      message.msg_controllen = sizeof (control.bytes);
+      cmsg = CMSG_FIRSTHDR (&message);
+      cmsg->cmsg_level = SOL_SOCKET;
+      cmsg->cmsg_type = SCM_RIGHTS;
+      cmsg->cmsg_len = CMSG_LEN (sizeof (int));
+      memcpy (CMSG_DATA (cmsg), &transport->pending_render_fence_fd,
+              sizeof (transport->pending_render_fence_fd));
+    }
+
+  do
+    n = sendmsg (transport->fence_fd, &message, MSG_NOSIGNAL | MSG_DONTWAIT);
+  while (n < 0 && errno == EINTR);
+
+  if (transport->pending_render_fence_fd >= 0)
+    {
+      close (transport->pending_render_fence_fd);
+      transport->pending_render_fence_fd = -1;
+    }
+
+  if (n == 1)
+    return true;
+
+  enter_fallback (transport);
+  return false;
+}
+
+int
+meta_anland_transport_poll_input_event (MetaAnlandTransport *transport,
+                                        struct InputEvent    *event,
+                                        int                   timeout_ms)
+{
+  struct data_msg header;
+
+  if (!transport || !event || transport->fallback)
+    return 0;
+
+  for (;;)
+    {
+      int wait_result = wait_for_fd (transport->data_fd, POLLIN, timeout_ms);
+
+      if (wait_result == 0)
+        return 0;
+      if (wait_result < 0 ||
+          recv_all_timeout (transport->data_fd, &header, sizeof (header),
+                            INPUT_TIMEOUT_MS) < 0)
+        {
+          enter_fallback (transport);
+          return -1;
+        }
+
+      if (header.type != DATA_MSG_INPUT_EVENT)
+        {
+          if (discard_data_payload (transport, header.size) < 0)
+            {
+              enter_fallback (transport);
+              return -1;
+            }
+          timeout_ms = 0;
+          continue;
+        }
+
+      if (header.size != sizeof (*event) ||
+          recv_all_timeout (transport->data_fd, event, sizeof (*event),
+                            INPUT_TIMEOUT_MS) < 0)
+        {
+          enter_fallback (transport);
+          return -1;
+        }
+
+      return 1;
+    }
+}
+
+int
+meta_anland_transport_read_input_payload (MetaAnlandTransport *transport,
+                                          void                 *payload,
+                                          size_t                size,
+                                          int                   timeout_ms)
+{
+  if (!transport || transport->fallback)
+    return 0;
+  if (size == 0)
+    return 1;
+  if (size > META_ANLAND_MAX_PAYLOAD_SIZE || !payload ||
+      recv_all_timeout (transport->data_fd, payload, size,
+                                    timeout_ms) < 0)
+    {
+      enter_fallback (transport);
+      return -1;
+    }
+
+  return 1;
+}
+
+int
+meta_anland_transport_read_input_fds (MetaAnlandTransport *transport,
+                                      int                  *fds,
+                                      int                   max_fds,
+                                      int                  *n_fds,
+                                      int                   timeout_ms)
+{
+  struct data_msg header;
+
+  if (!n_fds)
+    return -1;
+  *n_fds = 0;
+  if (!transport || transport->fallback)
+    return 0;
+  if (wait_for_fd (transport->data_fd, POLLIN, timeout_ms) != 1 ||
+      recv_fds_exact (transport->data_fd, &header, sizeof (header), fds,
+                      max_fds, n_fds) < 0 ||
+      header.type != DATA_MSG_INPUT_EXTEND_FDS || header.size != 0 ||
+      *n_fds < 1)
+    {
+      close_fds (fds, *n_fds);
+      *n_fds = 0;
+      enter_fallback (transport);
+      return -1;
+    }
+
+  return 1;
+}
+
+bool
+meta_anland_transport_send_output_event (MetaAnlandTransport     *transport,
+                                         const struct OutputEvent *event,
+                                         const void               *payload,
+                                         size_t                    payload_size)
+{
+  struct data_msg header = { .type = DATA_MSG_OUTPUT_EVENT,
+                             .size = sizeof (*event) };
+  size_t size;
+  uint8_t *message;
+
+  if (!transport || !event || transport->fallback ||
+      (payload_size > 0 && !payload) ||
+      payload_size > META_ANLAND_MAX_PAYLOAD_SIZE ||
+      payload_size > SIZE_MAX - sizeof (header) - sizeof (*event))
+    return false;
+
+  size = sizeof (header) + sizeof (*event) + payload_size;
+  message = malloc (size);
+  if (!message)
+    return false;
+
+  memcpy (message, &header, sizeof (header));
+  memcpy (message + sizeof (header), event, sizeof (*event));
+  if (payload_size > 0)
+    memcpy (message + sizeof (header) + sizeof (*event), payload, payload_size);
+
+  if (send_all_timeout (transport->data_fd, message, size,
+                        INPUT_TIMEOUT_MS) < 0)
+    {
+      free (message);
+      enter_fallback (transport);
+      return false;
+    }
+
+  free (message);
+  return true;
+}

--- a/producers/gnome/Debian13_v5/mutter/src/backends/anland/vendor/meta-anland-transport.h
+++ b/producers/gnome/Debian13_v5/mutter/src/backends/anland/vendor/meta-anland-transport.h
@@ -1,0 +1,71 @@
+#ifndef META_ANLAND_TRANSPORT_H
+#define META_ANLAND_TRANSPORT_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "meta-anland-protocol.h"
+
+typedef struct _MetaAnlandTransport MetaAnlandTransport;
+
+#define META_ANLAND_MAX_PAYLOAD_SIZE (1024 * 1024)
+
+typedef enum
+{
+  META_ANLAND_TRANSPORT_PICKUP_READY,
+  META_ANLAND_TRANSPORT_PICKUP_NO_CONSUMER,
+  META_ANLAND_TRANSPORT_PICKUP_DAEMON_LOST = -1,
+  META_ANLAND_TRANSPORT_PICKUP_PROTOCOL_ERROR = -2,
+} MetaAnlandTransportPickupResult;
+
+int meta_anland_transport_connect (MetaAnlandTransport **transport,
+                                   const char           *socket_path);
+void meta_anland_transport_disconnect (MetaAnlandTransport *transport);
+
+bool meta_anland_transport_get_screen_info (MetaAnlandTransport *transport,
+                                            struct screen_info   *screen_info);
+
+MetaAnlandTransportPickupResult
+meta_anland_transport_try_pickup (MetaAnlandTransport *transport);
+
+bool meta_anland_transport_is_fallback (MetaAnlandTransport *transport);
+void meta_anland_transport_enter_fallback (MetaAnlandTransport *transport);
+void meta_anland_transport_set_fallback_callback (MetaAnlandTransport *transport,
+                                                  void                 (*callback) (void *user_data),
+                                                  void                  *user_data);
+
+int meta_anland_transport_get_buffer_ready_fd (MetaAnlandTransport *transport);
+int meta_anland_transport_get_data_fd (MetaAnlandTransport *transport);
+int meta_anland_transport_get_audio_fd (MetaAnlandTransport *transport);
+int meta_anland_transport_get_buffer_count (MetaAnlandTransport *transport);
+int meta_anland_transport_get_selected_buffer (MetaAnlandTransport *transport);
+int meta_anland_transport_get_buffer_fd (MetaAnlandTransport *transport,
+                                         int                   index);
+bool meta_anland_transport_get_buffer_info (MetaAnlandTransport *transport,
+                                            int                   index,
+                                            struct buf_info      *buffer_info);
+
+void meta_anland_transport_set_render_fence (MetaAnlandTransport *transport,
+                                             int                   fence_fd);
+bool meta_anland_transport_notify_frame_done (MetaAnlandTransport *transport);
+
+int meta_anland_transport_poll_input_event (MetaAnlandTransport *transport,
+                                            struct InputEvent    *event,
+                                            int                   timeout_ms);
+int meta_anland_transport_read_input_payload (MetaAnlandTransport *transport,
+                                              void                 *payload,
+                                              size_t                size,
+                                              int                   timeout_ms);
+int meta_anland_transport_read_input_fds (MetaAnlandTransport *transport,
+                                          int                  *fds,
+                                          int                   max_fds,
+                                          int                  *n_fds,
+                                          int                   timeout_ms);
+
+bool meta_anland_transport_send_output_event (MetaAnlandTransport     *transport,
+                                              const struct OutputEvent *event,
+                                              const void               *payload,
+                                              size_t                    payload_size);
+
+#endif /* META_ANLAND_TRANSPORT_H */

--- a/producers/gnome/Debian13_v5/mutter/src/tests/anland-transport-tests.c
+++ b/producers/gnome/Debian13_v5/mutter/src/tests/anland-transport-tests.c
@@ -1,0 +1,503 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "meta-anland-socket-utils.h"
+#include "meta-anland-transport.h"
+
+_Static_assert (sizeof (struct ctrl_msg) == 8,
+                "Anland control header ABI changed");
+_Static_assert (sizeof (struct data_msg) == 8,
+                "Anland data header ABI changed");
+_Static_assert (sizeof (struct screen_info) == 16,
+                "Anland screen info ABI changed");
+_Static_assert (sizeof (struct buf_info) == 28,
+                "Anland buffer metadata ABI changed");
+_Static_assert (sizeof (struct InputEvent) == 20,
+                "Anland input event ABI changed");
+_Static_assert (sizeof (struct OutputEvent) == 20,
+                "Anland output event ABI changed");
+_Static_assert (sizeof (struct audio_format) == 20,
+                "Anland audio format ABI changed");
+_Static_assert (sizeof (struct audio_msg) == 8,
+                "Anland audio header ABI changed");
+
+typedef struct
+{
+  int ready;
+  int fence;
+  int data;
+  int audio;
+} MockPeers;
+
+typedef struct
+{
+  int listen_fd;
+  GMutex lock;
+  MockPeers peers;
+  gboolean delay_first_pickup;
+  gboolean failed;
+} MockDaemon;
+
+static void
+close_fd (int *fd)
+{
+  if (*fd >= 0)
+    {
+      close (*fd);
+      *fd = -1;
+    }
+}
+
+static void
+close_peers (MockDaemon *daemon)
+{
+  MockPeers peers;
+
+  g_mutex_lock (&daemon->lock);
+  peers = daemon->peers;
+  daemon->peers = (MockPeers) { -1, -1, -1, -1 };
+  g_mutex_unlock (&daemon->lock);
+
+  close_fd (&peers.ready);
+  close_fd (&peers.fence);
+  close_fd (&peers.data);
+  close_fd (&peers.audio);
+}
+
+static MockPeers
+get_peers (MockDaemon *daemon)
+{
+  MockPeers peers;
+
+  g_mutex_lock (&daemon->lock);
+  peers = daemon->peers;
+  g_mutex_unlock (&daemon->lock);
+  return peers;
+}
+
+static int
+new_memfd (const char *name,
+           size_t      size)
+{
+  int fd = memfd_create (name, MFD_CLOEXEC);
+
+  if (fd < 0 || ftruncate (fd, (off_t) size) < 0)
+    {
+      close_fd (&fd);
+      return -1;
+    }
+
+  return fd;
+}
+
+static gboolean
+send_screen_info (int control_fd)
+{
+  struct ctrl_msg header = {
+    .type = CTRL_MSG_SCREEN_INFO,
+    .size = sizeof (struct screen_info),
+  };
+  struct screen_info info = {
+    .width = 1920,
+    .height = 1080,
+    .format = 1,
+    .refresh = 120000,
+  };
+
+  return meta_anland_send_all (control_fd, &header, sizeof (header)) == 0 &&
+         meta_anland_send_all (control_fd, &info, sizeof (info)) == 0;
+}
+
+static gboolean
+send_buffers (int data_fd)
+{
+  struct data_msg header = {
+    .type = DATA_MSG_BUFS_READY,
+    .size = 2 * sizeof (struct buf_info),
+  };
+  struct buf_info infos[2] = {
+    { .stride = 5120, .width = 1280, .height = 720,
+      .format = 1, .modifier = 0, .offset = 0 },
+    { .stride = 5120, .width = 1280, .height = 720,
+      .format = 1, .modifier = 0, .offset = 0 },
+  };
+  int fds[2] = {
+    new_memfd ("mutter-anland-buffer-0", 4096),
+    new_memfd ("mutter-anland-buffer-1", 4096),
+  };
+  gboolean result;
+
+  result = fds[0] >= 0 && fds[1] >= 0 &&
+           meta_anland_send_fds (data_fd, &header, sizeof (header), fds, 2) == 0 &&
+           meta_anland_send_all (data_fd, infos, sizeof (infos)) == 0;
+  close_fd (&fds[0]);
+  close_fd (&fds[1]);
+  return result;
+}
+
+static gboolean
+publish_consumer (MockDaemon *daemon,
+                  int         control_fd)
+{
+  struct ctrl_msg response = { .type = CTRL_MSG_FDS_READY, .size = 0 };
+  int ready = -1;
+  int fence[2] = { -1, -1 };
+  int data[2] = { -1, -1 };
+  int audio[2] = { -1, -1 };
+  int shm_fd = -1;
+  int producer_fds[5];
+  uint32_t selected = 1;
+  gboolean result = FALSE;
+
+  ready = eventfd (0, EFD_CLOEXEC);
+  if (ready < 0 ||
+      socketpair (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, fence) < 0 ||
+      socketpair (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, data) < 0 ||
+      socketpair (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, audio) < 0)
+    goto out;
+  shm_fd = new_memfd ("mutter-anland-index", sizeof (selected));
+  if (shm_fd < 0 || pwrite (shm_fd, &selected, sizeof (selected), 0) !=
+                   (ssize_t) sizeof (selected))
+    goto out;
+
+  producer_fds[0] = ready;
+  producer_fds[1] = fence[0];
+  producer_fds[2] = data[0];
+  producer_fds[3] = shm_fd;
+  producer_fds[4] = audio[0];
+  if (meta_anland_send_fds (control_fd, &response, sizeof (response),
+                            producer_fds, G_N_ELEMENTS (producer_fds)) < 0)
+    goto out;
+
+  g_mutex_lock (&daemon->lock);
+  daemon->peers = (MockPeers) {
+    .ready = ready, .fence = fence[1], .data = data[1], .audio = audio[1],
+  };
+  g_mutex_unlock (&daemon->lock);
+  ready = fence[1] = data[1] = audio[1] = -1;
+  if (!send_buffers (get_peers (daemon).data))
+    goto out;
+  result = TRUE;
+
+out:
+  close_fd (&ready);
+  close_fd (&fence[0]);
+  close_fd (&fence[1]);
+  close_fd (&data[0]);
+  close_fd (&data[1]);
+  close_fd (&audio[0]);
+  close_fd (&audio[1]);
+  close_fd (&shm_fd);
+  if (!result)
+    close_peers (daemon);
+  return result;
+}
+
+static gpointer
+mock_daemon_thread (gpointer user_data)
+{
+  MockDaemon *daemon = user_data;
+  struct ctrl_msg request;
+  int control_fd = -1;
+
+  control_fd = accept4 (daemon->listen_fd, NULL, NULL, SOCK_CLOEXEC);
+  if (control_fd < 0 ||
+      meta_anland_recv_all (control_fd, &request, sizeof (request)) < 0 ||
+      request.type != CTRL_MSG_PRODUCER_HELLO || request.size != 0 ||
+      !send_screen_info (control_fd))
+    goto failed;
+
+  while (meta_anland_recv_all (control_fd, &request, sizeof (request)) == 0)
+    {
+      if (request.type != CTRL_MSG_PICKUP_FDS || request.size != 0)
+        goto failed;
+      if (daemon->delay_first_pickup)
+        {
+          daemon->delay_first_pickup = FALSE;
+          continue;
+        }
+      if (!publish_consumer (daemon, control_fd))
+        goto failed;
+    }
+
+  close_fd (&control_fd);
+  return NULL;
+
+failed:
+  daemon->failed = TRUE;
+  close_fd (&control_fd);
+  return NULL;
+}
+
+static int
+create_listener (const char *path)
+{
+  struct sockaddr_un address = { 0 };
+  int fd;
+
+  fd = socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd < 0)
+    return -1;
+  address.sun_family = AF_UNIX;
+  if (strlen (path) >= sizeof (address.sun_path))
+    goto failed;
+  strcpy (address.sun_path, path);
+  if (bind (fd, (struct sockaddr *) &address, sizeof (address)) < 0 ||
+      listen (fd, 1) < 0)
+    goto failed;
+
+  return fd;
+
+failed:
+  close (fd);
+  return -1;
+}
+
+static void
+send_data_message (int         fd,
+                   uint32_t    type,
+                   const void *payload,
+                   size_t      size)
+{
+  struct data_msg header = { .type = type, .size = size };
+
+  g_assert_cmpint (meta_anland_send_all (fd, &header, sizeof (header)), ==, 0);
+  if (size > 0)
+    g_assert_cmpint (meta_anland_send_all (fd, payload, size), ==, 0);
+}
+
+static void
+fallback_callback (void *user_data)
+{
+  int *count = user_data;
+
+  (*count)++;
+}
+
+static void
+test_transport_and_reconnect (void)
+{
+  g_autoptr (GError) error = NULL;
+  g_autofree char *directory = g_dir_make_tmp ("mutter-anland-XXXXXX", &error);
+  g_autofree char *socket_path = NULL;
+  MockDaemon daemon = {
+    .listen_fd = -1,
+    .peers = { -1, -1, -1, -1 },
+    .delay_first_pickup = TRUE,
+  };
+  MetaAnlandTransport *transport = NULL;
+  struct screen_info screen_info;
+  struct InputEvent event = { 0 };
+  struct InputEvent received_event;
+  struct OutputEvent output = { 0 };
+  struct data_msg output_header;
+  struct OutputEvent received_output;
+  MockPeers peers;
+  GThread *thread;
+  char text[] = "Anland text";
+  char audio_byte = 'A';
+  char received_audio = 0;
+  char received_text[sizeof (text)] = { 0 };
+  char fence_byte = 1;
+  int resource_fds[2] = { -1, -1 };
+  int received_resource_fds[2] = { -1, -1 };
+  int n_resource_fds = 0;
+  int fence_fds[1] = { -1 };
+  int n_fence_fds = 0;
+  int pipe_fds[2] = { -1, -1 };
+  int fallback_count = 0;
+  eventfd_t ready_value = 5;
+  eventfd_t received_ready = 0;
+
+  g_assert_no_error (error);
+  socket_path = g_build_filename (directory, "display.sock", NULL);
+  daemon.listen_fd = create_listener (socket_path);
+  if (daemon.listen_fd < 0)
+    g_error ("failed to create mock Anland socket %s: %s",
+             socket_path, g_strerror (errno));
+  g_assert_cmpint (daemon.listen_fd, >=, 0);
+  g_mutex_init (&daemon.lock);
+  thread = g_thread_new ("anland-mock-daemon", mock_daemon_thread, &daemon);
+
+  g_assert_cmpint (meta_anland_transport_connect (&transport, socket_path), ==, 0);
+  g_assert_true (meta_anland_transport_get_screen_info (transport, &screen_info));
+  g_assert_cmpuint (screen_info.refresh, ==, 120000);
+  g_assert_cmpint (meta_anland_transport_try_pickup (transport), ==,
+                   META_ANLAND_TRANSPORT_PICKUP_NO_CONSUMER);
+  g_assert_cmpint (meta_anland_transport_try_pickup (transport), ==,
+                   META_ANLAND_TRANSPORT_PICKUP_READY);
+  g_assert_false (meta_anland_transport_is_fallback (transport));
+  g_assert_cmpint (meta_anland_transport_get_buffer_count (transport), ==, 2);
+  g_assert_cmpint (meta_anland_transport_get_selected_buffer (transport), ==, 1);
+  g_assert_cmpint (meta_anland_transport_get_buffer_fd (transport, 0), >=, 0);
+
+  peers = get_peers (&daemon);
+  g_assert_cmpint (eventfd_write (peers.ready, ready_value), ==, 0);
+  g_assert_cmpint (eventfd_read (meta_anland_transport_get_buffer_ready_fd (transport),
+                                 &received_ready), ==, 0);
+  g_assert_cmpuint (received_ready, ==, ready_value);
+  g_assert_cmpint (send (peers.audio, &audio_byte, sizeof (audio_byte), 0), ==, 1);
+  g_assert_cmpint (recv (meta_anland_transport_get_audio_fd (transport),
+                         &received_audio, sizeof (received_audio), 0), ==, 1);
+  g_assert_cmpint (received_audio, ==, audio_byte);
+
+  send_data_message (peers.data, 0xfeed, text, sizeof (text));
+  event.type = INPUT_TYPE_TEXT_INPUT;
+  event.text_input.size = sizeof (text);
+  send_data_message (peers.data, DATA_MSG_INPUT_EVENT, &event, sizeof (event));
+  g_assert_cmpint (meta_anland_send_all (peers.data, text, sizeof (text)), ==, 0);
+  g_assert_cmpint (meta_anland_transport_poll_input_event (transport, &received_event, 100), ==, 1);
+  g_assert_cmpuint (received_event.type, ==, INPUT_TYPE_TEXT_INPUT);
+  g_assert_cmpint (meta_anland_transport_read_input_payload (transport, received_text,
+                                                              sizeof (received_text), 100), ==, 1);
+  g_assert_cmpmem (received_text, sizeof (received_text), text, sizeof (text));
+
+  g_assert_cmpint (pipe2 (resource_fds, O_CLOEXEC), ==, 0);
+  event = (struct InputEvent) {
+    .type = INPUT_TYPE_RESOURCE,
+    .resource = {
+      .type = SERVICE_TYPE_CAMERA,
+      .fdnum = G_N_ELEMENTS (resource_fds),
+    },
+  };
+  send_data_message (peers.data, DATA_MSG_INPUT_EVENT, &event, sizeof (event));
+  output_header = (struct data_msg) {
+    .type = DATA_MSG_INPUT_EXTEND_FDS,
+    .size = 0,
+  };
+  g_assert_cmpint (meta_anland_send_fds (peers.data, &output_header,
+                                         sizeof (output_header), resource_fds,
+                                         G_N_ELEMENTS (resource_fds)), ==, 0);
+  close_fd (&resource_fds[0]);
+  close_fd (&resource_fds[1]);
+  g_assert_cmpint (meta_anland_transport_poll_input_event (transport,
+                                                            &received_event, 100), ==, 1);
+  g_assert_cmpuint (received_event.type, ==, INPUT_TYPE_RESOURCE);
+  g_assert_cmpuint (received_event.resource.type, ==, SERVICE_TYPE_CAMERA);
+  g_assert_cmpuint (received_event.resource.fdnum, ==,
+                    G_N_ELEMENTS (received_resource_fds));
+  g_assert_cmpint (meta_anland_transport_read_input_fds (transport,
+                                                          received_resource_fds,
+                                                          G_N_ELEMENTS (received_resource_fds),
+                                                          &n_resource_fds, 100), ==, 1);
+  g_assert_cmpint (n_resource_fds, ==, G_N_ELEMENTS (received_resource_fds));
+  close_fd (&received_resource_fds[0]);
+  close_fd (&received_resource_fds[1]);
+
+  event.type = INPUT_TYPE_CLIPBOARD;
+  event.clipboard.size = sizeof (text);
+  send_data_message (peers.data, DATA_MSG_INPUT_EVENT, &event, sizeof (event));
+  g_assert_cmpint (meta_anland_send_all (peers.data, text, sizeof (text)), ==, 0);
+  g_assert_cmpint (meta_anland_transport_poll_input_event (transport, &received_event, 100), ==, 1);
+  g_assert_cmpuint (received_event.type, ==, INPUT_TYPE_CLIPBOARD);
+  g_assert_cmpint (meta_anland_transport_read_input_payload (transport, received_text,
+                                                              sizeof (received_text), 100), ==, 1);
+  g_assert_cmpmem (received_text, sizeof (received_text), text, sizeof (text));
+
+  output = (struct OutputEvent) {
+    .type = OUTPUT_TYPE_RESOURCES_REQUEST,
+    .resources_request = { .type = SERVICE_TYPE_CAMERA },
+  };
+  g_assert_true (meta_anland_transport_send_output_event (transport, &output,
+                                                           NULL, 0));
+  g_assert_cmpint (meta_anland_recv_all (peers.data, &output_header,
+                                         sizeof (output_header)), ==, 0);
+  g_assert_cmpuint (output_header.type, ==, DATA_MSG_OUTPUT_EVENT);
+  g_assert_cmpint (meta_anland_recv_all (peers.data, &received_output,
+                                         sizeof (received_output)), ==, 0);
+  g_assert_cmpuint (received_output.type, ==, OUTPUT_TYPE_RESOURCES_REQUEST);
+  g_assert_cmpuint (received_output.resources_request.type, ==,
+                    SERVICE_TYPE_CAMERA);
+
+  event = (struct InputEvent) {
+    .type = INPUT_TYPE_POINTER_MOTION,
+    .pointer_motion = {
+      .x = 640.0f,
+      .y = 360.0f,
+      .dx = -2.5f,
+      .dy = 1.5f,
+    },
+  };
+  send_data_message (peers.data, DATA_MSG_INPUT_EVENT, &event, sizeof (event));
+  g_assert_cmpint (meta_anland_transport_poll_input_event (transport, &received_event, 100), ==, 1);
+  g_assert_cmpuint (received_event.type, ==, INPUT_TYPE_POINTER_MOTION);
+  g_assert_cmpfloat (received_event.pointer_motion.x, ==, 640.0f);
+  g_assert_cmpfloat (received_event.pointer_motion.dy, ==, 1.5f);
+
+  event = (struct InputEvent) {
+    .type = INPUT_TYPE_DISPLAY_REFRESH,
+    .display = { .refresh_mhz = 90000 },
+  };
+  send_data_message (peers.data, DATA_MSG_INPUT_EVENT, &event, sizeof (event));
+  g_assert_cmpint (meta_anland_transport_poll_input_event (transport, &received_event, 100), ==, 1);
+  g_assert_cmpuint (received_event.type, ==, INPUT_TYPE_DISPLAY_REFRESH);
+  g_assert_cmpuint (received_event.display.refresh_mhz, ==, 90000);
+
+  output.type = OUTPUT_TYPE_CLIPBOARD;
+  output.clipboard.size = sizeof (text);
+  g_assert_true (meta_anland_transport_send_output_event (transport, &output,
+                                                           text, sizeof (text)));
+  g_assert_cmpint (meta_anland_recv_all (peers.data, &output_header,
+                                         sizeof (output_header)), ==, 0);
+  g_assert_cmpuint (output_header.type, ==, DATA_MSG_OUTPUT_EVENT);
+  g_assert_cmpint (meta_anland_recv_all (peers.data, &received_output,
+                                         sizeof (received_output)), ==, 0);
+  g_assert_cmpuint (output_header.size, ==, sizeof (received_output));
+  g_assert_cmpuint (received_output.type, ==, OUTPUT_TYPE_CLIPBOARD);
+  g_assert_cmpint (meta_anland_recv_all (peers.data, received_text,
+                                         sizeof (received_text)), ==, 0);
+  g_assert_cmpmem (received_text, sizeof (received_text), text, sizeof (text));
+
+  g_assert_cmpint (pipe2 (pipe_fds, O_CLOEXEC), ==, 0);
+  meta_anland_transport_set_render_fence (transport, pipe_fds[0]);
+  pipe_fds[0] = -1;
+  g_assert_true (meta_anland_transport_notify_frame_done (transport));
+  g_assert_cmpint (meta_anland_recv_fds (peers.fence, &fence_byte,
+                                         sizeof (fence_byte), fence_fds, 1,
+                                         &n_fence_fds), ==, 1);
+  g_assert_cmpint (fence_byte, ==, 0);
+  g_assert_cmpint (n_fence_fds, ==, 1);
+  close_fd (&fence_fds[0]);
+  close_fd (&pipe_fds[1]);
+
+  meta_anland_transport_set_fallback_callback (transport, fallback_callback,
+                                                &fallback_count);
+  g_mutex_lock (&daemon.lock);
+  close_fd (&daemon.peers.data);
+  g_mutex_unlock (&daemon.lock);
+  g_assert_cmpint (meta_anland_transport_poll_input_event (transport, &event, 100), ==, -1);
+  g_assert_true (meta_anland_transport_is_fallback (transport));
+  g_assert_cmpint (fallback_count, ==, 1);
+  close_peers (&daemon);
+
+  g_assert_cmpint (meta_anland_transport_try_pickup (transport), ==,
+                   META_ANLAND_TRANSPORT_PICKUP_READY);
+  g_assert_false (meta_anland_transport_is_fallback (transport));
+  meta_anland_transport_disconnect (transport);
+  g_thread_join (thread);
+  g_assert_false (daemon.failed);
+  close_fd (&daemon.listen_fd);
+  close_peers (&daemon);
+  g_assert_cmpint (g_unlink (socket_path), ==, 0);
+  g_assert_cmpint (g_rmdir (directory), ==, 0);
+  g_mutex_clear (&daemon.lock);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+  g_test_init (&argc, &argv, NULL);
+  g_test_add_func ("/backends/anland/transport-and-reconnect",
+                   test_transport_and_reconnect);
+  return g_test_run ();
+}

--- a/producers/gnome/Debian13_v5/startup.sh
+++ b/producers/gnome/Debian13_v5/startup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Linux truncates process names to 15 characters in /proc, so cover both forms.
+gnome_processes=(gnome-shell gnome-session gnome-session-b gnome-session-s gnome-session-service mutter)
+gnome_user_id="$(id -u)"
+for process_name in "${gnome_processes[@]}"; do
+    pkill -TERM -u "$gnome_user_id" -x "$process_name" > /dev/null 2>&1 || true
+done
+sleep 1
+for process_name in "${gnome_processes[@]}"; do
+    pkill -KILL -u "$gnome_user_id" -x "$process_name" > /dev/null 2>&1 || true
+done
+
+export ANLAND=1
+export ANLAND_SOCKET="${1:-/run/display.sock}"
+export QT_QPA_PLATFORM=wayland XDG_CURRENT_DESKTOP=GNOME XDG_SESSION_DESKTOP=gnome XDG_SESSION_TYPE=wayland GNOME_SHELL_SESSION_MODE=gnome
+export WAYLAND_DISPLAY=wayland-anland GNOME_WAYLAND_DISPLAY=wayland-anland
+export ANLAND_DRM_DEVICE=/dev/dri/renderD128
+export MESA_LOADER_DRIVER_OVERRIDE=kgsl TURNIP_KMD=kgsl GALLIUM_DRIVER=freedreno FD_FORCE_KGSL=1
+export XDG_RUNTIME_DIR=/run/user/$(id -u)
+sudo mkdir -p $XDG_RUNTIME_DIR
+sudo chown $(id -un):$(id -gn) $XDG_RUNTIME_DIR
+chmod 700 $XDG_RUNTIME_DIR
+rm -f $XDG_RUNTIME_DIR/wayland-* > /dev/null 2>&1
+sudo mkdir -p /tmp/.X11-unix
+sudo chmod 1777 /tmp/.X11-unix
+gnome-session

--- a/producers/gnome/Debian13_v5/xwayland.patch
+++ b/producers/gnome/Debian13_v5/xwayland.patch
@@ -1,0 +1,1 @@
+../../kde/Debian13_v5/xwayland.patch

--- a/producers/gnome/Ubuntu2604_v5/build.sh
+++ b/producers/gnome/Ubuntu2604_v5/build.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+#
+# build.sh — rebuild the patched Mutter and XWayland .deb packages and install them.
+#
+# Run this INSIDE the container (e.g. `droidspaces -n kde run` or a shell there).
+# It uses sudo for the privileged steps (apt / dpkg), so it works whether you
+# are root or an ordinary user with sudo rights.
+#
+# The Mutter patch enables the Anland backend, and the sibling 'mutter/'
+# directory contains the backend files copied into the source tree. The Mutter
+# source version is pinned below because the patch targets that Ubuntu package
+# revision. XWayland follows the latest source version available to apt.
+#
+# You can override the patch locations with MUTTER_PATCH=... and
+# XWAYLAND_PATCH=... ./build.sh.
+#
+set -u
+
+MUTTER_VERSION='50.1-0ubuntu2.2'
+
+# ---- sudo helper (no-op if already root) -----------------------------------
+if [ "$(id -u)" -eq 0 ]; then
+    SUDO=""
+else
+    SUDO="sudo"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKDIR="${WORKDIR:-$HOME/anland-debbuild}"
+JOBS="$(nproc)"
+
+# ---- locate a patch file by name, regardless of where it lives -------------
+find_patch() {
+    # $1 = base name to look for (e.g. mutter.patch)
+    local name="$1" explicit="${2:-}"
+    if [ -n "$explicit" ] && [ -f "$explicit" ]; then
+        printf '%s\n' "$explicit"; return 0
+    fi
+    local c
+    for c in "$SCRIPT_DIR/$name" "./$name" "$SCRIPT_DIR/../$name"; do
+        if [ -f "$c" ]; then printf '%s\n' "$c"; return 0; fi
+    done
+    # last resort: search a couple of likely roots
+    local hit
+    hit="$(find "$SCRIPT_DIR" "$PWD" -maxdepth 3 -name "$name" -type f 2>/dev/null | head -1)"
+    if [ -n "$hit" ]; then printf '%s\n' "$hit"; return 0; fi
+    return 1
+}
+
+log()  { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+warn() { printf '\033[1;33m[warn] %s\033[0m\n' "$*"; }
+die()  { printf '\033[1;31m[error] %s\033[0m\n' "$*" >&2; exit 1; }
+
+# ---- ensure deb-src entries exist so `apt source` works --------------------
+ensure_deb_src() {
+    if ! $SUDO grep -rqsE '^Types:.*deb-src|^deb-src ' \
+            /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null; then
+        log "Enabling deb-src repositories"
+        if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+            $SUDO sed -i 's/^Types: deb$/Types: deb deb-src/' \
+                /etc/apt/sources.list.d/ubuntu.sources
+        elif [ -f /etc/apt/sources.list ]; then
+            $SUDO sed -i 's/^deb \(.*\)$/deb \1\ndeb-src \1/' /etc/apt/sources.list
+        fi
+    fi
+    $SUDO apt-get update -qq || warn "apt-get update reported issues"
+}
+
+# ---- build one source package with an optional overlay and patch ------------
+build_pkg() {
+    local src="$1" patch="$2" version="${3:-}" overlay_dir="${4:-}" \
+        sentinel="${5:-}" source_spec="$1" source_label
+
+    if [ -n "$version" ]; then
+        source_spec="$src=$version"
+        source_label="$version"
+    else
+        source_label='latest available'
+    fi
+
+    log "Installing build dependencies for '$src' ($source_label)"
+    $SUDO apt-get build-dep -y "$source_spec" \
+        || warn "build-dep for $src had issues; continuing"
+
+    log "Fetching source for '$src' ($source_label)"
+    rm -rf "${WORKDIR:?}/$src"
+    mkdir -p "$WORKDIR/$src"
+    ( cd "$WORKDIR/$src" && apt-get source "$source_spec" ) \
+        || die "apt-get source $src failed"
+
+    local tree
+    tree="$(find "$WORKDIR/$src" -maxdepth 1 -type d -name "${src}-*" | head -1)"
+    [ -n "$tree" ] || die "could not find unpacked source tree for $src"
+
+    if [ -n "$overlay_dir" ]; then
+        [ -d "$overlay_dir" ] || die "overlay directory not found: $overlay_dir"
+        log "Overlaying '$overlay_dir' -> $tree (overwrite-merge)"
+        cp -a "$overlay_dir/." "$tree/"
+    fi
+
+    log "Applying patch: $patch -> $tree"
+    if ( cd "$tree" && patch --batch -p1 --forward --reject-file=- < "$patch" ); then
+        :
+    else
+        # already applied? Verify using the caller's patch sentinel.
+        if [ -n "$sentinel" ] && grep -rqF -- "$sentinel" "$tree" 2>/dev/null; then
+            warn "patch looks already applied, continuing"
+        else
+            die "patch did not apply cleanly for $src"
+        fi
+    fi
+
+    log "Building '$src' $source_label (.deb)"
+    # -d: don't re-check build-deps (already installed above)
+    # -b -uc -us: binary only, unsigned. changelog untouched -> official version.
+    ( cd "$tree" && DEB_BUILD_OPTIONS="nocheck parallel=$JOBS" \
+        dpkg-buildpackage -b -uc -us -d ) \
+        || die "dpkg-buildpackage failed for $src"
+
+    log "Installing built .deb(s) for '$src'"
+    local debs
+    debs="$(find "$WORKDIR/$src" -maxdepth 1 -name '*.deb' -type f)"
+    [ -n "$debs" ] || die "no .deb produced for $src"
+    printf '%s\n' "$debs"
+    # shellcheck disable=SC2086
+    $SUDO dpkg --force-confdef --force-confold -i $debs \
+        || warn "dpkg -i for $src reported issues (deps?)"
+}
+
+# ---------------------------------------------------------------------------
+main() {
+    local mutter_patch xwayland_patch
+    mutter_patch="$(find_patch mutter.patch "${MUTTER_PATCH:-}")" \
+        || die "mutter.patch not found (set MUTTER_PATCH=... to override)"
+    xwayland_patch="$(find_patch xwayland.patch "${XWAYLAND_PATCH:-}")" \
+        || die "xwayland.patch not found (set XWAYLAND_PATCH=... to override)"
+
+    log "mutter version : $MUTTER_VERSION"
+    log "mutter.patch   : $mutter_patch"
+    log "xwayland.patch : $xwayland_patch"
+    log "xwayland source: latest available"
+    log "work dir       : $WORKDIR"
+
+    ensure_deb_src
+
+    build_pkg mutter "$mutter_patch" "$MUTTER_VERSION" "$SCRIPT_DIR/mutter" \
+        'have_anland = get_option'
+    build_pkg xwayland "$xwayland_patch" '' '' \
+        'No usable linux-dmabuf main device'
+
+    sed -i '/PULSE_SERVER=unix:\/tmp\/.pulse-socket/d' /etc/environment
+
+    log "Done. Patched Mutter and XWayland built and installed."
+    echo "Built packages are under: $WORKDIR/{mutter,xwayland}/"
+    echo "Restart the compositor session for the changes to take effect."
+}
+
+main "$@"

--- a/producers/gnome/Ubuntu2604_v5/mutter.patch
+++ b/producers/gnome/Ubuntu2604_v5/mutter.patch
@@ -1,0 +1,1073 @@
+diff --git a/debian/libmutter-18-0.symbols b/debian/libmutter-18-0.symbols
+index a52ba2e15e..960620b838 100644
+--- a/debian/libmutter-18-0.symbols
++++ b/debian/libmutter-18-0.symbols
+@@ -2046,10 +2046,13 @@ libmutter-clutter-18.so.0 libmutter-18-0 #MINVER#
+  clutter_stage_view_notify_presented@Base 43.0
+  clutter_stage_view_notify_ready@Base 43.0
+  clutter_stage_view_peek_scanout@Base 43.0
++ clutter_stage_view_present@Base 50.1
++ clutter_stage_view_replace_framebuffer@Base 50.1
+  clutter_stage_view_schedule_update@Base 43.0
+  clutter_stage_view_schedule_update_now@Base 44.0
+  clutter_stage_view_set_color_state@Base 47.0
+  clutter_stage_view_set_output_color_state@Base 47.0
++ clutter_stage_view_set_present_func@Base 50.1
+  clutter_stage_view_take_accumulated_redraw_clip@Base 43.0
+  clutter_stage_view_take_scanout@Base 43.0
+  clutter_stage_window_get_type@Base 43.0
+diff --git a/debian/rules b/debian/rules
+index 518700016e..c0d4cb5dbc 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -23,7 +23,8 @@ CONFFLAGS = \
+ 	-Dauto_features=enabled \
+ 	-Degl_device=true \
+ 	-Dremote_desktop=true \
+-	-Dwayland_eglstream=true
++	-Dwayland_eglstream=true \
++	-Danland=enabled
+ export deb_udevdir = $(shell pkg-config --variable=udevdir udev | sed s,^/,,)
+ 
+ # Update the cogl_trace architectures in the symbols file to match this list:
+diff --git a/clutter/clutter/clutter-stage-view-private.h b/clutter/clutter/clutter-stage-view-private.h
+index 31ac7e144e..246bb5afc2 100644
+--- a/clutter/clutter/clutter-stage-view-private.h
++++ b/clutter/clutter/clutter-stage-view-private.h
+@@ -21,6 +21,11 @@
+ #include "clutter/clutter-types.h"
+ #include "mtk/mtk.h"
+ 
++typedef gboolean (* MetaStageViewPresentFunc) (ClutterStageView *view,
++                                                ClutterFrame     *frame,
++                                                int64_t           global_frame_counter,
++                                                gpointer          user_data);
++
+ CLUTTER_EXPORT
+ void clutter_stage_view_after_paint (ClutterStageView *view,
+                                      MtkRegion        *redraw_clip);
+@@ -46,6 +51,20 @@ void clutter_stage_view_invalidate_projection (ClutterStageView *view);
+ void clutter_stage_view_set_projection (ClutterStageView        *view,
+                                         const graphene_matrix_t *matrix);
+ 
++CLUTTER_EXPORT
++void clutter_stage_view_replace_framebuffer (ClutterStageView *view,
++                                              CoglFramebuffer  *framebuffer);
++
++CLUTTER_EXPORT
++void clutter_stage_view_set_present_func (ClutterStageView        *view,
++                                           MetaStageViewPresentFunc present_func,
++                                           gpointer                 user_data);
++
++CLUTTER_EXPORT
++gboolean clutter_stage_view_present (ClutterStageView *view,
++                                      ClutterFrame     *frame,
++                                      int64_t           global_frame_counter);
++
+ CLUTTER_EXPORT
+ void clutter_stage_view_add_redraw_clip (ClutterStageView   *view,
+                                          const MtkRectangle *clip);
+diff --git a/clutter/clutter/clutter-stage-view.c b/clutter/clutter/clutter-stage-view.c
+index aedd5f6cf9..fe9ff27c0b 100644
+--- a/clutter/clutter/clutter-stage-view.c
++++ b/clutter/clutter/clutter-stage-view.c
+@@ -90,6 +90,9 @@ typedef struct _ClutterStageViewPrivate
+   gboolean has_accumulated_redraw_clip;
+   MtkRegion *accumulated_redraw_clip;
+ 
++  MetaStageViewPresentFunc present_func;
++  gpointer present_user_data;
++
+   float refresh_rate;
+   int64_t vblank_duration_us;
+   ClutterFrameClock *frame_clock;
+@@ -1148,6 +1151,51 @@ clutter_stage_view_set_framebuffer (ClutterStageView *view,
+     }
+ }
+ 
++void
++clutter_stage_view_replace_framebuffer (ClutterStageView *view,
++                                        CoglFramebuffer  *framebuffer)
++{
++  ClutterStageViewPrivate *priv =
++    clutter_stage_view_get_instance_private (view);
++
++  g_return_if_fail (framebuffer != NULL);
++  g_return_if_fail (cogl_framebuffer_get_width (priv->framebuffer) ==
++                    cogl_framebuffer_get_width (framebuffer));
++  g_return_if_fail (cogl_framebuffer_get_height (priv->framebuffer) ==
++                    cogl_framebuffer_get_height (framebuffer));
++
++  g_set_object (&priv->framebuffer, framebuffer);
++  clutter_stage_view_invalidate_viewport (view);
++  clutter_stage_view_invalidate_projection (view);
++}
++
++void
++clutter_stage_view_set_present_func (ClutterStageView        *view,
++                                     MetaStageViewPresentFunc present_func,
++                                     gpointer                 user_data)
++{
++  ClutterStageViewPrivate *priv =
++    clutter_stage_view_get_instance_private (view);
++
++  priv->present_func = present_func;
++  priv->present_user_data = user_data;
++}
++
++gboolean
++clutter_stage_view_present (ClutterStageView *view,
++                            ClutterFrame     *frame,
++                            int64_t           global_frame_counter)
++{
++  ClutterStageViewPrivate *priv =
++    clutter_stage_view_get_instance_private (view);
++
++  if (!priv->present_func)
++    return FALSE;
++
++  return priv->present_func (view, frame, global_frame_counter,
++                             priv->present_user_data);
++}
++
+ static void
+ clutter_stage_view_set_transform (ClutterStageView    *view,
+                                   MtkMonitorTransform  transform)
+diff --git a/config.h.meson b/config.h.meson
+index 65794f2674..b84ee1dd45 100644
+--- a/config.h.meson
++++ b/config.h.meson
+@@ -52,6 +52,9 @@
+ /* Define if you want to enable the native (KMS) backend based on systemd */
+ #mesondefine HAVE_NATIVE_BACKEND
+ 
++/* Define if the Anland display backend is enabled */
++#mesondefine HAVE_ANLAND
++
+ /* Define if you want to enable XWayland support */
+ #mesondefine HAVE_XWAYLAND
+ 
+diff --git a/meson.build b/meson.build
+index 14fb130583..878be6a938 100644
+--- a/meson.build
++++ b/meson.build
+@@ -279,6 +279,11 @@ if have_native_backend
+   endif
+ endif
+ 
++have_anland = get_option('anland').enabled()
++if have_anland and not have_native_backend
++  error('The Anland backend requires the native backend')
++endif
++
+ is_ubuntu = run_command(
+   'grep', '-F', 'NAME="Ubuntu"', '/etc/os-release', check: false).returncode() == 0
+ snapd_support_dep = declare_dependency(
+@@ -318,7 +323,7 @@ if have_startup_notification
+ endif
+ 
+ have_remote_desktop = get_option('remote_desktop')
+-if have_remote_desktop
++if have_remote_desktop or have_anland
+   libpipewire_dep = dependency('libpipewire-0.3', version: libpipewire_req)
+ endif
+ 
+@@ -569,6 +574,7 @@ cdata.set('HAVE_GLES2', have_gles2)
+ cdata.set('HAVE_XWAYLAND', have_xwayland)
+ cdata.set('HAVE_LOGIND', have_logind)
+ cdata.set('HAVE_NATIVE_BACKEND', have_native_backend)
++cdata.set('HAVE_ANLAND', have_anland)
+ cdata.set('HAVE_REMOTE_DESKTOP', have_remote_desktop)
+ cdata.set('HAVE_DEVKIT', have_devkit)
+ cdata.set('HAVE_GNOME_DESKTOP', have_gnome_desktop)
+diff --git a/meson.options b/meson.options
+index 4824a8c750..aee9be7f64 100644
+--- a/meson.options
++++ b/meson.options
+@@ -46,6 +46,12 @@ option('native_backend',
+   description: 'Enable the native backend'
+ )
+ 
++option('anland',
++  type: 'feature',
++  value: 'disabled',
++  description: 'Enable the Anland display backend'
++)
++
+ option('remote_desktop',
+   type: 'boolean',
+   value: true,
+diff --git a/src/backends/meta-stage-impl.c b/src/backends/meta-stage-impl.c
+index e6f3b18a0a..738f315e93 100644
+--- a/src/backends/meta-stage-impl.c
++++ b/src/backends/meta-stage-impl.c
+@@ -308,6 +308,13 @@ swap_framebuffer (ClutterStageWindow *stage_window,
+     {
+       MetaStageView *view = META_STAGE_VIEW (stage_view);
+ 
++      if (clutter_stage_view_present (stage_view, frame,
++                                      priv->global_frame_counter))
++        {
++          priv->global_frame_counter++;
++          return;
++        }
++
+       meta_topic (META_DEBUG_BACKEND,
+                   "fake offscreen swap (framebuffer: %p)",
+                   framebuffer);
+diff --git a/src/backends/native/meta-renderer-native.c b/src/backends/native/meta-renderer-native.c
+index d53a298a34..9505f14a18 100644
+--- a/src/backends/native/meta-renderer-native.c
++++ b/src/backends/native/meta-renderer-native.c
+@@ -712,11 +712,43 @@ meta_renderer_native_create_dma_buf_framebuffer (MetaRendererNative  *renderer_n
+   CoglTexture *cogl_tex;
+   CoglOffscreen *cogl_fbo;
+   const MetaFormatInfo *format_info;
++  const uint64_t *import_modifiers = modifiers;
+ 
+   format_info = meta_format_info_from_drm_format (drm_format);
+-  g_assert (format_info);
++  if (!format_info)
++    {
++      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
++                   "Unsupported dma-buf format 0x%08x", drm_format);
++      return NULL;
++    }
+   cogl_format = format_info->cogl_format;
+ 
++  if (!meta_egl_has_extensions (egl, egl_display, NULL,
++                                "EGL_EXT_image_dma_buf_import", NULL))
++    {
++      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
++                   "EGL does not support dma-buf image import");
++      return NULL;
++    }
++
++  if (modifiers &&
++      !meta_egl_has_extensions (egl, egl_display, NULL,
++                                "EGL_EXT_image_dma_buf_import_modifiers",
++                                NULL))
++    {
++      for (int i = 0; i < n_planes; i++)
++        {
++          if (modifiers[i] != DRM_FORMAT_MOD_LINEAR)
++            {
++              g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
++                           "EGL cannot import non-linear dma-buf modifiers");
++              return NULL;
++            }
++        }
++
++      import_modifiers = NULL;
++    }
++
+   egl_image = meta_egl_create_dmabuf_image (egl,
+                                             egl_display,
+                                             width,
+@@ -726,7 +758,7 @@ meta_renderer_native_create_dma_buf_framebuffer (MetaRendererNative  *renderer_n
+                                             fds,
+                                             strides,
+                                             offsets,
+-                                            modifiers,
++                                            import_modifiers,
+                                             error);
+   if (egl_image == EGL_NO_IMAGE_KHR)
+     return NULL;
+diff --git a/src/backends/native/meta-seat-impl.c b/src/backends/native/meta-seat-impl.c
+index d13be4f14a..a5bd16b89c 100644
+--- a/src/backends/native/meta-seat-impl.c
++++ b/src/backends/native/meta-seat-impl.c
+@@ -985,6 +985,67 @@ meta_seat_impl_notify_absolute_motion_in_impl (MetaSeatImpl       *seat_impl,
+   queue_event (seat_impl, event);
+ }
+ 
++void
++meta_seat_impl_notify_absolute_relative_motion_in_impl (MetaSeatImpl       *seat_impl,
++                                                        ClutterInputDevice *input_device,
++                                                        uint64_t            time_us,
++                                                        float               x,
++                                                        float               y,
++                                                        float               dx,
++                                                        float               dy,
++                                                        float               dx_unaccel,
++                                                        float               dy_unaccel,
++                                                        double             *axes)
++{
++  MetaSeatImplPrivate *priv = meta_seat_impl_get_instance_private (seat_impl);
++  MetaInputDeviceNative *device_native =
++    META_INPUT_DEVICE_NATIVE (input_device);
++  ClutterModifierType modifiers;
++  ClutterEvent *event;
++  graphene_point_t coords, new_coords;
++  float dx_constrained, dy_constrained;
++
++  if (clutter_input_device_get_device_type (input_device) == CLUTTER_TABLET_DEVICE)
++    {
++      modifiers = device_native->button_state;
++    }
++  else
++    {
++      modifiers = seat_impl->button_state;
++    }
++
++  meta_seat_impl_get_onscreen_coords_for_source_device (seat_impl,
++                                                        input_device,
++                                                        &coords);
++
++  new_coords = GRAPHENE_POINT_INIT (x, y);
++  constrain_coordinates (seat_impl, input_device, time_us, coords, &new_coords);
++  dx_constrained = new_coords.x - coords.x;
++  dy_constrained = new_coords.y - coords.y;
++  update_device_coords_in_impl (seat_impl, input_device, new_coords);
++
++  modifiers |= xkb_state_serialize_mods (seat_impl->xkb, XKB_STATE_MODS_EFFECTIVE);
++
++  g_signal_emit (seat_impl, signals[POINTER_POSITION_CHANGED_IN_IMPL], 0,
++                 &priv->pointer_state);
++
++  event =
++    clutter_event_motion_new (CLUTTER_EVENT_FLAG_RELATIVE_MOTION,
++                              time_us,
++                              input_device,
++                              device_native->last_tool,
++                              modifiers,
++                              new_coords,
++                              GRAPHENE_POINT_INIT (dx, dy),
++                              GRAPHENE_POINT_INIT (dx_unaccel,
++                                                   dy_unaccel),
++                              GRAPHENE_POINT_INIT (dx_constrained,
++                                                   dy_constrained),
++                              axes);
++
++  queue_event (seat_impl, event);
++}
++
+ void
+ meta_seat_impl_notify_button_in_impl (MetaSeatImpl       *seat_impl,
+                                       ClutterInputDevice *input_device,
+diff --git a/src/backends/native/meta-seat-impl.h b/src/backends/native/meta-seat-impl.h
+index 5233715b9f..0555e83547 100644
+--- a/src/backends/native/meta-seat-impl.h
++++ b/src/backends/native/meta-seat-impl.h
+@@ -147,6 +147,17 @@ void meta_seat_impl_notify_absolute_motion_in_impl (MetaSeatImpl       *seat_imp
+                                                     float               y,
+                                                     double             *axes);
+ 
++void meta_seat_impl_notify_absolute_relative_motion_in_impl (MetaSeatImpl       *seat_impl,
++                                                             ClutterInputDevice *input_device,
++                                                             uint64_t            time_us,
++                                                             float               x,
++                                                             float               y,
++                                                             float               dx,
++                                                             float               dy,
++                                                             float               dx_unaccel,
++                                                             float               dy_unaccel,
++                                                             double             *axes);
++
+ void meta_seat_impl_notify_button_in_impl (MetaSeatImpl       *seat_impl,
+                                            ClutterInputDevice *input_device,
+                                            uint64_t            time_us,
+diff --git a/src/backends/native/meta-virtual-input-device-native.c b/src/backends/native/meta-virtual-input-device-native.c
+index e82b9aa210..e5c6264f44 100644
+--- a/src/backends/native/meta-virtual-input-device-native.c
++++ b/src/backends/native/meta-virtual-input-device-native.c
+@@ -64,6 +64,15 @@ typedef struct
+   double y;
+ } MetaVirtualEventMotion;
+ 
++typedef struct
++{
++  uint64_t time_us;
++  double x;
++  double y;
++  double dx;
++  double dy;
++} MetaVirtualEventAbsoluteRelativeMotion;
++
+ typedef struct
+ {
+   uint64_t time_us;
+@@ -96,6 +105,12 @@ typedef struct
+   double y;
+ } MetaVirtualEventTouch;
+ 
++typedef struct
++{
++  uint64_t time_us;
++  GArray *events;
++} MetaVirtualEventTouchBatch;
++
+ G_DEFINE_TYPE (MetaVirtualInputDeviceNative,
+                meta_virtual_input_device_native,
+                CLUTTER_TYPE_VIRTUAL_INPUT_DEVICE)
+@@ -312,6 +327,57 @@ meta_virtual_input_device_native_notify_absolute_motion (ClutterVirtualInputDevi
+   g_object_unref (task);
+ }
+ 
++static gboolean
++notify_absolute_relative_motion_in_impl (GTask *task)
++{
++  MetaVirtualInputDeviceNative *virtual_native =
++    g_task_get_source_object (task);
++  MetaSeatNative *seat_native =
++    meta_virtual_input_device_native_get_seat_native (virtual_native);
++  MetaVirtualEventAbsoluteRelativeMotion *event = g_task_get_task_data (task);
++
++  if (event->time_us == CLUTTER_CURRENT_TIME)
++    event->time_us = g_get_monotonic_time ();
++
++  meta_seat_impl_notify_absolute_relative_motion_in_impl (
++    seat_native->impl, virtual_native->impl_state->device, event->time_us,
++    (float) event->x, (float) event->y, (float) event->dx, (float) event->dy,
++    (float) event->dx, (float) event->dy, NULL);
++  g_task_return_boolean (task, TRUE);
++  return G_SOURCE_REMOVE;
++}
++
++void
++meta_virtual_input_device_native_notify_absolute_relative_motion (
++  MetaVirtualInputDeviceNative *virtual_native,
++  uint64_t                      time_us,
++  double                        x,
++  double                        y,
++  double                        dx,
++  double                        dy)
++{
++  MetaSeatNative *seat_native;
++  MetaVirtualEventAbsoluteRelativeMotion *event;
++  GTask *task;
++
++  g_return_if_fail (META_IS_VIRTUAL_INPUT_DEVICE_NATIVE (virtual_native));
++  g_return_if_fail (virtual_native->impl_state != NULL);
++
++  seat_native = meta_virtual_input_device_native_get_seat_native (virtual_native);
++  event = g_new0 (MetaVirtualEventAbsoluteRelativeMotion, 1);
++  event->time_us = time_us;
++  event->x = x;
++  event->y = y;
++  event->dx = dx;
++  event->dy = dy;
++
++  task = g_task_new (virtual_native, NULL, NULL, NULL);
++  g_task_set_task_data (task, event, g_free);
++  meta_seat_impl_run_input_task (seat_native->impl, task,
++                                 (GSourceFunc) notify_absolute_relative_motion_in_impl);
++  g_object_unref (task);
++}
++
+ static gboolean
+ notify_button_in_impl (GTask *task)
+ {
+@@ -971,6 +1037,98 @@ meta_virtual_input_device_native_notify_touch_up (ClutterVirtualInputDevice *vir
+   g_object_unref (task);
+ }
+ 
++static gboolean
++notify_touch_events_in_impl (GTask *task)
++{
++  MetaVirtualInputDeviceNative *virtual_native =
++    g_task_get_source_object (task);
++  MetaSeatNative *seat_native =
++    meta_virtual_input_device_native_get_seat_native (virtual_native);
++  MetaSeatImpl *seat = seat_native->impl;
++  MetaVirtualEventTouchBatch *batch = g_task_get_task_data (task);
++  GArray *events = batch->events;
++  uint64_t time_us = batch->time_us;
++  guint i;
++
++  for (i = 0; i < events->len; i++)
++    {
++      const MetaVirtualTouchEvent *event =
++        &g_array_index (events, MetaVirtualTouchEvent, i);
++      int device_slot = virtual_native->slot_base + event->slot;
++
++      switch (event->type)
++        {
++        case META_VIRTUAL_TOUCH_EVENT_DOWN:
++          meta_seat_impl_notify_touch_event_in_impl (
++            seat, virtual_native->impl_state->device, CLUTTER_TOUCH_BEGIN,
++            time_us, device_slot, (float) event->x, (float) event->y);
++          break;
++        case META_VIRTUAL_TOUCH_EVENT_MOTION:
++          meta_seat_impl_notify_touch_event_in_impl (
++            seat, virtual_native->impl_state->device, CLUTTER_TOUCH_UPDATE,
++            time_us, device_slot, (float) event->x, (float) event->y);
++          break;
++        case META_VIRTUAL_TOUCH_EVENT_UP:
++        case META_VIRTUAL_TOUCH_EVENT_CANCEL:
++          meta_seat_impl_notify_touch_event_in_impl (
++            seat, virtual_native->impl_state->device,
++            event->type == META_VIRTUAL_TOUCH_EVENT_UP ? CLUTTER_TOUCH_END :
++                                                         CLUTTER_TOUCH_CANCEL,
++            time_us, device_slot, (float) event->x, (float) event->y);
++          break;
++        }
++    }
++
++  g_task_return_boolean (task, TRUE);
++  return G_SOURCE_REMOVE;
++}
++
++static void
++meta_virtual_event_touch_batch_free (MetaVirtualEventTouchBatch *batch)
++{
++  g_clear_pointer (&batch->events, g_array_unref);
++  g_free (batch);
++}
++
++void
++meta_virtual_input_device_native_notify_touch_events (
++  MetaVirtualInputDeviceNative *virtual_native,
++  uint64_t                      time_us,
++  const MetaVirtualTouchEvent  *events,
++  gsize                         n_events)
++{
++  MetaSeatNative *seat_native;
++  MetaVirtualEventTouchBatch *batch;
++  GArray *copied_events;
++  GTask *task;
++  gsize i;
++
++  g_return_if_fail (META_IS_VIRTUAL_INPUT_DEVICE_NATIVE (virtual_native));
++  g_return_if_fail (virtual_native->impl_state != NULL);
++  g_return_if_fail (n_events > 0);
++  g_return_if_fail (events != NULL);
++
++  copied_events = g_array_sized_new (FALSE, FALSE, sizeof (*events), n_events);
++  for (i = 0; i < n_events; i++)
++    {
++      g_return_if_fail (events[i].slot >= 0 &&
++                        events[i].slot < CLUTTER_VIRTUAL_INPUT_DEVICE_MAX_TOUCH_SLOTS);
++      g_array_append_val (copied_events, events[i]);
++    }
++
++  seat_native = meta_virtual_input_device_native_get_seat_native (virtual_native);
++  batch = g_new0 (MetaVirtualEventTouchBatch, 1);
++  batch->time_us = time_us == CLUTTER_CURRENT_TIME ?
++    g_get_monotonic_time () : time_us;
++  batch->events = copied_events;
++  task = g_task_new (virtual_native, NULL, NULL, NULL);
++  g_task_set_task_data (task, batch,
++                        (GDestroyNotify) meta_virtual_event_touch_batch_free);
++  meta_seat_impl_run_input_task (seat_native->impl, task,
++                                 (GSourceFunc) notify_touch_events_in_impl);
++  g_object_unref (task);
++}
++
+ static void
+ meta_virtual_input_device_native_get_property (GObject    *object,
+                                                guint       prop_id,
+diff --git a/src/backends/native/meta-virtual-input-device-native.h b/src/backends/native/meta-virtual-input-device-native.h
+index a41b5ed294..149c989282 100644
+--- a/src/backends/native/meta-virtual-input-device-native.h
++++ b/src/backends/native/meta-virtual-input-device-native.h
+@@ -19,6 +19,8 @@
+ 
+ #pragma once
+ 
++#include <stdint.h>
++
+ #include "clutter/clutter-virtual-input-device.h"
+ 
+ #define META_TYPE_VIRTUAL_INPUT_DEVICE_NATIVE (meta_virtual_input_device_native_get_type ())
+@@ -26,3 +28,33 @@ G_DECLARE_FINAL_TYPE (MetaVirtualInputDeviceNative,
+                       meta_virtual_input_device_native,
+                       META, VIRTUAL_INPUT_DEVICE_NATIVE,
+                       ClutterVirtualInputDevice)
++
++typedef enum
++{
++  META_VIRTUAL_TOUCH_EVENT_DOWN,
++  META_VIRTUAL_TOUCH_EVENT_MOTION,
++  META_VIRTUAL_TOUCH_EVENT_UP,
++  META_VIRTUAL_TOUCH_EVENT_CANCEL,
++} MetaVirtualTouchEventType;
++
++typedef struct
++{
++  MetaVirtualTouchEventType type;
++  int slot;
++  double x;
++  double y;
++} MetaVirtualTouchEvent;
++
++void meta_virtual_input_device_native_notify_absolute_relative_motion (
++  MetaVirtualInputDeviceNative *virtual_device,
++  uint64_t                      time_us,
++  double                        x,
++  double                        y,
++  double                        dx,
++  double                        dy);
++
++void meta_virtual_input_device_native_notify_touch_events (
++  MetaVirtualInputDeviceNative *virtual_device,
++  uint64_t                      time_us,
++  const MetaVirtualTouchEvent  *events,
++  gsize                         n_events);
+diff --git a/src/core/display.c b/src/core/display.c
+index dd75585c23..39bfa6ac52 100644
+--- a/src/core/display.c
++++ b/src/core/display.c
+@@ -42,6 +42,9 @@
+ 
+ #include "backends/meta-backend-private.h"
+ #include "backends/meta-cursor-xcursor.h"
++#ifdef HAVE_ANLAND
++#include "backends/anland/meta-backend-anland.h"
++#endif
+ #include "backends/meta-cursor-tracker-private.h"
+ #include "backends/meta-input-capture.h"
+ #include "backends/meta-input-device-private.h"
+@@ -680,15 +683,29 @@ meta_display_init_x11_finish (MetaDisplay   *display,
+                               GError       **error)
+ {
+   MetaX11Display *x11_display;
++  gboolean x11_services_started;
+ 
+   g_assert (g_task_get_source_tag (G_TASK (result)) == meta_display_init_x11);
+ 
+-  if (!g_task_propagate_boolean (G_TASK (result), error))
++  x11_services_started = g_task_propagate_boolean (G_TASK (result), error);
++  if (!x11_services_started)
+     {
+-      if (*error == NULL)
+-        g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Unknown error");
++#ifdef HAVE_ANLAND
++      MetaContext *context = meta_display_get_context (display);
++      MetaBackend *backend = meta_context_get_backend (context);
+ 
+-      return FALSE;
++      if (*error == NULL && META_IS_BACKEND_ANLAND (backend))
++        {
++          g_message ("Continuing without X11 session services on Anland");
++        }
++      else
++#endif
++        {
++          if (*error == NULL)
++            g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Unknown error");
++
++          return FALSE;
++        }
+     }
+ 
+   if (display->x11_display)
+diff --git a/src/core/meta-context-main.c b/src/core/meta-context-main.c
+index 91cde41746..9687188af2 100644
+--- a/src/core/meta-context-main.c
++++ b/src/core/meta-context-main.c
+@@ -39,6 +39,10 @@
+ #include "backends/native/meta-backend-native-types.h"
+ #endif
+ 
++#ifdef HAVE_ANLAND
++#include "backends/anland/meta-backend-anland.h"
++#endif
++
+ #ifdef HAVE_DEVKIT
+ #include "core/meta-mdk.h"
+ #endif
+@@ -53,6 +57,10 @@ typedef struct _MetaContextMainOptions
+   gboolean headless;
+   gboolean devkit;
+   GList *virtual_monitor_infos;
++#endif
++#ifdef HAVE_ANLAND
++  gboolean anland;
++  char *anland_socket;
+ #endif
+   char *trace_file;
+   gboolean debug_control;
+@@ -92,6 +100,29 @@ check_configuration (MetaContextMain  *context_main,
+     }
+ #endif /* HAVE_NATIVE_BACKEND */
+ 
++#ifdef HAVE_ANLAND
++  if (context_main->options.anland_socket &&
++      !context_main->options.anland)
++    {
++      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
++                   "--anland-socket requires --anland");
++      return FALSE;
++    }
++
++  if (context_main->options.anland &&
++      (context_main->options.display_server ||
++       context_main->options.headless
++#ifdef HAVE_DEVKIT
++       || context_main->options.devkit
++#endif
++      ))
++    {
++      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
++                   "Can't run Anland with display server or headless mode");
++      return FALSE;
++    }
++#endif /* HAVE_ANLAND */
++
+   return TRUE;
+ }
+ 
+@@ -105,11 +136,19 @@ meta_context_main_configure (MetaContext   *context,
+   MetaContextClass *context_class =
+     META_CONTEXT_CLASS (meta_context_main_parent_class);
+   g_autofree char *wayland_display = NULL;
++#ifdef HAVE_ANLAND
++  const char *anland_socket;
++#endif
+ 
+   if (!context_class->configure (context, argc, argv, error))
+     return FALSE;
+ 
+   wayland_display = g_steal_pointer (&context_main->options.wayland_display);
++#ifdef HAVE_ANLAND
++  anland_socket = g_getenv ("ANLAND_SOCKET");
++  if (anland_socket && *anland_socket)
++    context_main->options.anland = TRUE;
++#endif
+ 
+   if (!check_configuration (context_main, error))
+     return FALSE;
+@@ -240,6 +279,13 @@ meta_context_main_setup (MetaContext  *context,
+     }
+ #endif
+ 
++#ifdef HAVE_ANLAND
++  if (context_main->options.anland &&
++      !meta_backend_anland_setup (
++        META_BACKEND_ANLAND (meta_context_get_backend (context)), error))
++    return FALSE;
++#endif
++
+   return TRUE;
+ }
+ 
+@@ -255,6 +301,31 @@ create_headless_backend (MetaContext  *context,
+                          NULL);
+ }
+ 
++#ifdef HAVE_ANLAND
++static MetaBackend *
++create_anland_backend (MetaContext  *context,
++                       GError      **error)
++{
++  MetaContextMain *context_main = META_CONTEXT_MAIN (context);
++
++  if (context_main->options.anland_socket)
++    {
++      return g_initable_new (META_TYPE_BACKEND_ANLAND,
++                             NULL, error,
++                             "context", context,
++                             "mode", META_BACKEND_NATIVE_MODE_HEADLESS,
++                             "anland-socket", context_main->options.anland_socket,
++                             NULL);
++    }
++
++  return g_initable_new (META_TYPE_BACKEND_ANLAND,
++                         NULL, error,
++                         "context", context,
++                         "mode", META_BACKEND_NATIVE_MODE_HEADLESS,
++                         NULL);
++}
++#endif
++
+ static MetaBackend *
+ create_native_backend (MetaContext  *context,
+                        GError      **error)
+@@ -273,6 +344,10 @@ meta_context_main_create_backend (MetaContext  *context,
+   MetaContextMain *context_main = META_CONTEXT_MAIN (context);
+ 
+ #ifdef HAVE_NATIVE_BACKEND
++#ifdef HAVE_ANLAND
++  if (context_main->options.anland)
++    return create_anland_backend (context, error);
++#endif
+   if (context_main->options.headless ||
+       context_main->options.devkit)
+     return create_headless_backend (context, error);
+@@ -381,6 +456,19 @@ meta_context_main_add_option_entries (MetaContextMain *context_main)
+       &context_main->options.headless,
+       N_("Run as a headless display server")
+     },
++#ifdef HAVE_ANLAND
++    {
++      "anland", 0, 0, G_OPTION_ARG_NONE,
++      &context_main->options.anland,
++      N_("Run with the Anland display backend")
++    },
++    {
++      "anland-socket", 0, 0, G_OPTION_ARG_FILENAME,
++      &context_main->options.anland_socket,
++      N_("Specify Anland display daemon socket"),
++      "PATH"
++    },
++#endif
+     {
+       "virtual-monitor", 0, 0, G_OPTION_ARG_CALLBACK,
+       add_virtual_monitor_cb,
+@@ -438,6 +526,7 @@ meta_context_main_finalize (GObject *object)
+ #ifdef HAVE_NATIVE_BACKEND
+   MetaContextMain *context_main = META_CONTEXT_MAIN (object);
+ 
++  g_clear_pointer (&context_main->options.anland_socket, g_free);
+   g_list_free_full (context_main->persistent_virtual_monitors, g_object_unref);
+   context_main->persistent_virtual_monitors = NULL;
+ 
+diff --git a/src/meson.build b/src/meson.build
+index 04aef85771..d6f566ed32 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -83,9 +83,14 @@ if have_libwacom
+   ]
+ endif
+ 
+-if have_remote_desktop
++if have_remote_desktop or have_anland
+   mutter_pkg_private_deps += [
+     libpipewire_dep,
++  ]
++endif
++
++if have_remote_desktop
++  mutter_pkg_private_deps += [
+     libeis_dep,
+   ]
+ endif
+@@ -825,6 +830,25 @@ if have_native_backend
+   ]
+ endif
+ 
++if have_anland
++  mutter_sources += [
++    'backends/anland/meta-backend-anland.c',
++    'backends/anland/meta-backend-anland.h',
++    'backends/anland/meta-anland-audio.c',
++    'backends/anland/meta-anland-audio.h',
++    'backends/anland/meta-anland-camera.c',
++    'backends/anland/meta-anland-camera.h',
++    'backends/anland/meta-anland-input.c',
++    'backends/anland/meta-anland-input.h',
++    'backends/anland/meta-anland-clipboard.c',
++    'backends/anland/meta-anland-clipboard.h',
++    'backends/anland/vendor/meta-anland-socket-utils.c',
++    'backends/anland/vendor/meta-anland-socket-utils.h',
++    'backends/anland/vendor/meta-anland-transport.c',
++    'backends/anland/vendor/meta-anland-transport.h',
++  ]
++endif
++
+ if have_devkit
+   mutter_sources += [
+     'core/meta-mdk.c',
+diff --git a/src/tests/meson.build b/src/tests/meson.build
+index 837e4ef433..7cc7cc4528 100644
+--- a/src/tests/meson.build
++++ b/src/tests/meson.build
+@@ -142,6 +142,24 @@ gnome.compile_schemas(
+   depend_files: 'org.gnome.mutter.test.gschema.xml',
+ )
+ 
++anland_transport_test = executable('mutter-anland-transport-tests',
++  sources: [
++    'anland-transport-tests.c',
++    '../backends/anland/vendor/meta-anland-socket-utils.c',
++    '../backends/anland/vendor/meta-anland-transport.c',
++  ],
++  include_directories: [
++    tests_includes,
++    include_directories('../backends/anland/vendor'),
++  ],
++  dependencies: glib_dep,
++  install: false,
++)
++
++test('anland-transport', anland_transport_test,
++  suite: ['core', 'mutter/anland'],
++)
++
+ if have_cogl_tests
+   subdir('cogl')
+ endif
+diff --git a/src/wayland/meta-wayland-text-input.c b/src/wayland/meta-wayland-text-input.c
+index aac1b88536..10271645d5 100644
+--- a/src/wayland/meta-wayland-text-input.c
++++ b/src/wayland/meta-wayland-text-input.c
+@@ -23,6 +23,7 @@
+ 
+ #include <wayland-server.h>
+ 
++#include "clutter/clutter/clutter-input-focus.h"
+ #include "compositor/meta-surface-actor-wayland.h"
+ #include "wayland/meta-wayland-private.h"
+ #include "wayland/meta-wayland-seat.h"
+@@ -809,6 +810,22 @@ meta_wayland_text_input_destroy (MetaWaylandTextInput *text_input)
+   g_free (text_input);
+ }
+ 
++gboolean
++meta_wayland_text_input_commit_string (MetaWaylandTextInput *text_input,
++                                       const char           *text)
++{
++  if (!text_input || !text || !*text || !text_input->enabled ||
++      !text_input->surface ||
++      wl_list_empty (&text_input->focus_resource_list) ||
++      !clutter_input_focus_is_focused (text_input->input_focus))
++    return FALSE;
++
++  CLUTTER_INPUT_FOCUS_GET_CLASS (text_input->input_focus)->commit_text (
++    text_input->input_focus, text);
++  meta_wayland_text_input_focus_flush_done (text_input->input_focus);
++  return TRUE;
++}
++
+ static void
+ meta_wayland_text_input_create_new_resource (MetaWaylandTextInput *text_input,
+                                              struct wl_client     *client,
+diff --git a/src/wayland/meta-wayland-text-input.h b/src/wayland/meta-wayland-text-input.h
+index 458614c959..c28d0a0876 100644
+--- a/src/wayland/meta-wayland-text-input.h
++++ b/src/wayland/meta-wayland-text-input.h
+@@ -43,3 +43,6 @@ gboolean meta_wayland_text_input_update (MetaWaylandTextInput *text_input,
+ 
+ gboolean meta_wayland_text_input_handle_event (MetaWaylandTextInput *text_input,
+                                                const ClutterEvent   *event);
++
++gboolean meta_wayland_text_input_commit_string (MetaWaylandTextInput *text_input,
++                                                const char           *text);
+diff --git a/src/wayland/meta-wayland.c b/src/wayland/meta-wayland.c
+index cc303d3648..90f4fbf381 100644
+--- a/src/wayland/meta-wayland.c
++++ b/src/wayland/meta-wayland.c
+@@ -774,11 +774,13 @@ set_gnome_env (const char *name,
+       g_autofree char *remote_error = NULL;
+ 
+       remote_error = g_dbus_error_get_remote_error (error);
+-      if (g_strcmp0 (remote_error, "org.freedesktop.DBus.Error.NameHasNoOwner") == 0)
++      if (g_strcmp0 (remote_error, "org.freedesktop.DBus.Error.NameHasNoOwner") == 0 ||
++          g_strcmp0 (remote_error,
++                     "org.gnome.SessionManager.NotInInitialization") == 0)
+         {
+           return update_activation_environment (session_bus, name, value);
+         }
+-      else if (g_strcmp0 (remote_error, "org.gnome.SessionManager.NotInInitialization") != 0)
++      else
+         {
+           g_warning ("Failed to set environment variable %s for gnome-session: %s",
+                      name, error->message);
+diff --git a/src/wayland/meta-xwayland.c b/src/wayland/meta-xwayland.c
+index 535cb57112..e5e1d6f504 100644
+--- a/src/wayland/meta-xwayland.c
++++ b/src/wayland/meta-xwayland.c
+@@ -47,6 +47,9 @@
+ 
+ #include "backends/meta-monitor-manager-private.h"
+ #include "backends/meta-settings-private.h"
++#ifdef HAVE_ANLAND
++#include "backends/anland/meta-backend-anland.h"
++#endif
+ #include "meta/main.h"
+ #include "meta/meta-backend.h"
+ #include "mtk/mtk-x11.h"
+@@ -513,7 +516,8 @@ meta_xwayland_override_display_number (int number)
+ }
+ 
+ static gboolean
+-ensure_x11_unix_perms (GError **error)
++ensure_x11_unix_perms (GError  **error,
++                       gboolean  allow_untrusted_owner)
+ {
+   /* Try to detect systems on which /tmp/.X11-unix is owned by neither root nor
+    * ourselves because in that case the owner can take over the socket we create
+@@ -545,7 +549,8 @@ ensure_x11_unix_perms (GError **error)
+   /* If the directory already exists, it should belong to the same
+    * user as /tmp or belong to ourselves ...
+    * (if /tmp is not owned by root or ourselves we're in deep trouble) */
+-  if (x11_tmp.st_uid != tmp.st_uid && x11_tmp.st_uid != getuid ())
++  if (!allow_untrusted_owner &&
++      x11_tmp.st_uid != tmp.st_uid && x11_tmp.st_uid != getuid ())
+     {
+       g_set_error (error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED,
+                    "Wrong ownership for directory \"%s\", owned by %d but "
+@@ -577,12 +582,13 @@ ensure_x11_unix_perms (GError **error)
+ }
+ 
+ static gboolean
+-ensure_x11_unix_dir (GError **error)
++ensure_x11_unix_dir (GError  **error,
++                     gboolean  allow_untrusted_owner)
+ {
+   if (mkdir (X11_TMP_UNIX_DIR, 01777) != 0)
+     {
+       if (errno == EEXIST)
+-        return ensure_x11_unix_perms (error);
++        return ensure_x11_unix_perms (error, allow_untrusted_owner);
+ 
+       g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno),
+                    "Failed to create directory \"%s\": %s",
+@@ -624,12 +630,13 @@ static gboolean
+ choose_xdisplay (MetaXWaylandManager     *manager,
+                  MetaXWaylandConnection  *connection,
+                  int                     *display,
++                 gboolean                 allow_untrusted_owner,
+                  GError                 **error)
+ {
+   int number_of_tries = 0;
+   char *lock_file = NULL;
+ 
+-  if (!ensure_x11_unix_dir (error))
++  if (!ensure_x11_unix_dir (error, allow_untrusted_owner))
+     return FALSE;
+ 
+   do
+@@ -764,12 +771,15 @@ on_displayfd_ready (int          fd,
+                     gpointer     user_data)
+ {
+   GTask *task = user_data;
++  char display_name[16];
++  ssize_t bytes_read;
+ 
+   /* The server writes its display name to the displayfd
+-   * socket when it's ready. We don't care about the data
+-   * in the socket, just that it wrote something, since
+-   * that means it's ready. */
+-  g_task_return_boolean (task, !!(condition & G_IO_IN));
++   * socket when it's ready. PRoot may only report G_IO_HUP
++   * after Xwayland writes and closes the socket, so check
++   * the pending data instead of relying on the condition. */
++  bytes_read = recv (fd, display_name, sizeof (display_name), MSG_DONTWAIT);
++  g_task_return_boolean (task, bytes_read > 0);
+   g_object_unref (task);
+ 
+   return G_SOURCE_REMOVE;
+@@ -1091,8 +1101,13 @@ meta_xwayland_init (MetaXWaylandManager    *manager,
+   MetaMonitorManager *monitor_manager =
+     meta_backend_get_monitor_manager (backend);
+   MetaX11DisplayPolicy policy;
++  gboolean allow_untrusted_owner = FALSE;
+   int display = 0;
+ 
++#ifdef HAVE_ANLAND
++  allow_untrusted_owner = META_IS_BACKEND_ANLAND (backend);
++#endif
++
+   if (display_number_override != -1)
+     display = display_number_override;
+   else if (g_getenv ("RUNNING_UNDER_GDM"))
+@@ -1100,13 +1115,15 @@ meta_xwayland_init (MetaXWaylandManager    *manager,
+ 
+   if (!manager->public_connection.name)
+     {
+-      if (!choose_xdisplay (manager, &manager->public_connection, &display, error))
++      if (!choose_xdisplay (manager, &manager->public_connection, &display,
++                            allow_untrusted_owner, error))
+         return FALSE;
+       manager->public_connection.name =
+         g_strdup_printf (":%d", manager->public_connection.display_index);
+ 
+       display++;
+-      if (!choose_xdisplay (manager, &manager->private_connection, &display, error))
++      if (!choose_xdisplay (manager, &manager->private_connection, &display,
++                            allow_untrusted_owner, error))
+         return FALSE;
+       manager->private_connection.name =
+         g_strdup_printf ("unix:%s%d", X11_TMP_UNIX_PATH,

--- a/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-anland-audio.c
+++ b/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-anland-audio.c
@@ -1,0 +1,665 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#include "config.h"
+
+#include "backends/anland/meta-anland-audio.h"
+
+#include "backends/anland/vendor/meta-anland-protocol.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <glib.h>
+#include <pipewire/pipewire.h>
+#include <spa/param/audio/format-utils.h>
+#include <spa/pod/builder.h>
+#include <spa/utils/hook.h>
+
+#define DEFAULT_RATE          48000
+#define DEFAULT_PLAY_CHANNELS 2
+#define DEFAULT_CAP_CHANNELS  1
+#define MIC_RING_BYTES        (48000 * 2 * (int) sizeof (int16_t))
+#define MAX_DGRAM             (64 * 1024)
+#define RECONNECT_SECS        1
+#define MIN_AUDIO_RATE     8000
+#define MAX_AUDIO_RATE   384000
+#define MAX_AUDIO_CHANNELS     2
+#define MAX_AUDIO_QUANTUM  65536
+#define KEEPALIVE_FRAMES       480
+#define KEEPALIVE_BYTES        (KEEPALIVE_FRAMES * DEFAULT_PLAY_CHANNELS * (int) sizeof (int16_t))
+
+struct _MetaAnlandAudio
+{
+  struct pw_thread_loop *loop;
+  struct pw_context *context;
+  struct pw_core *core;
+  struct spa_hook core_listener;
+  struct spa_source *reconnect_timer;
+  bool pw_connected;
+
+  struct pw_stream *capture;
+  struct spa_hook capture_listener;
+  struct pw_stream *source;
+  struct spa_hook source_listener;
+
+  uint32_t play_rate;
+  uint32_t play_channels;
+  uint32_t cap_rate;
+  uint32_t cap_channels;
+  uint32_t play_quantum;
+  uint32_t cap_quantum;
+
+  int audio_fd;
+  struct spa_source *io;
+
+  uint8_t *ring;
+  size_t ring_size;
+  size_t ring_head;
+  size_t ring_tail;
+  size_t ring_fill;
+
+  uint8_t silence[KEEPALIVE_BYTES];
+
+  uint8_t rx[MAX_DGRAM];
+  bool loop_started;
+};
+
+static int connect_stream (struct pw_stream  *stream,
+                           enum spa_direction  direction,
+                           uint32_t            rate,
+                           uint32_t            channels,
+                           uint32_t            quantum);
+static const struct spa_pod * build_format (struct spa_pod_builder *builder,
+                                             uint32_t                rate,
+                                             uint32_t                channels);
+static void set_latency (struct pw_stream *stream,
+                         uint32_t          quantum,
+                         uint32_t          rate);
+
+static void
+ring_reset (MetaAnlandAudio *audio)
+{
+  audio->ring_head = audio->ring_tail = audio->ring_fill = 0;
+}
+
+static void
+ring_write (MetaAnlandAudio *audio,
+            const uint8_t   *data,
+            size_t           size)
+{
+  size_t first;
+
+  if (size > audio->ring_size)
+    {
+      data += size - audio->ring_size;
+      size = audio->ring_size;
+    }
+
+  if (audio->ring_fill + size > audio->ring_size)
+    {
+      size_t drop = audio->ring_fill + size - audio->ring_size;
+
+      audio->ring_tail = (audio->ring_tail + drop) % audio->ring_size;
+      audio->ring_fill -= drop;
+    }
+
+  first = MIN (audio->ring_size - audio->ring_head, size);
+  memcpy (audio->ring + audio->ring_head, data, first);
+  memcpy (audio->ring, data + first, size - first);
+  audio->ring_head = (audio->ring_head + size) % audio->ring_size;
+  audio->ring_fill += size;
+}
+
+static size_t
+ring_read (MetaAnlandAudio *audio,
+           uint8_t         *data,
+           size_t           size)
+{
+  size_t available = MIN (size, audio->ring_fill);
+  size_t first = MIN (audio->ring_size - audio->ring_tail, available);
+
+  memcpy (data, audio->ring + audio->ring_tail, first);
+  memcpy (data + first, audio->ring, available - first);
+  audio->ring_tail = (audio->ring_tail + available) % audio->ring_size;
+  audio->ring_fill -= available;
+  return available;
+}
+
+static void
+on_capture_process (void *user_data)
+{
+  MetaAnlandAudio *audio = user_data;
+  struct pw_buffer *buffer;
+  struct spa_data *data;
+
+  buffer = pw_stream_dequeue_buffer (audio->capture);
+  if (!buffer)
+    return;
+
+  data = &buffer->buffer->datas[0];
+  if (audio->audio_fd >= 0)
+    {
+      const uint8_t *payload = audio->silence;
+      size_t payload_size = sizeof (audio->silence);
+
+      if (data->data && data->chunk && data->chunk->size > 0)
+        {
+          payload = (uint8_t *) data->data + data->chunk->offset;
+          payload_size = data->chunk->size;
+        }
+
+      struct audio_msg header = {
+        .type = AUDIO_MSG_PCM,
+        .size = payload_size,
+      };
+      struct iovec iov[2] = {
+        { .iov_base = &header, .iov_len = sizeof (header) },
+        { .iov_base = (void *) payload, .iov_len = payload_size },
+      };
+      struct msghdr message = {
+        .msg_iov = iov,
+        .msg_iovlen = G_N_ELEMENTS (iov),
+      };
+
+      /* The PipeWire loop must not stall on a slow or disconnected consumer. */
+      sendmsg (audio->audio_fd, &message, MSG_DONTWAIT | MSG_NOSIGNAL);
+    }
+
+  pw_stream_queue_buffer (audio->capture, buffer);
+}
+
+static void
+on_source_process (void *user_data)
+{
+  MetaAnlandAudio *audio = user_data;
+  struct pw_buffer *buffer;
+  struct spa_data *data;
+  uint32_t stride;
+  uint32_t frames;
+  uint32_t size;
+  size_t available;
+
+  buffer = pw_stream_dequeue_buffer (audio->source);
+  if (!buffer)
+    return;
+
+  data = &buffer->buffer->datas[0];
+  if (!data->data || !data->chunk)
+    {
+      pw_stream_queue_buffer (audio->source, buffer);
+      return;
+    }
+
+  stride = sizeof (int16_t) * audio->cap_channels;
+  frames = data->maxsize / stride;
+  if (buffer->requested && buffer->requested < frames)
+    frames = buffer->requested;
+  size = frames * stride;
+
+  available = ring_read (audio, data->data, size);
+  if (available < size)
+    memset ((uint8_t *) data->data + available, 0, size - available);
+
+  data->chunk->offset = 0;
+  data->chunk->stride = stride;
+  data->chunk->size = size;
+  pw_stream_queue_buffer (audio->source, buffer);
+}
+
+static const struct pw_stream_events capture_events = {
+  PW_VERSION_STREAM_EVENTS,
+  .process = on_capture_process,
+};
+
+static const struct pw_stream_events source_events = {
+  PW_VERSION_STREAM_EVENTS,
+  .process = on_source_process,
+};
+
+static void
+apply_format (MetaAnlandAudio          *audio,
+              const struct audio_format *format)
+{
+  gboolean playback = format->role == AUDIO_ROLE_PLAYBACK;
+  uint32_t rate = format->rate ? format->rate : DEFAULT_RATE;
+  uint32_t channels = format->channels ? format->channels :
+    (playback ? DEFAULT_PLAY_CHANNELS : DEFAULT_CAP_CHANNELS);
+  uint32_t *current_rate = playback ? &audio->play_rate : &audio->cap_rate;
+  uint32_t *current_channels = playback ? &audio->play_channels :
+    &audio->cap_channels;
+  uint32_t *current_quantum = playback ? &audio->play_quantum :
+    &audio->cap_quantum;
+  struct pw_stream *stream = playback ? audio->capture : audio->source;
+  gboolean format_changed;
+  gboolean quantum_changed;
+
+  format_changed = rate != *current_rate || channels != *current_channels;
+  quantum_changed = format->quantum != *current_quantum;
+  if (!format_changed && !quantum_changed)
+    return;
+
+  *current_rate = rate;
+  *current_channels = channels;
+  *current_quantum = format->quantum;
+
+  if (!audio->pw_connected || !stream)
+    return;
+
+  if (format_changed)
+    {
+      uint8_t buffer[1024];
+      struct spa_pod_builder builder = SPA_POD_BUILDER_INIT (buffer,
+                                                              sizeof (buffer));
+      const struct spa_pod *params[1] = {
+        build_format (&builder, rate, channels),
+      };
+
+      set_latency (stream, format->quantum, rate);
+      pw_stream_update_params (stream, params, G_N_ELEMENTS (params));
+    }
+  else if (format->quantum > 0)
+    {
+      set_latency (stream, format->quantum, rate);
+    }
+}
+
+static bool
+valid_format (const struct audio_format *format)
+{
+  return (format->role == AUDIO_ROLE_PLAYBACK ||
+          format->role == AUDIO_ROLE_CAPTURE) &&
+         format->format == AUDIO_FORMAT_S16LE &&
+         format->rate >= MIN_AUDIO_RATE &&
+         format->rate <= MAX_AUDIO_RATE &&
+         format->channels > 0 &&
+         format->channels <= MAX_AUDIO_CHANNELS &&
+         format->quantum <= MAX_AUDIO_QUANTUM;
+}
+
+static void
+on_audio_readable (void     *user_data,
+                   int       fd,
+                   uint32_t  mask)
+{
+  MetaAnlandAudio *audio = user_data;
+
+  if (mask & (SPA_IO_ERR | SPA_IO_HUP) || !(mask & SPA_IO_IN))
+    return;
+
+  for (;;)
+    {
+      struct audio_msg header;
+      size_t available;
+      ssize_t received = recv (fd, audio->rx, sizeof (audio->rx),
+                               MSG_DONTWAIT | MSG_TRUNC);
+
+      if (received <= 0)
+        break;
+      if ((size_t) received > sizeof (audio->rx) ||
+          (size_t) received < sizeof (header))
+        continue;
+
+      memcpy (&header, audio->rx, sizeof (header));
+      available = (size_t) received - sizeof (header);
+      if (header.type == AUDIO_MSG_FORMAT)
+        {
+          struct audio_format format;
+
+          if (header.size != sizeof (format) || header.size != available)
+            continue;
+
+          memcpy (&format, audio->rx + sizeof (header), sizeof (format));
+          if (valid_format (&format))
+            apply_format (audio, &format);
+          continue;
+        }
+
+      if (header.type != AUDIO_MSG_PCM || header.size != available ||
+          header.size % (sizeof (int16_t) * audio->cap_channels) != 0)
+        continue;
+
+      ring_write (audio, audio->rx + sizeof (header), header.size);
+    }
+}
+
+static void
+arm_reconnect (MetaAnlandAudio *audio)
+{
+  struct timespec interval = { .tv_sec = RECONNECT_SECS, .tv_nsec = 0 };
+
+  pw_loop_update_timer (pw_thread_loop_get_loop (audio->loop),
+                        audio->reconnect_timer, &interval, NULL, false);
+}
+
+static void
+on_core_error (void        *user_data,
+               uint32_t     id,
+               int          seq,
+               int          result,
+               const char  *message)
+{
+  MetaAnlandAudio *audio = user_data;
+
+  (void) seq;
+  (void) message;
+
+  if (id != PW_ID_CORE || result != -EPIPE)
+    return;
+
+  audio->pw_connected = false;
+  arm_reconnect (audio);
+}
+
+static const struct pw_core_events core_events = {
+  PW_VERSION_CORE_EVENTS,
+  .error = on_core_error,
+};
+
+static const struct spa_pod *
+build_format (struct spa_pod_builder *builder,
+              uint32_t                rate,
+              uint32_t                channels)
+{
+  struct spa_audio_info_raw info = {
+    .format = SPA_AUDIO_FORMAT_S16_LE,
+    .rate = rate,
+    .channels = channels,
+  };
+
+  if (channels >= 2)
+    {
+      info.position[0] = SPA_AUDIO_CHANNEL_FL;
+      info.position[1] = SPA_AUDIO_CHANNEL_FR;
+    }
+  else
+    {
+      info.position[0] = SPA_AUDIO_CHANNEL_MONO;
+    }
+
+  return spa_format_audio_raw_build (builder, SPA_PARAM_EnumFormat, &info);
+}
+
+static void
+set_latency (struct pw_stream *stream,
+             uint32_t          quantum,
+             uint32_t          rate)
+{
+  char latency[32];
+  struct spa_dict_item items[] = {
+    SPA_DICT_ITEM_INIT (PW_KEY_NODE_LATENCY, latency),
+  };
+  struct spa_dict properties = SPA_DICT_INIT (items, G_N_ELEMENTS (items));
+
+  if (quantum == 0)
+    return;
+
+  g_snprintf (latency, sizeof (latency), "%u/%u", quantum, rate);
+  pw_stream_update_properties (stream, &properties);
+}
+
+static int
+connect_stream (struct pw_stream  *stream,
+                enum spa_direction  direction,
+                uint32_t            rate,
+                uint32_t            channels,
+                uint32_t            quantum)
+{
+  uint8_t buffer[1024];
+  struct spa_pod_builder builder = SPA_POD_BUILDER_INIT (buffer,
+                                                          sizeof (buffer));
+  const struct spa_pod *params[1] = {
+    build_format (&builder, rate, channels),
+  };
+
+  set_latency (stream, quantum, rate);
+  return pw_stream_connect (stream, direction, PW_ID_ANY,
+                            PW_STREAM_FLAG_AUTOCONNECT |
+                            PW_STREAM_FLAG_MAP_BUFFERS |
+                            PW_STREAM_FLAG_RT_PROCESS,
+                            params, G_N_ELEMENTS (params));
+}
+
+static void
+teardown_pw (MetaAnlandAudio *audio)
+{
+  if (audio->capture)
+    {
+      spa_hook_remove (&audio->capture_listener);
+      pw_stream_destroy (audio->capture);
+      audio->capture = NULL;
+    }
+
+  if (audio->source)
+    {
+      spa_hook_remove (&audio->source_listener);
+      pw_stream_destroy (audio->source);
+      audio->source = NULL;
+    }
+
+  if (audio->core)
+    {
+      spa_hook_remove (&audio->core_listener);
+      pw_core_disconnect (audio->core);
+      audio->core = NULL;
+    }
+}
+
+static int
+build_pw (MetaAnlandAudio *audio)
+{
+  audio->core = pw_context_connect (audio->context, NULL, 0);
+  if (!audio->core)
+    return -1;
+
+  pw_core_add_listener (audio->core, &audio->core_listener, &core_events, audio);
+
+  audio->capture = pw_stream_new (
+    audio->core, "anland-speaker",
+    pw_properties_new (PW_KEY_MEDIA_TYPE, "Audio",
+                       PW_KEY_MEDIA_CLASS, "Audio/Sink",
+                       PW_KEY_NODE_NAME, "anland-speaker",
+                       PW_KEY_NODE_DESCRIPTION, "Anland remote speaker",
+                       PW_KEY_PRIORITY_SESSION, "1010",
+                       PW_KEY_PRIORITY_DRIVER, "1010",
+                       PW_KEY_NODE_ALWAYS_PROCESS, "true",
+                       PW_KEY_NODE_PAUSE_ON_IDLE, "false",
+                       PW_KEY_NODE_SUSPEND_ON_IDLE, "false",
+                       "session.suspend-timeout-seconds", "0",
+                       NULL));
+  if (!audio->capture)
+    return -1;
+
+  pw_stream_add_listener (audio->capture, &audio->capture_listener,
+                          &capture_events, audio);
+
+  audio->source = pw_stream_new (
+    audio->core, "anland-mic",
+    pw_properties_new (PW_KEY_MEDIA_TYPE, "Audio",
+                       PW_KEY_MEDIA_CLASS, "Audio/Source",
+                       PW_KEY_NODE_NAME, "anland-mic",
+                       PW_KEY_NODE_DESCRIPTION, "Anland remote microphone",
+                       PW_KEY_PRIORITY_SESSION, "1010",
+                       PW_KEY_PRIORITY_DRIVER, "1010",
+                       NULL));
+  if (!audio->source)
+    return -1;
+
+  pw_stream_add_listener (audio->source, &audio->source_listener,
+                          &source_events, audio);
+
+  if (connect_stream (audio->capture, PW_DIRECTION_INPUT, audio->play_rate,
+                      audio->play_channels, audio->play_quantum) < 0 ||
+      connect_stream (audio->source, PW_DIRECTION_OUTPUT, audio->cap_rate,
+                      audio->cap_channels, audio->cap_quantum) < 0)
+    return -1;
+
+  return 0;
+}
+
+static void
+on_reconnect_timer (void     *user_data,
+                    uint64_t  expirations)
+{
+  MetaAnlandAudio *audio = user_data;
+
+  (void) expirations;
+
+  if (audio->pw_connected)
+    return;
+
+  teardown_pw (audio);
+  if (build_pw (audio) == 0)
+    {
+      audio->pw_connected = true;
+    }
+  else
+    {
+      teardown_pw (audio);
+      arm_reconnect (audio);
+    }
+}
+
+void
+meta_anland_audio_set_fd (MetaAnlandAudio *audio,
+                          int              fd)
+{
+  struct pw_loop *loop;
+  int owned_fd = -1;
+
+  if (!audio)
+    return;
+
+  if (fd >= 0)
+    {
+      owned_fd = fcntl (fd, F_DUPFD_CLOEXEC, 0);
+      if (owned_fd < 0)
+        g_warning ("Anland failed to duplicate audio fd: %s", strerror (errno));
+    }
+
+  pw_thread_loop_lock (audio->loop);
+
+  loop = pw_thread_loop_get_loop (audio->loop);
+  if (audio->io)
+    {
+      pw_loop_destroy_source (loop, audio->io);
+      audio->io = NULL;
+    }
+
+  if (audio->audio_fd >= 0)
+    close (audio->audio_fd);
+  audio->audio_fd = owned_fd;
+  ring_reset (audio);
+
+  if (owned_fd >= 0)
+    {
+      audio->io = pw_loop_add_io (loop, owned_fd, SPA_IO_IN, false,
+                                  on_audio_readable, audio);
+      if (!audio->io)
+        {
+          close (audio->audio_fd);
+          audio->audio_fd = -1;
+        }
+    }
+
+  pw_thread_loop_unlock (audio->loop);
+}
+
+MetaAnlandAudio *
+meta_anland_audio_new (void)
+{
+  MetaAnlandAudio *audio;
+
+  pw_init (NULL, NULL);
+
+  audio = g_new0 (MetaAnlandAudio, 1);
+  if (!audio)
+    goto fail_init;
+
+  audio->audio_fd = -1;
+  audio->play_rate = DEFAULT_RATE;
+  audio->play_channels = DEFAULT_PLAY_CHANNELS;
+  audio->cap_rate = DEFAULT_RATE;
+  audio->cap_channels = DEFAULT_CAP_CHANNELS;
+  audio->ring_size = MIC_RING_BYTES;
+  audio->ring = g_malloc (audio->ring_size);
+  if (!audio->ring)
+    goto fail;
+
+  audio->loop = pw_thread_loop_new ("anland-audio", NULL);
+  if (!audio->loop)
+    goto fail;
+
+  audio->context = pw_context_new (pw_thread_loop_get_loop (audio->loop),
+                                   NULL, 0);
+  if (!audio->context)
+    goto fail;
+
+  audio->reconnect_timer = pw_loop_add_timer (
+    pw_thread_loop_get_loop (audio->loop), on_reconnect_timer, audio);
+  if (!audio->reconnect_timer)
+    goto fail;
+
+  if (pw_thread_loop_start (audio->loop) < 0)
+    goto fail;
+  audio->loop_started = true;
+
+  pw_thread_loop_lock (audio->loop);
+  if (build_pw (audio) == 0)
+    {
+      audio->pw_connected = true;
+    }
+  else
+    {
+      teardown_pw (audio);
+      arm_reconnect (audio);
+    }
+  pw_thread_loop_unlock (audio->loop);
+
+  return audio;
+
+fail:
+  if (audio->loop_started)
+    pw_thread_loop_stop (audio->loop);
+  if (audio->reconnect_timer)
+    pw_loop_destroy_source (pw_thread_loop_get_loop (audio->loop),
+                            audio->reconnect_timer);
+  if (audio->context)
+    pw_context_destroy (audio->context);
+  if (audio->loop)
+    pw_thread_loop_destroy (audio->loop);
+  g_free (audio->ring);
+  g_free (audio);
+fail_init:
+  return NULL;
+}
+
+void
+meta_anland_audio_free (MetaAnlandAudio *audio)
+{
+  if (!audio)
+    return;
+
+  if (audio->loop_started)
+    pw_thread_loop_stop (audio->loop);
+  teardown_pw (audio);
+  if (audio->io)
+    pw_loop_destroy_source (pw_thread_loop_get_loop (audio->loop), audio->io);
+  if (audio->reconnect_timer)
+    pw_loop_destroy_source (pw_thread_loop_get_loop (audio->loop),
+                            audio->reconnect_timer);
+  if (audio->audio_fd >= 0)
+    close (audio->audio_fd);
+  if (audio->context)
+    pw_context_destroy (audio->context);
+  if (audio->loop)
+    pw_thread_loop_destroy (audio->loop);
+  g_free (audio->ring);
+  g_free (audio);
+}

--- a/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-anland-audio.h
+++ b/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-anland-audio.h
@@ -1,0 +1,11 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#pragma once
+
+typedef struct _MetaAnlandAudio MetaAnlandAudio;
+
+MetaAnlandAudio * meta_anland_audio_new (void);
+void meta_anland_audio_free (MetaAnlandAudio *audio);
+
+void meta_anland_audio_set_fd (MetaAnlandAudio *audio,
+                               int              fd);

--- a/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-anland-camera.c
+++ b/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-anland-camera.c
@@ -1,0 +1,1036 @@
+#include "config.h"
+
+#include "backends/anland/meta-anland-camera.h"
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <sys/mman.h>
+
+#include <pipewire/pipewire.h>
+#include <glib.h>
+#include <spa/param/video/format-utils.h>
+#include <spa/param/buffers.h>
+#include <spa/pod/builder.h>
+#include <spa/utils/hook.h>
+
+/*
+ * Control-channel protocol + stream/shm protocol. MUST stay in sync with the
+ * consumer's camera_service.h.
+ */
+struct camera_ctrl_msg {
+    uint8_t  type;
+    uint8_t  reserved;
+    uint16_t len;
+    uint8_t  payload[];
+} __attribute__((packed));
+
+#define CAMERA_CTRL_GET_INFO     0x01
+#define CAMERA_CTRL_START_RECORD 0x02   /* payload: id(1B) w(2B,LE) h(2B,LE) */
+#define CAMERA_CTRL_STOP_RECORD  0x03   /* payload: id(1B) */
+#define CAMERA_CTRL_INFO_REPLY   0x81
+
+/* stream_fd control protocol (SEQPACKET). Frame pixels travel through shared memory;
+ * this only carries the shm hand-off and the READY/DONE pacing. */
+#define CAMERA_SLOTS 2
+struct cam_stream_msg {
+    uint8_t  type;
+    uint8_t  slot;
+    uint16_t fmt;   /* READY: CAM_FMT_*; else 0 */
+    uint32_t a;     /* SHM_OFFER: slot_bytes; READY: width  */
+    uint32_t b;     /* READY: height                        */
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct camera_ctrl_msg) == 4,
+               "camera control header must match Anland 5.13");
+_Static_assert(sizeof(struct cam_stream_msg) == 12,
+               "camera stream message must match Anland 5.13");
+
+#define CAM_STREAM_GET_SHM   1
+#define CAM_STREAM_SHM_OFFER 2
+#define CAM_STREAM_READY     3
+#define CAM_STREAM_DONE      4
+
+/* Pixel layout in a slot (matches consumer camera_service.h). All are w*h*3/2 bytes,
+ * single block, Y-stride = w, so only the announced SPA format differs. */
+#define CAM_FMT_I420 0
+#define CAM_FMT_NV12 1
+#define CAM_FMT_NV21 2
+
+/* Default resolution we advertise + request before anything is negotiated. The node
+ * format then FOLLOWS whatever the consumer actually delivers (every READY carries the
+ * real w/h): if the device's CameraX picks a different size, the first frame triggers a
+ * re-negotiation so the node always matches the real frames -- no garbage, no truncation. */
+#define CAM_DEF_W   1280
+#define CAM_DEF_H   720
+#define CAM_FPS     30
+
+#define MAX_CAMERAS 8
+#define RECONNECT_SECS 1
+#define MAX_CAMERA_FRAME_BYTES (256U * 1024U * 1024U)
+
+struct cam {
+    struct anland_camera *owner;
+    int                   index;        /* camera id, for ctrl messages */
+
+    /* Persistent virtual webcam node -- created when a camera first appears, kept
+     * alive across consumer disconnects (blank frames keep flowing), destroyed only
+     * when the camera count shrinks or the engine stops. */
+    struct pw_stream     *node;
+    struct spa_hook       listener;
+    bool                  streaming;    /* an app is consuming this node */
+    bool                  recording;    /* we've told the consumer to START on ctrl */
+    bool                  process_seen; /* one-shot debug: on_process was called */
+
+    /* Current negotiated node format. The node always advertises exactly this, and we
+     * re-negotiate it to match the resolution + pixel layout the consumer actually sends. */
+    uint32_t              fmt_w, fmt_h;
+    int                   fmt_code;   /* CAM_FMT_* currently announced */
+
+    /* Hot-swapped per (re)connect. -1 while detached -> the node emits blank frames. */
+    int                   stream_fd;
+    struct spa_source    *io;
+
+    /* Per-camera shared-memory double buffer, offered by the consumer over stream_fd.
+     * On READY we copy the named slot out into our own `frame` (so the consumer can
+     * reuse the slot immediately) and DONE it; on_process emits `frame` at app pace. */
+    int                   shm_fd;       /* owned dup of the consumer's ashmem, -1 none */
+    uint8_t              *shm;          /* mmap (PROT_READ), CAMERA_SLOTS*slot_bytes    */
+    size_t                shm_bytes;
+    size_t                slot_bytes;
+    bool                  shm_requested;
+
+    /* Producer-owned copy of the latest frame (loop thread only). */
+    uint8_t              *frame;
+    size_t                frame_cap;
+    size_t                frame_size;
+    bool                  have_frame;
+};
+
+struct anland_camera {
+    struct pw_thread_loop *loop;
+    struct pw_context     *context;
+    struct pw_core        *core;
+    struct spa_hook        core_listener;
+    struct spa_source     *reconnect_timer;
+    bool                   pw_connected;
+    bool                   loop_started;
+
+    int                    ctrl_fd;     /* owned; shared control socket, -1 when none */
+    struct spa_source     *ctrl_io;
+    uint8_t                ctrl_buffer[sizeof(struct camera_ctrl_msg) +
+                                       1 + MAX_CAMERAS * 4];
+    size_t                 ctrl_buffer_len;
+    bool                   info_pending;
+    int                    num_cameras; /* number of live nodes */
+    struct cam             cams[MAX_CAMERAS];
+};
+
+static int  build_pw(struct anland_camera *c);
+static void teardown_pw(struct anland_camera *c);
+static void create_nodes(struct anland_camera *c);
+static void destroy_nodes(struct anland_camera *c);
+static void attach_fd(struct cam *cam, int fd);
+static void detach_fd(struct cam *cam);
+static void clear_resources_locked(struct anland_camera *c);
+static void renegotiate_format(struct cam *cam, uint32_t w, uint32_t h,
+                               int fmt_code);
+static const struct spa_pod *build_video_format(struct spa_pod_builder *b,
+                                                uint32_t w, uint32_t h, int fmt_code);
+
+static bool camera_frame_size(uint32_t width, uint32_t height, size_t *size)
+{
+    size_t pixels;
+
+    if (width == 0 || height == 0 || width > UINT16_MAX ||
+        height > UINT16_MAX || width > SIZE_MAX / height)
+        return false;
+    pixels = (size_t)width * height;
+    if (pixels > SIZE_MAX - pixels / 2 ||
+        pixels + pixels / 2 > MAX_CAMERA_FRAME_BYTES)
+        return false;
+    *size = pixels + pixels / 2;
+    return true;
+}
+
+static bool valid_camera_format(int format)
+{
+    return format == CAM_FMT_I420 || format == CAM_FMT_NV12 ||
+           format == CAM_FMT_NV21;
+}
+
+/* ---- control channel ---- */
+
+static void send_ctrl(struct anland_camera *c, uint8_t type,
+                      const uint8_t *payload, uint16_t len)
+{
+    if (c->ctrl_fd < 0)
+        return;
+    uint8_t buf[sizeof(struct camera_ctrl_msg) + 8];
+    if (len > sizeof(buf) - sizeof(struct camera_ctrl_msg))
+        return;
+    struct camera_ctrl_msg *h = (struct camera_ctrl_msg *)buf;
+    h->type = type;
+    h->reserved = 0;
+    h->len = GUINT16_TO_LE(len);
+    if (len)
+        memcpy(buf + sizeof(*h), payload, len);
+    send(c->ctrl_fd, buf, sizeof(*h) + len, MSG_NOSIGNAL | MSG_DONTWAIT);
+}
+
+static bool
+handle_camera_info(struct anland_camera *c,
+                   const uint8_t       *payload,
+                   size_t               payload_size)
+{
+    uint8_t n_cameras;
+
+    if (payload_size < 1)
+        return false;
+
+    n_cameras = payload[0];
+    if (n_cameras != c->num_cameras ||
+        payload_size != 1 + (size_t) n_cameras * 4)
+        return false;
+
+    for (int i = 0; i < n_cameras; i++) {
+        struct cam *cam = &c->cams[i];
+        uint16_t wire_width;
+        uint16_t wire_height;
+        uint32_t width;
+        uint32_t height;
+        size_t frame_size;
+
+        memcpy(&wire_width, payload + 1 + (size_t) i * 4,
+               sizeof(wire_width));
+        memcpy(&wire_height, payload + 1 + (size_t) i * 4 + 2,
+               sizeof(wire_height));
+        width = GUINT16_FROM_LE(wire_width);
+        height = GUINT16_FROM_LE(wire_height);
+        if (!camera_frame_size(width, height, &frame_size))
+            return false;
+
+        if (!cam->node) {
+            cam->fmt_w = width;
+            cam->fmt_h = height;
+        } else if (!cam->have_frame &&
+                   (cam->fmt_w != width || cam->fmt_h != height)) {
+            renegotiate_format(cam, width, height, cam->fmt_code);
+        }
+    }
+
+    return true;
+}
+
+static bool
+consume_control_messages(struct anland_camera *c)
+{
+    while (c->ctrl_buffer_len >= sizeof(struct camera_ctrl_msg)) {
+        struct camera_ctrl_msg header;
+        size_t message_size;
+
+        memcpy(&header, c->ctrl_buffer, sizeof(header));
+        header.len = GUINT16_FROM_LE(header.len);
+        if (header.len > sizeof(c->ctrl_buffer) - sizeof(header))
+            return false;
+
+        message_size = sizeof(header) + header.len;
+        if (c->ctrl_buffer_len < message_size)
+            return true;
+
+        if (!c->info_pending ||
+            header.type != CAMERA_CTRL_INFO_REPLY || header.reserved != 0 ||
+            !handle_camera_info(c, c->ctrl_buffer + sizeof(header), header.len))
+            return false;
+
+        c->info_pending = false;
+        c->ctrl_buffer_len -= message_size;
+        memmove(c->ctrl_buffer, c->ctrl_buffer + message_size,
+                c->ctrl_buffer_len);
+    }
+
+    return true;
+}
+
+static void
+on_control_readable(void *data,
+                    int   fd,
+                    uint32_t mask)
+{
+    struct anland_camera *c = data;
+
+    if (mask & (SPA_IO_ERR | SPA_IO_HUP)) {
+        clear_resources_locked(c);
+        return;
+    }
+
+    while (mask & SPA_IO_IN) {
+        ssize_t n;
+
+        if (c->ctrl_buffer_len == sizeof(c->ctrl_buffer) || fd != c->ctrl_fd) {
+            clear_resources_locked(c);
+            return;
+        }
+
+        n = recv(fd, c->ctrl_buffer + c->ctrl_buffer_len,
+                 sizeof(c->ctrl_buffer) - c->ctrl_buffer_len, MSG_DONTWAIT);
+        if (n > 0) {
+            c->ctrl_buffer_len += (size_t) n;
+            if (!consume_control_messages(c)) {
+                g_warning("Anland camera control channel sent an invalid reply");
+                clear_resources_locked(c);
+                return;
+            }
+            continue;
+        }
+        if (n == 0) {
+            clear_resources_locked(c);
+            return;
+        }
+        if (errno == EINTR)
+            continue;
+        if (errno == EAGAIN)
+            return;
+#if EWOULDBLOCK != EAGAIN
+        if (errno == EWOULDBLOCK)
+            return;
+#endif
+        clear_resources_locked(c);
+        return;
+    }
+}
+
+static void
+request_camera_info(struct anland_camera *c)
+{
+    struct camera_ctrl_msg request = {
+        .type = CAMERA_CTRL_GET_INFO,
+        .reserved = 0,
+        .len = 0,
+    };
+
+    if (c->ctrl_fd < 0)
+        return;
+
+    if (send(c->ctrl_fd, &request, sizeof(request),
+             MSG_NOSIGNAL | MSG_DONTWAIT) == (ssize_t) sizeof(request))
+        c->info_pending = true;
+}
+
+/* Send a fixed stream-control message (GET_SHM / DONE) on a camera's stream socket. */
+static void send_stream(struct cam *cam, uint8_t type, uint8_t slot)
+{
+    if (cam->stream_fd < 0)
+        return;
+    struct cam_stream_msg m = { .type = type, .slot = slot };
+    send(cam->stream_fd, &m, sizeof(m), MSG_NOSIGNAL | MSG_DONTWAIT);
+}
+
+/* Ask the consumer to hand over the shm fd (once per (re)attach, while streaming). */
+static void request_shm(struct cam *cam)
+{
+    if (!cam->streaming || cam->stream_fd < 0 || cam->shm || cam->shm_requested)
+        return;
+    cam->shm_requested = true;
+    send_stream(cam, CAM_STREAM_GET_SHM, 0);
+}
+
+/* Reconcile the "should the consumer be recording?" state with what we've told it.
+ * Recording is wanted when an app is consuming the node AND we have a live control
+ * socket + stream fd. Requests the consumer at the node's current format. */
+static void update_recording(struct cam *cam)
+{
+    const bool want = cam->streaming && cam->stream_fd >= 0 && cam->owner->ctrl_fd >= 0;
+    if (want == cam->recording)
+        return;
+    if (want) {
+        uint8_t p[5];
+        uint16_t w = GUINT16_TO_LE((uint16_t)cam->fmt_w);
+        uint16_t h = GUINT16_TO_LE((uint16_t)cam->fmt_h);
+        p[0] = (uint8_t)cam->index;
+        memcpy(p + 1, &w, sizeof(w));
+        memcpy(p + 3, &h, sizeof(h));
+        send_ctrl(cam->owner, CAMERA_CTRL_START_RECORD, p, sizeof(p));
+        g_debug("anland-camera: start camera %d at %ux%u\n",
+                   cam->index, cam->fmt_w, cam->fmt_h);
+        request_shm(cam);   /* pull the shm fd so frames can flow */
+    } else if (cam->owner->ctrl_fd >= 0) {
+        uint8_t id = (uint8_t)cam->index;
+        send_ctrl(cam->owner, CAMERA_CTRL_STOP_RECORD, &id, 1);
+        g_debug("anland-camera: stop camera %d\n", cam->index);
+    }
+    cam->recording = want;
+}
+
+/* ---- frame emission ---- */
+
+/* The graph calls this whenever the consuming app needs a frame. Emit the latest
+ * received frame, or neutral gray while detached / before the first frame arrives, so
+ * a consuming app always gets a feed. Runs on the loop thread, same as the stream-
+ * socket reader, so cam->frame needs no lock. */
+static void on_process(void *data)
+{
+    struct cam *cam = data;
+    if (!cam->node)
+        return;
+
+    struct pw_buffer *pwb = pw_stream_dequeue_buffer(cam->node);
+    if (!cam->process_seen) {
+        cam->process_seen = true;
+    }
+    if (!pwb)
+        return;
+    struct spa_data *d = &pwb->buffer->datas[0];
+    if (d->data && d->chunk) {
+        const bool live = cam->have_frame && cam->stream_fd >= 0;
+        size_t fmt_bytes = 0;
+        size_t avail;
+        uint32_t copy;
+
+        if (!camera_frame_size(cam->fmt_w, cam->fmt_h, &fmt_bytes)) {
+            pw_stream_queue_buffer(cam->node, pwb);
+            return;
+        }
+        avail = live ? cam->frame_size : fmt_bytes;
+        copy = avail < d->maxsize ? (uint32_t)avail : d->maxsize;
+        if (live)
+            memcpy(d->data, cam->frame, copy);
+        else
+            memset(d->data, 128, copy);   /* neutral gray: valid I420 at any size */
+        d->chunk->offset = 0;
+        d->chunk->stride = cam->fmt_w;   /* I420 Y-plane stride */
+        d->chunk->size = copy;
+    }
+    pw_stream_queue_buffer(cam->node, pwb);
+}
+
+/* Re-announce the node's format to match what the consumer is actually sending (size
+ * AND pixel layout), so the advertised caps always equal the real frames. The app
+ * renegotiates and on_param_changed resizes the buffer pool. fmt_* are updated
+ * optimistically so this doesn't re-fire on every subsequent frame. */
+static void renegotiate_format(struct cam *cam, uint32_t w, uint32_t h, int fmt_code)
+{
+    size_t frame_size;
+
+    if (!cam->node || !valid_camera_format(fmt_code) ||
+        !camera_frame_size(w, h, &frame_size))
+        return;
+    g_debug("anland-camera: camera %d format %ux%u/%d -> %ux%u/%d\n",
+               cam->index, cam->fmt_w, cam->fmt_h, cam->fmt_code,
+               w, h, fmt_code);
+    cam->fmt_w = w;
+    cam->fmt_h = h;
+    cam->fmt_code = fmt_code;
+    uint8_t buffer[1024];
+    struct spa_pod_builder b = SPA_POD_BUILDER_INIT(buffer, sizeof(buffer));
+    const struct spa_pod *params[1] = { build_video_format(&b, w, h, fmt_code) };
+    pw_stream_update_params(cam->node, params, 1);
+}
+
+/* ---- stream socket: shm hand-off + READY/DONE pacing ---- */
+
+static void unmap_shm(struct cam *cam)
+{
+    if (cam->shm) {
+        munmap(cam->shm, cam->shm_bytes);
+        cam->shm = NULL;
+    }
+    if (cam->shm_fd >= 0) {
+        close(cam->shm_fd);
+        cam->shm_fd = -1;
+    }
+    cam->shm_bytes = cam->slot_bytes = 0;
+    cam->shm_requested = false;
+}
+
+static void handle_stream_msg(struct cam *cam, const struct cam_stream_msg *m, int rfd)
+{
+    switch (m->type) {
+    case CAM_STREAM_SHM_OFFER: {
+        size_t slot_bytes = m->a;
+        size_t total;
+
+        if (rfd < 0 || slot_bytes == 0 ||
+            slot_bytes > MAX_CAMERA_FRAME_BYTES ||
+            slot_bytes > SIZE_MAX / CAMERA_SLOTS) {
+            if (rfd >= 0)
+                close(rfd);
+            return;
+        }
+        total = (size_t)CAMERA_SLOTS * slot_bytes;
+        if (cam->shm)
+            munmap(cam->shm, cam->shm_bytes);
+        if (cam->shm_fd >= 0)
+            close(cam->shm_fd);
+        cam->shm_fd = rfd;
+        cam->slot_bytes = slot_bytes;
+        cam->shm_bytes = total;
+        cam->shm = mmap(NULL, total, PROT_READ, MAP_SHARED, rfd, 0);
+        if (cam->shm == MAP_FAILED) {
+            cam->shm = NULL;
+            close(rfd);
+            cam->shm_fd = -1;
+            cam->shm_bytes = cam->slot_bytes = 0;
+            return;
+        }
+        g_debug("anland-camera: camera %d mapped %zu bytes per slot\n",
+                   cam->index, slot_bytes);
+        break;
+    }
+    case CAM_STREAM_READY: {
+        if (rfd >= 0)
+            close(rfd);   /* READY carries no fd */
+        uint8_t slot = m->slot;
+        uint32_t w = m->a, h = m->b;
+        int fmt = m->fmt;
+        size_t bytes;
+        bool valid = valid_camera_format(fmt) &&
+                     camera_frame_size(w, h, &bytes);
+        if (cam->shm && slot < CAMERA_SLOTS && valid &&
+            bytes <= cam->slot_bytes) {
+            if (cam->frame_cap < bytes) {
+                uint8_t *nb = realloc(cam->frame, bytes);
+                if (nb) {
+                    cam->frame = nb;
+                    cam->frame_cap = bytes;
+                }
+            }
+            if (cam->frame_cap >= bytes && bytes > 0) {
+                /* Copy out of the slot promptly so the consumer can reuse it. */
+                memcpy(cam->frame, cam->shm + (size_t)slot * cam->slot_bytes, bytes);
+                cam->frame_size = bytes;
+                cam->have_frame = true;
+            }
+        }
+        /* Release the slot (even if we couldn't read, so the consumer never wedges). */
+        send_stream(cam, CAM_STREAM_DONE, slot);
+        if (valid && (w != cam->fmt_w || h != cam->fmt_h ||
+                      fmt != cam->fmt_code))
+            renegotiate_format(cam, w, h, fmt);
+        break;
+    }
+    default:
+        if (rfd >= 0)
+            close(rfd);
+        break;
+    }
+}
+
+static void on_stream_readable(void *data, int fd, uint32_t mask)
+{
+    struct cam *cam = data;
+    if (mask & (SPA_IO_ERR | SPA_IO_HUP))
+        return;
+    if (!(mask & SPA_IO_IN))
+        return;
+
+    for (;;) {
+        struct cam_stream_msg m;
+        int rfd = -1;
+        struct iovec iov = { .iov_base = &m, .iov_len = sizeof(m) };
+        union {
+            char buf[CMSG_SPACE(sizeof(int))];
+            struct cmsghdr align;
+        } cmsg;
+        struct msghdr msg = { .msg_iov = &iov, .msg_iovlen = 1,
+                              .msg_control = cmsg.buf, .msg_controllen = sizeof(cmsg.buf) };
+        ssize_t n = recvmsg(fd, &msg, MSG_DONTWAIT);
+        if (n <= 0)
+            break;
+        if (msg.msg_flags & MSG_CTRUNC)
+            continue;
+        for (struct cmsghdr *c = CMSG_FIRSTHDR(&msg); c;
+             c = CMSG_NXTHDR(&msg, c)) {
+            if (c->cmsg_level != SOL_SOCKET || c->cmsg_type != SCM_RIGHTS ||
+                c->cmsg_len < CMSG_LEN(sizeof(int)))
+                continue;
+            memcpy(&rfd, CMSG_DATA(c), sizeof(rfd));
+            break;
+        }
+        if (n == (ssize_t)sizeof(m))
+            handle_stream_msg(cam, &m, rfd);
+        else if (rfd >= 0)
+            close(rfd);
+    }
+}
+
+/* Point a camera at a fresh stream socket (or -1 to detach). Drops the old shm mapping
+ * (the new connection re-offers it) so a stale region never bleeds into the new one. */
+static void attach_fd(struct cam *cam, int fd)
+{
+    struct pw_loop *loop = pw_thread_loop_get_loop(cam->owner->loop);
+    if (cam->io) {
+        pw_loop_destroy_source(loop, cam->io);
+        cam->io = NULL;
+    }
+    if (cam->stream_fd >= 0)
+        close(cam->stream_fd);
+    cam->stream_fd = fd;
+    unmap_shm(cam);                   /* re-requested on the new connection */
+    cam->have_frame = false;          /* show blank until a fresh frame arrives */
+    if (fd >= 0)
+        cam->io = pw_loop_add_io(loop, fd, SPA_IO_IN, false, on_stream_readable, cam);
+    if (fd >= 0 && !cam->io) {
+        close(cam->stream_fd);
+        cam->stream_fd = -1;
+    }
+    update_recording(cam);            /* START + GET_SHM if an app is consuming */
+    request_shm(cam);                 /* also (re)request if already streaming */
+}
+
+static void detach_fd(struct cam *cam)
+{
+    attach_fd(cam, -1);
+}
+
+/* ---- Video/Source node ---- */
+
+static uint32_t spa_video_fmt(int code)
+{
+    switch (code) {
+    case CAM_FMT_NV12: return SPA_VIDEO_FORMAT_NV12;
+    case CAM_FMT_NV21: return SPA_VIDEO_FORMAT_NV21;
+    default:           return SPA_VIDEO_FORMAT_I420;
+    }
+}
+
+static const struct spa_pod *build_video_format(struct spa_pod_builder *b,
+                                                uint32_t w, uint32_t h, int fmt_code)
+{
+    struct spa_video_info_raw info;
+    spa_zero(info);
+    info.format = spa_video_fmt(fmt_code);
+    info.size = SPA_RECTANGLE(w, h);
+    info.framerate = SPA_FRACTION(CAM_FPS, 1);
+    return spa_format_video_raw_build(b, SPA_PARAM_EnumFormat, &info);
+}
+
+static void on_stream_state_changed(void *data, enum pw_stream_state old,
+                                    enum pw_stream_state state, const char *error)
+{
+    struct cam *cam = data;
+    (void)error;
+    (void)old;
+    const bool streaming = (state == PW_STREAM_STATE_STREAMING);
+    if (streaming == cam->streaming)
+        return;
+    cam->streaming = streaming;
+    update_recording(cam);
+}
+
+/* The format was negotiated: parse it and declare a buffer pool of the matching size.
+ * Without this PipeWire never allocates correctly-sized buffers and
+ * pw_stream_dequeue_buffer() returns NULL forever, so on_process can never emit. */
+static void on_param_changed(void *data, uint32_t id, const struct spa_pod *param)
+{
+    struct cam *cam = data;
+    if (!param || id != SPA_PARAM_Format)
+        return;
+
+    uint32_t mtype, msubtype;
+    if (spa_format_parse(param, &mtype, &msubtype) < 0 ||
+        mtype != SPA_MEDIA_TYPE_video || msubtype != SPA_MEDIA_SUBTYPE_raw)
+        return;
+
+    struct spa_video_info_raw raw;
+    spa_zero(raw);
+    if (spa_format_video_raw_parse(param, &raw) < 0)
+        return;
+    if (raw.size.width)
+        cam->fmt_w = raw.size.width;
+    if (raw.size.height)
+        cam->fmt_h = raw.size.height;
+
+    size_t frame_size;
+    if (!camera_frame_size(cam->fmt_w, cam->fmt_h, &frame_size) ||
+        frame_size > INT32_MAX)
+        return;
+
+    uint8_t buffer[512];
+    struct spa_pod_builder b = SPA_POD_BUILDER_INIT(buffer, sizeof(buffer));
+    const struct spa_pod *params[1];
+    params[0] = spa_pod_builder_add_object(&b,
+        SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,
+        SPA_PARAM_BUFFERS_buffers,  SPA_POD_CHOICE_RANGE_Int(4, 2, 8),
+        SPA_PARAM_BUFFERS_blocks,   SPA_POD_Int(1),
+        SPA_PARAM_BUFFERS_size,     SPA_POD_Int((int)frame_size),
+        SPA_PARAM_BUFFERS_stride,   SPA_POD_Int((int)cam->fmt_w),
+        SPA_PARAM_BUFFERS_dataType, SPA_POD_CHOICE_FLAGS_Int(
+            (1 << SPA_DATA_MemPtr) | (1 << SPA_DATA_MemFd)));
+    pw_stream_update_params(cam->node, params, 1);
+}
+
+static const struct pw_stream_events stream_events = {
+    PW_VERSION_STREAM_EVENTS,
+    .state_changed = on_stream_state_changed,
+    .param_changed = on_param_changed,
+    .process = on_process,
+};
+
+static int connect_node(struct cam *cam)
+{
+    char name[32], desc[48];
+    snprintf(name, sizeof(name), "anland-camera-%d", cam->index);
+    snprintf(desc, sizeof(desc), "Anland remote camera %d", cam->index);
+
+    cam->node = pw_stream_new(cam->owner->core, name,
+        pw_properties_new(
+            PW_KEY_MEDIA_TYPE, "Video",
+            PW_KEY_MEDIA_CATEGORY, "Capture",
+            PW_KEY_MEDIA_CLASS, "Video/Source",
+            PW_KEY_MEDIA_ROLE, "Camera",
+            PW_KEY_NODE_NAME, name,
+            PW_KEY_NODE_DESCRIPTION, desc,
+            NULL));
+    if (!cam->node)
+        return -1;
+    pw_stream_add_listener(cam->node, &cam->listener, &stream_events, cam);
+
+    uint8_t buffer[1024];
+    struct spa_pod_builder b = SPA_POD_BUILDER_INIT(buffer, sizeof(buffer));
+    const struct spa_pod *params[1] = {
+        build_video_format(&b, cam->fmt_w, cam->fmt_h, cam->fmt_code) };
+
+    /* No DRIVER flag: the consuming app (graph) drives, so PipeWire calls on_process
+     * on demand. No RT_PROCESS either, so on_process runs on the same loop thread as
+     * the stream-socket reader and shares cam->frame without a lock. */
+    int ret = pw_stream_connect(cam->node, PW_DIRECTION_OUTPUT, PW_ID_ANY,
+                                PW_STREAM_FLAG_MAP_BUFFERS, params, 1);
+    if (ret < 0) {
+        spa_hook_remove(&cam->listener);
+        pw_stream_destroy(cam->node);
+        cam->node = NULL;
+    }
+    return ret;
+}
+
+/* Create the node for one camera slot (no fd attached yet). PipeWire drives its
+ * .process whenever an app consumes it. */
+static int create_node(struct cam *cam)
+{
+    if (cam->node)
+        return 0;
+    cam->streaming = false;
+    cam->recording = false;
+    cam->process_seen = false;
+    if (cam->fmt_w == 0 || cam->fmt_h == 0) {
+        cam->fmt_w = CAM_DEF_W;
+        cam->fmt_h = CAM_DEF_H;
+    }
+    /* The consumer always delivers NV21, so advertise it from the start -- no live
+     * format switch (which crashes downstream gst). Only resolution ever renegotiates. */
+    cam->fmt_code = CAM_FMT_NV21;
+    return connect_node(cam);
+}
+
+/* (Re)create nodes for the current camera count, e.g. after a PipeWire reconnect.
+ * The stream fds in cam->stream_fd are preserved, so readers are re-armed. */
+static void create_nodes(struct anland_camera *c)
+{
+    if (!c->pw_connected || !c->core)
+        return;
+    struct pw_loop *loop = pw_thread_loop_get_loop(c->loop);
+    for (int i = 0; i < c->num_cameras; i++) {
+        struct cam *cam = &c->cams[i];
+        if (cam->node)
+            continue;
+        create_node(cam);
+        if (cam->stream_fd >= 0 && !cam->io)
+            cam->io = pw_loop_add_io(loop, cam->stream_fd, SPA_IO_IN, false,
+                                     on_stream_readable, cam);
+    }
+}
+
+/* Destroy one camera's node and reader. Keeps stream_fd (caller decides). */
+static void destroy_node(struct cam *cam)
+{
+    struct pw_loop *loop = cam->owner && cam->owner->loop
+                               ? pw_thread_loop_get_loop(cam->owner->loop) : NULL;
+    if (cam->node) {
+        spa_hook_remove(&cam->listener);
+        pw_stream_destroy(cam->node);
+        cam->node = NULL;
+    }
+    if (cam->io && loop) {
+        pw_loop_destroy_source(loop, cam->io);
+        cam->io = NULL;
+    }
+    cam->streaming = false;
+    cam->recording = false;
+}
+
+static void destroy_nodes(struct anland_camera *c)
+{
+    for (int i = 0; i < MAX_CAMERAS; i++)
+        destroy_node(&c->cams[i]);
+}
+
+/* ---- PipeWire connection lifecycle (mirrors the audio engine) ---- */
+
+static void arm_reconnect(struct anland_camera *c)
+{
+    struct timespec val = { .tv_sec = RECONNECT_SECS, .tv_nsec = 0 };
+    pw_loop_update_timer(pw_thread_loop_get_loop(c->loop), c->reconnect_timer,
+                         &val, NULL, false);
+}
+
+static void on_core_error(void *data, uint32_t id, int seq, int res, const char *message)
+{
+    struct anland_camera *c = data;
+    (void)seq;
+    (void)message;
+    if (id == PW_ID_CORE && res == -EPIPE) {
+        c->pw_connected = false;
+        arm_reconnect(c);
+    }
+}
+
+static const struct pw_core_events core_events = {
+    PW_VERSION_CORE_EVENTS,
+    .error = on_core_error,
+};
+
+static int build_pw(struct anland_camera *c)
+{
+    c->core = pw_context_connect(c->context, NULL, 0);
+    if (!c->core)
+        return -1;
+    pw_core_add_listener(c->core, &c->core_listener, &core_events, c);
+    return 0;
+}
+
+static void teardown_pw(struct anland_camera *c)
+{
+    destroy_nodes(c);
+    if (c->core) {
+        spa_hook_remove(&c->core_listener);
+        pw_core_disconnect(c->core);
+        c->core = NULL;
+    }
+}
+
+static void on_reconnect_timer(void *data, uint64_t expirations)
+{
+    struct anland_camera *c = data;
+    (void)expirations;
+    if (c->pw_connected)
+        return;
+
+    teardown_pw(c);
+    if (build_pw(c) == 0) {
+        c->pw_connected = true;
+        create_nodes(c);   /* rebuild nodes from the still-valid stream fds */
+    } else {
+        teardown_pw(c);
+        arm_reconnect(c);
+    }
+}
+
+/* ---- public API ---- */
+
+static void close_resource_set(int ctrl_fd, const int *stream_fds, int num_cameras)
+{
+    if (ctrl_fd >= 0)
+        close(ctrl_fd);
+    if (!stream_fds)
+        return;
+    for (int i = 0; i < num_cameras; i++)
+        if (stream_fds[i] >= 0)
+            close(stream_fds[i]);
+}
+
+void meta_anland_camera_set_resources(struct anland_camera *c, int ctrl_fd,
+                                 const int *stream_fds, int num_cameras)
+{
+    if (!c || !stream_fds || num_cameras < 0) {
+        close_resource_set(ctrl_fd, stream_fds,
+                           num_cameras > 0 ? num_cameras : 0);
+        return;
+    }
+
+    int accepted = num_cameras < MAX_CAMERAS ? num_cameras : MAX_CAMERAS;
+    for (int i = accepted; i < num_cameras; i++) {
+        if (stream_fds[i] >= 0)
+            close(stream_fds[i]);
+    }
+
+    pw_thread_loop_lock(c->loop);
+
+    /* Swap in the new control socket. */
+    if (c->ctrl_io) {
+        pw_loop_destroy_source(pw_thread_loop_get_loop(c->loop), c->ctrl_io);
+        c->ctrl_io = NULL;
+    }
+    if (c->ctrl_fd >= 0)
+        close(c->ctrl_fd);
+    c->ctrl_fd = ctrl_fd;
+    c->ctrl_buffer_len = 0;
+    c->info_pending = false;
+    if (c->ctrl_fd >= 0) {
+        c->ctrl_io = pw_loop_add_io(pw_thread_loop_get_loop(c->loop), c->ctrl_fd,
+                                    SPA_IO_IN, false, on_control_readable, c);
+        if (!c->ctrl_io) {
+            g_warning("Failed to monitor the Anland camera control channel");
+            clear_resources_locked(c);
+            pw_thread_loop_unlock(c->loop);
+            return;
+        }
+    }
+
+    /* Pop excess cameras if the new connection exposes fewer than before. */
+    for (int i = accepted; i < c->num_cameras; i++) {
+        destroy_node(&c->cams[i]);
+        detach_fd(&c->cams[i]);   /* closes the now-stale stream fd */
+    }
+
+    /* Create any newly-appeared cameras, then (re)attach every live one's stream fd.
+     * Existing nodes are kept (apply-in-place, like the audio engine hot-swaps its
+     * socket) so consuming apps never see the webcam disappear across a reconnect. */
+    c->num_cameras = accepted;
+    for (int i = 0; i < accepted; i++) {
+        struct cam *cam = &c->cams[i];
+        cam->owner = c;
+        cam->index = i;
+        if (c->pw_connected && c->core)
+            create_node(cam);
+        attach_fd(cam, stream_fds[i]);
+    }
+
+    /* The reply is parsed by the PipeWire loop, so a missing consumer response cannot
+     * stall Mutter's main context. It also confirms that the resource fd count and
+     * advertised physical cameras agree. */
+    request_camera_info(c);
+
+    pw_thread_loop_unlock(c->loop);
+}
+
+static void clear_resources_locked(struct anland_camera *c)
+{
+    /* Consumer is gone: drop the control socket and detach every camera's stream fd.
+     * The nodes stay alive and keep emitting blank frames, so PipeWire and any
+     * capturing app never see the cameras disappear -- the audio engine's detach
+     * behaviour. */
+    for (int i = 0; i < c->num_cameras; i++) {
+        struct cam *cam = &c->cams[i];
+        if (cam->recording && c->ctrl_fd >= 0) {
+            uint8_t id = (uint8_t)cam->index;
+            send_ctrl(c, CAMERA_CTRL_STOP_RECORD, &id, 1);
+        }
+        cam->recording = false;
+    }
+    if (c->ctrl_io) {
+        pw_loop_destroy_source(pw_thread_loop_get_loop(c->loop), c->ctrl_io);
+        c->ctrl_io = NULL;
+    }
+    if (c->ctrl_fd >= 0) {
+        close(c->ctrl_fd);
+        c->ctrl_fd = -1;
+    }
+    c->ctrl_buffer_len = 0;
+    c->info_pending = false;
+    for (int i = 0; i < c->num_cameras; i++)
+        detach_fd(&c->cams[i]);
+}
+
+void meta_anland_camera_clear(struct anland_camera *c)
+{
+    if (!c)
+        return;
+    pw_thread_loop_lock(c->loop);
+    clear_resources_locked(c);
+    pw_thread_loop_unlock(c->loop);
+}
+
+struct anland_camera *meta_anland_camera_new(void)
+{
+    pw_init(NULL, NULL);
+
+    struct anland_camera *c = calloc(1, sizeof(*c));
+    if (!c) {
+        return NULL;
+    }
+    c->ctrl_fd = -1;
+    for (int i = 0; i < MAX_CAMERAS; i++) {
+        c->cams[i].owner = c;
+        c->cams[i].index = i;
+        c->cams[i].stream_fd = -1;
+        c->cams[i].shm_fd = -1;
+    }
+
+    c->loop = pw_thread_loop_new("anland-camera", NULL);
+    if (!c->loop)
+        goto fail;
+
+    c->context = pw_context_new(pw_thread_loop_get_loop(c->loop), NULL, 0);
+    if (!c->context)
+        goto fail;
+
+    c->reconnect_timer = pw_loop_add_timer(pw_thread_loop_get_loop(c->loop),
+                                           on_reconnect_timer, c);
+    if (!c->reconnect_timer)
+        goto fail;
+
+    if (pw_thread_loop_start(c->loop) < 0)
+        goto fail;
+    c->loop_started = true;
+
+    pw_thread_loop_lock(c->loop);
+    if (build_pw(c) == 0) {
+        c->pw_connected = true;
+    } else {
+        teardown_pw(c);
+        arm_reconnect(c);
+    }
+    pw_thread_loop_unlock(c->loop);
+
+    return c;
+
+fail:
+    if (c->loop_started)
+        pw_thread_loop_stop(c->loop);
+    if (c->reconnect_timer)
+        pw_loop_destroy_source(pw_thread_loop_get_loop(c->loop),
+                               c->reconnect_timer);
+    if (c->context)
+        pw_context_destroy(c->context);
+    if (c->loop)
+        pw_thread_loop_destroy(c->loop);
+    free(c);
+    return NULL;
+}
+
+void meta_anland_camera_free(struct anland_camera *c)
+{
+    if (!c)
+        return;
+
+    if (c->loop_started)
+        pw_thread_loop_lock(c->loop);
+    clear_resources_locked(c);
+    teardown_pw(c);
+    for (int i = 0; i < MAX_CAMERAS; i++) {
+        struct cam *cam = &c->cams[i];
+        unmap_shm(cam);
+        free(cam->frame);
+        cam->frame = NULL;
+    }
+    if (c->reconnect_timer)
+        pw_loop_destroy_source(pw_thread_loop_get_loop(c->loop), c->reconnect_timer);
+    if (c->loop_started)
+        pw_thread_loop_unlock(c->loop);
+
+    if (c->loop_started)
+        pw_thread_loop_stop(c->loop);
+    if (c->context)
+        pw_context_destroy(c->context);
+    if (c->loop)
+        pw_thread_loop_destroy(c->loop);
+    free(c);
+}

--- a/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-anland-camera.h
+++ b/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-anland-camera.h
@@ -1,0 +1,14 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#pragma once
+
+typedef struct anland_camera MetaAnlandCamera;
+
+MetaAnlandCamera * meta_anland_camera_new (void);
+void meta_anland_camera_free (MetaAnlandCamera *camera);
+
+void meta_anland_camera_set_resources (MetaAnlandCamera *camera,
+                                       int               control_fd,
+                                       const int        *stream_fds,
+                                       int               n_stream_fds);
+void meta_anland_camera_clear (MetaAnlandCamera *camera);

--- a/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-anland-clipboard.c
+++ b/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-anland-clipboard.c
@@ -1,0 +1,321 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#include "config.h"
+
+#include "backends/anland/meta-anland-clipboard.h"
+
+#include "backends/anland/vendor/meta-anland-transport.h"
+#include "meta/display.h"
+#include "meta/meta-backend.h"
+#include "meta/meta-context.h"
+#include "meta/meta-selection.h"
+#include "meta/meta-selection-source-memory.h"
+
+#include <string.h>
+
+#define ANLAND_CLIPBOARD_LIMIT (1024 * 1024)
+
+typedef struct
+{
+  MetaAnlandClipboard *clipboard;
+  guint generation;
+  GOutputStream *output;
+} ClipboardTransfer;
+
+struct _MetaAnlandClipboard
+{
+  int ref_count;
+  MetaSelection *selection;
+  MetaSelectionSource *source;
+  MetaAnlandTransport *transport;
+  GCancellable *transfer_cancellable;
+  GBytes *cached_contents;
+  guint generation;
+  gulong owner_changed_id;
+  gboolean disposed;
+};
+
+static MetaAnlandClipboard *
+meta_anland_clipboard_ref (MetaAnlandClipboard *clipboard)
+{
+  clipboard->ref_count++;
+  return clipboard;
+}
+
+static void
+meta_anland_clipboard_unref (MetaAnlandClipboard *clipboard)
+{
+  if (--clipboard->ref_count != 0)
+    return;
+
+  g_clear_object (&clipboard->transfer_cancellable);
+  g_clear_object (&clipboard->source);
+  g_clear_pointer (&clipboard->cached_contents, g_bytes_unref);
+  g_clear_object (&clipboard->selection);
+  g_free (clipboard);
+}
+
+static gboolean
+contents_are_valid (GBytes *contents)
+{
+  const char *data;
+  gsize size;
+
+  data = g_bytes_get_data (contents, &size);
+  if (size == 0)
+    return TRUE;
+
+  return size <= ANLAND_CLIPBOARD_LIMIT &&
+         !memchr (data, '\0', size) &&
+         g_utf8_validate (data, size, NULL);
+}
+
+static gboolean
+contents_equal (GBytes *a,
+                GBytes *b)
+{
+  return a && b && g_bytes_equal (a, b);
+}
+
+static void
+send_contents (MetaAnlandClipboard *clipboard,
+               GBytes              *contents)
+{
+  struct OutputEvent event = {
+    .type = OUTPUT_TYPE_CLIPBOARD,
+  };
+  const void *data;
+  gsize size;
+
+  if (!clipboard->transport ||
+      meta_anland_transport_is_fallback (clipboard->transport))
+    return;
+
+  data = g_bytes_get_data (contents, &size);
+  event.clipboard.size = size;
+  meta_anland_transport_send_output_event (clipboard->transport, &event,
+                                           data, size);
+}
+
+static void
+set_cached_contents (MetaAnlandClipboard *clipboard,
+                     GBytes              *contents)
+{
+  if (contents_equal (clipboard->cached_contents, contents))
+    return;
+
+  g_clear_pointer (&clipboard->cached_contents, g_bytes_unref);
+  clipboard->cached_contents = g_bytes_ref (contents);
+}
+
+static void
+clipboard_transfer_free (ClipboardTransfer *transfer)
+{
+  g_clear_object (&transfer->output);
+  meta_anland_clipboard_unref (transfer->clipboard);
+  g_free (transfer);
+}
+
+static void
+on_selection_transfer_complete (MetaSelection *selection,
+                                GAsyncResult  *result,
+                                gpointer       user_data)
+{
+  ClipboardTransfer *transfer = user_data;
+  MetaAnlandClipboard *clipboard = transfer->clipboard;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GBytes) contents = NULL;
+
+  if (!meta_selection_transfer_finish (selection, result, &error))
+    {
+      if (!error || !g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+        g_warning ("Anland failed to transfer clipboard: %s",
+                   error ? error->message : "unknown error");
+      goto out;
+    }
+
+  if (clipboard->disposed || transfer->generation != clipboard->generation)
+    goto out;
+
+  g_output_stream_close (transfer->output, NULL, NULL);
+  contents = g_memory_output_stream_steal_as_bytes (
+    G_MEMORY_OUTPUT_STREAM (transfer->output));
+  if (!contents_are_valid (contents))
+    {
+      g_warning ("Anland ignored invalid or oversized clipboard contents");
+      goto out;
+    }
+
+  set_cached_contents (clipboard, contents);
+  send_contents (clipboard, contents);
+
+out:
+  clipboard_transfer_free (transfer);
+}
+
+static const char *
+choose_mimetype (MetaSelection *selection)
+{
+  GList *mimetypes;
+  GList *l;
+  const char *chosen = NULL;
+
+  mimetypes = meta_selection_get_mimetypes (selection,
+                                            META_SELECTION_CLIPBOARD);
+  for (l = mimetypes; l; l = l->next)
+    {
+      if (g_str_equal (l->data, "text/plain;charset=utf-8"))
+        {
+          chosen = "text/plain;charset=utf-8";
+          break;
+        }
+
+      if (!chosen && g_str_equal (l->data, "text/plain"))
+        chosen = "text/plain";
+    }
+  g_list_free_full (mimetypes, g_free);
+
+  return chosen;
+}
+
+static void
+cancel_selection_transfer (MetaAnlandClipboard *clipboard)
+{
+  if (clipboard->transfer_cancellable)
+    g_cancellable_cancel (clipboard->transfer_cancellable);
+  g_clear_object (&clipboard->transfer_cancellable);
+}
+
+static void
+on_selection_owner_changed (MetaSelection       *selection,
+                            MetaSelectionType    selection_type,
+                            MetaSelectionSource *owner,
+                            MetaAnlandClipboard *clipboard)
+{
+  ClipboardTransfer *transfer;
+  const char *mimetype;
+  GOutputStream *output;
+
+  if (selection_type != META_SELECTION_CLIPBOARD || clipboard->disposed)
+    return;
+
+  cancel_selection_transfer (clipboard);
+  clipboard->generation++;
+
+  if (owner == clipboard->source)
+    return;
+
+  g_clear_object (&clipboard->source);
+  if (!owner)
+    {
+      g_autoptr (GBytes) empty = g_bytes_new_static ("", 0);
+
+      set_cached_contents (clipboard, empty);
+      send_contents (clipboard, empty);
+      return;
+    }
+
+  mimetype = choose_mimetype (selection);
+  if (!mimetype)
+    return;
+
+  output = g_memory_output_stream_new_resizable ();
+  clipboard->transfer_cancellable = g_cancellable_new ();
+  transfer = g_new0 (ClipboardTransfer, 1);
+  transfer->clipboard = meta_anland_clipboard_ref (clipboard);
+  transfer->generation = clipboard->generation;
+  transfer->output = g_object_ref (output);
+  meta_selection_transfer_async (selection, META_SELECTION_CLIPBOARD, mimetype,
+                                 ANLAND_CLIPBOARD_LIMIT, output,
+                                 clipboard->transfer_cancellable,
+                                 (GAsyncReadyCallback) on_selection_transfer_complete,
+                                 transfer);
+  g_object_unref (output);
+}
+
+MetaAnlandClipboard *
+meta_anland_clipboard_new (MetaBackend *backend)
+{
+  MetaAnlandClipboard *clipboard;
+  MetaContext *context;
+  MetaDisplay *display;
+
+  context = meta_backend_get_context (backend);
+  display = meta_context_get_display (context);
+  if (!display)
+    return NULL;
+
+  clipboard = g_new0 (MetaAnlandClipboard, 1);
+  clipboard->ref_count = 1;
+  clipboard->selection = g_object_ref (meta_display_get_selection (display));
+  clipboard->owner_changed_id = g_signal_connect_after (
+    clipboard->selection, "owner-changed",
+    G_CALLBACK (on_selection_owner_changed), clipboard);
+  return clipboard;
+}
+
+void
+meta_anland_clipboard_free (MetaAnlandClipboard *clipboard)
+{
+  if (!clipboard)
+    return;
+
+  clipboard->disposed = TRUE;
+  meta_anland_clipboard_set_transport (clipboard, NULL);
+  if (clipboard->owner_changed_id)
+    {
+      g_signal_handler_disconnect (clipboard->selection,
+                                   clipboard->owner_changed_id);
+      clipboard->owner_changed_id = 0;
+    }
+  meta_anland_clipboard_unref (clipboard);
+}
+
+void
+meta_anland_clipboard_set_transport (MetaAnlandClipboard *clipboard,
+                                     MetaAnlandTransport *transport)
+{
+  if (!clipboard || clipboard->transport == transport)
+    return;
+
+  clipboard->generation++;
+  cancel_selection_transfer (clipboard);
+  clipboard->transport = transport;
+
+  /*
+   * The consumer reads the Android clipboard as part of its reconnect path.
+   * Do not race that initial sync by replaying cached compositor contents here:
+   * when the app was in the background, doing so can overwrite a newer Android
+   * clipboard before it has a chance to send it to Mutter.
+   */
+}
+
+gboolean
+meta_anland_clipboard_set_from_consumer (MetaAnlandClipboard *clipboard,
+                                         GBytes              *contents)
+{
+  g_autoptr (GError) error = NULL;
+  g_autoptr (MetaSelectionSource) source = NULL;
+
+  if (!clipboard || !contents_are_valid (contents))
+    return FALSE;
+
+  if (contents_equal (clipboard->cached_contents, contents))
+    return TRUE;
+
+  source = meta_selection_source_memory_new ("text/plain;charset=utf-8",
+                                              contents, &error);
+  if (!source)
+    {
+      g_warning ("Anland failed to create clipboard source: %s", error->message);
+      return FALSE;
+    }
+
+  cancel_selection_transfer (clipboard);
+  clipboard->generation++;
+  set_cached_contents (clipboard, contents);
+  g_set_object (&clipboard->source, source);
+  meta_selection_set_owner (clipboard->selection, META_SELECTION_CLIPBOARD,
+                            source);
+  return TRUE;
+}

--- a/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-anland-clipboard.h
+++ b/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-anland-clipboard.h
@@ -1,0 +1,18 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#pragma once
+
+#include <gio/gio.h>
+
+typedef struct _MetaAnlandClipboard MetaAnlandClipboard;
+typedef struct _MetaAnlandTransport MetaAnlandTransport;
+typedef struct _MetaBackend MetaBackend;
+
+MetaAnlandClipboard * meta_anland_clipboard_new (MetaBackend *backend);
+void meta_anland_clipboard_free (MetaAnlandClipboard *clipboard);
+
+void meta_anland_clipboard_set_transport (MetaAnlandClipboard *clipboard,
+                                          MetaAnlandTransport *transport);
+
+gboolean meta_anland_clipboard_set_from_consumer (MetaAnlandClipboard *clipboard,
+                                                   GBytes              *contents);

--- a/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-anland-input.c
+++ b/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-anland-input.c
@@ -1,0 +1,582 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#include "config.h"
+
+#include "backends/anland/meta-anland-input.h"
+
+#include "backends/meta-backend-private.h"
+#include "backends/meta-logical-monitor-private.h"
+#include "backends/meta-monitor-manager-private.h"
+#include "backends/native/meta-virtual-input-device-native.h"
+
+#include <linux/input.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define ANLAND_MAX_TOUCH_BATCH_EVENTS 128
+#define ANLAND_TOUCH_BATCH_TIMEOUT_MS 100
+
+struct _MetaAnlandInput
+{
+  MetaBackend *backend;
+  ClutterVirtualInputDevice *pointer;
+  ClutterVirtualInputDevice *keyboard;
+  ClutterVirtualInputDevice *touchscreen;
+  gboolean pressed_keys[KEY_CNT];
+  gboolean pressed_buttons[KEY_CNT];
+  GHashTable *touch_slots;
+  gboolean active_touch_slots[CLUTTER_VIRTUAL_INPUT_DEVICE_MAX_TOUCH_SLOTS];
+  GArray *touch_batch;
+  guint touch_batch_timeout_id;
+
+  MetaAnlandInputRefreshFunc refresh_func;
+  gpointer refresh_user_data;
+};
+
+static void
+map_input_coordinates (MetaAnlandInput *input,
+                       uint32_t         input_width,
+                       uint32_t         input_height,
+                       float            x,
+                       float            y,
+                       gboolean         is_delta,
+                       float           *mapped_x,
+                       float           *mapped_y)
+{
+  MetaMonitorManager *monitor_manager;
+  MetaLogicalMonitor *logical_monitor;
+  MtkRectangle layout;
+
+  *mapped_x = x;
+  *mapped_y = y;
+
+  if (input_width == 0 || input_height == 0)
+    return;
+
+  monitor_manager = meta_backend_get_monitor_manager (input->backend);
+  logical_monitor =
+    meta_monitor_manager_get_primary_logical_monitor (monitor_manager);
+  if (!logical_monitor)
+    return;
+
+  layout = meta_logical_monitor_get_layout (logical_monitor);
+
+  /* Anland reports buffer pixels, while Clutter uses the logical layout. */
+  *mapped_x = x * layout.width / input_width;
+  *mapped_y = y * layout.height / input_height;
+
+  if (!is_delta)
+    {
+      *mapped_x += layout.x;
+      *mapped_y += layout.y;
+    }
+}
+
+static gboolean
+is_finite_pair (float x,
+                float y)
+{
+  return isfinite (x) && isfinite (y);
+}
+
+static void
+clear_touch_slot (MetaAnlandInput *input,
+                  int              slot)
+{
+  GHashTableIter iter;
+  gpointer key;
+  gpointer value;
+
+  g_hash_table_iter_init (&iter, input->touch_slots);
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    {
+      if (GPOINTER_TO_UINT (value) == (guint) slot + 1)
+        {
+          g_hash_table_iter_remove (&iter);
+          break;
+        }
+    }
+  input->active_touch_slots[slot] = FALSE;
+}
+
+static void
+cancel_touches (MetaAnlandInput *input)
+{
+  MetaVirtualTouchEvent events[CLUTTER_VIRTUAL_INPUT_DEVICE_MAX_TOUCH_SLOTS];
+  guint n_events = 0;
+  guint slot;
+
+  if (!input->touchscreen)
+    return;
+
+  for (slot = 0; slot < G_N_ELEMENTS (input->active_touch_slots); slot++)
+    {
+      if (!input->active_touch_slots[slot])
+        continue;
+
+      events[n_events++] = (MetaVirtualTouchEvent) {
+        .type = META_VIRTUAL_TOUCH_EVENT_CANCEL,
+        .slot = slot,
+      };
+    }
+
+  if (n_events > 0)
+    meta_virtual_input_device_native_notify_touch_events (
+      META_VIRTUAL_INPUT_DEVICE_NATIVE (input->touchscreen),
+      g_get_monotonic_time (), events, n_events);
+
+  if (input->touch_slots)
+    g_hash_table_remove_all (input->touch_slots);
+  memset (input->active_touch_slots, 0, sizeof (input->active_touch_slots));
+}
+
+static gboolean
+touch_batch_timeout_cb (gpointer user_data)
+{
+  MetaAnlandInput *input = user_data;
+
+  input->touch_batch_timeout_id = 0;
+  if (input->touch_batch->len > 0)
+    {
+      g_warning ("Anland input dropped an incomplete touch frame");
+      cancel_touches (input);
+      g_array_set_size (input->touch_batch, 0);
+    }
+
+  return G_SOURCE_REMOVE;
+}
+
+static void
+schedule_touch_batch_timeout (MetaAnlandInput *input)
+{
+  if (!input->touch_batch_timeout_id)
+    input->touch_batch_timeout_id =
+      g_timeout_add (ANLAND_TOUCH_BATCH_TIMEOUT_MS,
+                     touch_batch_timeout_cb, input);
+}
+
+static int
+allocate_touch_slot (MetaAnlandInput *input)
+{
+  guint slot;
+
+  for (slot = 0; slot < G_N_ELEMENTS (input->active_touch_slots); slot++)
+    {
+      if (!input->active_touch_slots[slot])
+        return slot;
+    }
+
+  return -1;
+}
+
+static void
+flush_touch_batch (MetaAnlandInput *input)
+{
+  guint i;
+
+  if (input->touch_batch_timeout_id)
+    {
+      g_source_remove (input->touch_batch_timeout_id);
+      input->touch_batch_timeout_id = 0;
+    }
+
+  if (input->touch_batch->len == 0)
+    return;
+
+  meta_virtual_input_device_native_notify_touch_events (
+    META_VIRTUAL_INPUT_DEVICE_NATIVE (input->touchscreen),
+    g_get_monotonic_time (), (const MetaVirtualTouchEvent *) input->touch_batch->data,
+    input->touch_batch->len);
+
+  for (i = 0; i < input->touch_batch->len; i++)
+    {
+      const MetaVirtualTouchEvent *event =
+        &g_array_index (input->touch_batch, MetaVirtualTouchEvent, i);
+
+      if (event->type == META_VIRTUAL_TOUCH_EVENT_UP)
+        clear_touch_slot (input, event->slot);
+    }
+  g_array_set_size (input->touch_batch, 0);
+}
+
+static void
+handle_pointer_motion (MetaAnlandInput         *input,
+                       const struct InputEvent *event,
+                       uint32_t                 input_width,
+                       uint32_t                 input_height)
+{
+  float x, y, dx, dy;
+
+  if (!is_finite_pair (event->pointer_motion.x, event->pointer_motion.y) ||
+      !is_finite_pair (event->pointer_motion.dx, event->pointer_motion.dy))
+    return;
+
+  map_input_coordinates (input, input_width, input_height,
+                         event->pointer_motion.x, event->pointer_motion.y,
+                         FALSE, &x, &y);
+  map_input_coordinates (input, input_width, input_height,
+                         event->pointer_motion.dx, event->pointer_motion.dy,
+                         TRUE, &dx, &dy);
+
+  meta_virtual_input_device_native_notify_absolute_relative_motion (
+    META_VIRTUAL_INPUT_DEVICE_NATIVE (input->pointer), g_get_monotonic_time (),
+    x, y, dx, dy);
+}
+
+static void
+handle_pointer_button (MetaAnlandInput         *input,
+                       const struct InputEvent *event)
+{
+  uint32_t button = event->pointer_button.button;
+  gboolean pressed = event->pointer_button.pressed != 0;
+
+  if (button >= KEY_CNT || button < BTN_LEFT || button > BTN_GEAR_UP ||
+      input->pressed_buttons[button] == pressed)
+    return;
+
+  input->pressed_buttons[button] = pressed;
+  clutter_virtual_input_device_notify_button (
+    input->pointer, g_get_monotonic_time (), meta_evdev_button_to_clutter (button),
+    pressed ? CLUTTER_BUTTON_STATE_PRESSED : CLUTTER_BUTTON_STATE_RELEASED);
+}
+
+static void
+handle_pointer_axis (MetaAnlandInput         *input,
+                     const struct InputEvent *event)
+{
+  ClutterScrollDirection direction;
+  double dx = 0.0;
+  double dy = 0.0;
+  int64_t discrete = event->pointer_axis.discrete;
+  int steps;
+
+  if (!isfinite (event->pointer_axis.value))
+    return;
+
+  switch (event->pointer_axis.axis)
+    {
+    case 0:
+      dy = event->pointer_axis.value;
+      direction = discrete >= 0 ? CLUTTER_SCROLL_DOWN : CLUTTER_SCROLL_UP;
+      break;
+    case 1:
+      dx = event->pointer_axis.value;
+      direction = discrete >= 0 ? CLUTTER_SCROLL_RIGHT : CLUTTER_SCROLL_LEFT;
+      break;
+    default:
+      g_warning ("Anland input ignored invalid scroll axis %u",
+                 event->pointer_axis.axis);
+      return;
+    }
+
+  if (dx != 0.0 || dy != 0.0)
+    clutter_virtual_input_device_notify_scroll_continuous (
+      input->pointer, g_get_monotonic_time (), dx, dy,
+      CLUTTER_SCROLL_SOURCE_WHEEL, CLUTTER_SCROLL_FINISHED_NONE);
+
+  steps = MIN (llabs (discrete), 120);
+  while (steps-- > 0)
+    clutter_virtual_input_device_notify_discrete_scroll (
+      input->pointer, g_get_monotonic_time (), direction,
+      CLUTTER_SCROLL_SOURCE_WHEEL);
+}
+
+static void
+handle_key (MetaAnlandInput         *input,
+            const struct InputEvent *event)
+{
+  uint32_t keycode = event->key.keycode;
+  gboolean pressed;
+
+  if (keycode >= KEY_CNT ||
+      (event->key.action != INPUT_ACTION_DOWN &&
+       event->key.action != INPUT_ACTION_UP))
+    return;
+
+  pressed = event->key.action == INPUT_ACTION_DOWN;
+  if (input->pressed_keys[keycode] == pressed)
+    return;
+
+  input->pressed_keys[keycode] = pressed;
+  clutter_virtual_input_device_notify_key (
+    input->keyboard, g_get_monotonic_time (), keycode,
+    pressed ? CLUTTER_KEY_STATE_PRESSED : CLUTTER_KEY_STATE_RELEASED);
+}
+
+static void
+handle_touch (MetaAnlandInput         *input,
+              const struct InputEvent *event,
+              uint32_t                 input_width,
+              uint32_t                 input_height)
+{
+  gpointer value;
+  int slot;
+  MetaVirtualTouchEvent touch_event;
+  float x, y;
+
+  if ((event->touch.action == INPUT_ACTION_DOWN ||
+       event->touch.action == INPUT_ACTION_MOVE) &&
+      !is_finite_pair (event->touch.x, event->touch.y))
+    return;
+
+  if (event->touch.action == INPUT_ACTION_DOWN ||
+      event->touch.action == INPUT_ACTION_MOVE)
+    map_input_coordinates (input, input_width, input_height,
+                           event->touch.x, event->touch.y,
+                           FALSE, &x, &y);
+
+  value = g_hash_table_lookup (input->touch_slots,
+                               GINT_TO_POINTER (event->touch.pointer_id));
+  switch (event->touch.action)
+    {
+    case INPUT_ACTION_DOWN:
+      if (value)
+        return;
+
+      slot = allocate_touch_slot (input);
+      if (slot < 0)
+        {
+          g_warning ("Anland input ran out of touch slots");
+          return;
+        }
+      input->active_touch_slots[slot] = TRUE;
+      g_hash_table_insert (input->touch_slots,
+                           GINT_TO_POINTER (event->touch.pointer_id),
+                           GUINT_TO_POINTER (slot + 1));
+      touch_event = (MetaVirtualTouchEvent) {
+        .type = META_VIRTUAL_TOUCH_EVENT_DOWN,
+        .slot = slot,
+        .x = x,
+        .y = y,
+      };
+      break;
+    case INPUT_ACTION_MOVE:
+      if (!value)
+        return;
+      touch_event = (MetaVirtualTouchEvent) {
+        .type = META_VIRTUAL_TOUCH_EVENT_MOTION,
+        .slot = GPOINTER_TO_UINT (value) - 1,
+        .x = x,
+        .y = y,
+      };
+      break;
+    case INPUT_ACTION_UP:
+      if (!value)
+        return;
+      touch_event = (MetaVirtualTouchEvent) {
+        .type = META_VIRTUAL_TOUCH_EVENT_UP,
+        .slot = GPOINTER_TO_UINT (value) - 1,
+      };
+      break;
+    default:
+      return;
+    }
+
+  if (input->touch_batch->len >= ANLAND_MAX_TOUCH_BATCH_EVENTS)
+    {
+      g_warning ("Anland input dropped an oversized touch frame");
+      cancel_touches (input);
+      g_array_set_size (input->touch_batch, 0);
+      return;
+    }
+
+  g_array_append_val (input->touch_batch, touch_event);
+  schedule_touch_batch_timeout (input);
+}
+
+MetaAnlandInput *
+meta_anland_input_new (MetaBackend               *backend,
+                       MetaAnlandInputRefreshFunc  refresh_func,
+                       gpointer                    user_data,
+                       GError                    **error)
+{
+  MetaAnlandInput *input;
+  ClutterSeat *seat;
+
+  seat = meta_backend_get_default_seat (backend);
+  if (!seat)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Anland backend has no default input seat");
+      return NULL;
+    }
+
+  input = g_new0 (MetaAnlandInput, 1);
+  input->backend = backend;
+  input->touch_slots = g_hash_table_new (g_direct_hash, g_direct_equal);
+  input->touch_batch = g_array_new (FALSE, FALSE, sizeof (MetaVirtualTouchEvent));
+  input->pointer = clutter_seat_create_virtual_device (seat,
+                                                        CLUTTER_POINTER_DEVICE);
+  input->keyboard = clutter_seat_create_virtual_device (seat,
+                                                         CLUTTER_KEYBOARD_DEVICE);
+  input->touchscreen = clutter_seat_create_virtual_device (seat,
+                                                            CLUTTER_TOUCHSCREEN_DEVICE);
+  if (!input->pointer || !input->keyboard || !input->touchscreen)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Failed to create Anland virtual input devices");
+      meta_anland_input_free (input);
+      return NULL;
+    }
+
+  input->refresh_func = refresh_func;
+  input->refresh_user_data = user_data;
+  return input;
+}
+
+void
+meta_anland_input_free (MetaAnlandInput *input)
+{
+  if (!input)
+    return;
+
+  if (input->touch_batch_timeout_id)
+    {
+      g_source_remove (input->touch_batch_timeout_id);
+      input->touch_batch_timeout_id = 0;
+    }
+  meta_anland_input_reset (input);
+  g_clear_object (&input->pointer);
+  g_clear_object (&input->keyboard);
+  g_clear_object (&input->touchscreen);
+  g_clear_pointer (&input->touch_slots, g_hash_table_unref);
+  g_clear_pointer (&input->touch_batch, g_array_unref);
+  g_free (input);
+}
+
+MetaAnlandInputEventResult
+meta_anland_input_handle_event (MetaAnlandInput         *input,
+                                MetaAnlandTransport     *transport,
+                                const struct InputEvent *event,
+                                uint32_t                 input_width,
+                                uint32_t                 input_height)
+{
+  switch (event->type)
+    {
+    case INPUT_TYPE_POINTER_MOTION:
+      handle_pointer_motion (input, event, input_width, input_height);
+      break;
+    case INPUT_TYPE_POINTER_BUTTON:
+      handle_pointer_button (input, event);
+      break;
+    case INPUT_TYPE_POINTER_AXIS:
+      handle_pointer_axis (input, event);
+      break;
+    case INPUT_TYPE_KEY:
+      handle_key (input, event);
+      break;
+    case INPUT_TYPE_TOUCH:
+      handle_touch (input, event, input_width, input_height);
+      break;
+    case INPUT_TYPE_TOUCH_FRAME:
+      flush_touch_batch (input);
+      break;
+    case INPUT_TYPE_DISPLAY_REFRESH:
+      if (event->display.refresh_mhz >= 1000 &&
+          event->display.refresh_mhz <= 1000000 && input->refresh_func)
+        input->refresh_func (event->display.refresh_mhz,
+                             input->refresh_user_data);
+      break;
+    case INPUT_TYPE_CLIPBOARD:
+    case INPUT_TYPE_TEXT_INPUT:
+      return META_ANLAND_INPUT_EVENT_NEEDS_PAYLOAD;
+    case INPUT_TYPE_RESOURCE:
+      return META_ANLAND_INPUT_EVENT_NEEDS_RESOURCE_FDS;
+    case INPUT_TYPE_ACTION:
+      break;
+    default:
+      g_warning ("Anland input ignored unknown event type %u", event->type);
+      break;
+    }
+
+  return META_ANLAND_INPUT_EVENT_HANDLED;
+}
+
+gboolean
+meta_anland_input_inject_text (MetaAnlandInput *input,
+                               const char      *text)
+{
+  const char *cursor = text;
+  gboolean injected = FALSE;
+
+  if (!input || !input->keyboard || !text)
+    return FALSE;
+
+  while (*cursor)
+    {
+      gunichar keyval;
+
+      keyval = g_utf8_get_char_validated (cursor, -1);
+      if (keyval == (gunichar) -1 || keyval == (gunichar) -2)
+        return FALSE;
+
+      switch (keyval)
+        {
+        case '\n':
+        case '\r':
+          keyval = CLUTTER_KEY_Return;
+          break;
+        case '\t':
+          keyval = CLUTTER_KEY_Tab;
+          break;
+        case '\b':
+          keyval = CLUTTER_KEY_BackSpace;
+          break;
+        default:
+          break;
+        }
+
+      clutter_virtual_input_device_notify_keyval (
+        input->keyboard, g_get_monotonic_time (), keyval,
+        CLUTTER_KEY_STATE_PRESSED);
+      clutter_virtual_input_device_notify_keyval (
+        input->keyboard, g_get_monotonic_time (), keyval,
+        CLUTTER_KEY_STATE_RELEASED);
+      cursor = g_utf8_next_char (cursor);
+      injected = TRUE;
+    }
+
+  return injected;
+}
+
+void
+meta_anland_input_reset (MetaAnlandInput *input)
+{
+  guint code;
+
+  if (!input)
+    return;
+
+  if (input->touch_batch_timeout_id)
+    {
+      g_source_remove (input->touch_batch_timeout_id);
+      input->touch_batch_timeout_id = 0;
+    }
+
+  for (code = 0; code < G_N_ELEMENTS (input->pressed_keys); code++)
+    {
+      if (!input->pressed_keys[code])
+        continue;
+
+      clutter_virtual_input_device_notify_key (
+        input->keyboard, g_get_monotonic_time (), code,
+        CLUTTER_KEY_STATE_RELEASED);
+      input->pressed_keys[code] = FALSE;
+    }
+
+  for (code = BTN_LEFT; code < G_N_ELEMENTS (input->pressed_buttons); code++)
+    {
+      if (!input->pressed_buttons[code])
+        continue;
+
+      clutter_virtual_input_device_notify_button (
+        input->pointer, g_get_monotonic_time (),
+        meta_evdev_button_to_clutter (code), CLUTTER_BUTTON_STATE_RELEASED);
+      input->pressed_buttons[code] = FALSE;
+    }
+
+  cancel_touches (input);
+  g_array_set_size (input->touch_batch, 0);
+}

--- a/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-anland-input.h
+++ b/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-anland-input.h
@@ -1,0 +1,37 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#pragma once
+
+#include <glib.h>
+
+#include "backends/anland/vendor/meta-anland-transport.h"
+#include "backends/meta-backend-types.h"
+
+typedef struct _MetaAnlandInput MetaAnlandInput;
+
+typedef enum
+{
+  META_ANLAND_INPUT_EVENT_HANDLED,
+  META_ANLAND_INPUT_EVENT_NEEDS_PAYLOAD,
+  META_ANLAND_INPUT_EVENT_NEEDS_RESOURCE_FDS,
+  META_ANLAND_INPUT_EVENT_ERROR,
+} MetaAnlandInputEventResult;
+
+typedef void (* MetaAnlandInputRefreshFunc) (uint32_t refresh_mhz,
+                                              gpointer user_data);
+
+MetaAnlandInput * meta_anland_input_new (MetaBackend                *backend,
+                                         MetaAnlandInputRefreshFunc   refresh_func,
+                                         gpointer                     user_data,
+                                         GError                     **error);
+void meta_anland_input_free (MetaAnlandInput *input);
+
+MetaAnlandInputEventResult
+meta_anland_input_handle_event (MetaAnlandInput          *input,
+                                MetaAnlandTransport      *transport,
+                                const struct InputEvent  *event,
+                                uint32_t                  input_width,
+                                uint32_t                  input_height);
+gboolean meta_anland_input_inject_text (MetaAnlandInput *input,
+                                        const char      *text);
+void meta_anland_input_reset (MetaAnlandInput *input);

--- a/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-backend-anland.c
+++ b/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-backend-anland.c
@@ -1,0 +1,1067 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#include "config.h"
+
+#include "backends/anland/meta-backend-anland.h"
+
+#include "backends/anland/meta-anland-audio.h"
+#include "backends/anland/meta-anland-camera.h"
+#include "backends/anland/meta-anland-clipboard.h"
+#include "backends/anland/meta-anland-input.h"
+#include "backends/anland/vendor/meta-anland-transport.h"
+#include "backends/meta-backend-private.h"
+#include "backends/meta-fd-source.h"
+#include "backends/meta-monitor-manager-private.h"
+#include "backends/meta-renderer.h"
+#include "backends/meta-renderer-view.h"
+#include "backends/meta-stage-view-private.h"
+#include "backends/meta-virtual-monitor.h"
+#include "backends/native/meta-renderer-native-private.h"
+#include "meta/meta-backend.h"
+#include "meta/meta-context.h"
+#include "meta/meta-wayland-compositor.h"
+#include "wayland/meta-wayland.h"
+
+#include <drm_fourcc.h>
+#include <fcntl.h>
+#include <math.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define ANLAND_RECONNECT_INTERVAL_MS 200
+#define ANLAND_PROTOCOL_FORMAT_RGBA_8888 1
+#define ANLAND_MAX_RESOURCE_FDS 64
+
+enum
+{
+  PROP_0,
+
+  PROP_ANLAND_SOCKET,
+};
+
+struct _MetaBackendAnland
+{
+  MetaBackendNative parent;
+
+  char *socket_path;
+  MetaAnlandTransport *transport;
+  MetaVirtualMonitor *virtual_monitor;
+  struct screen_info screen_info;
+  guint reconnect_source_id;
+  MetaAnlandAudio *audio;
+  MetaAnlandCamera *camera;
+  MetaAnlandInput *input;
+  MetaAnlandClipboard *clipboard;
+
+  GSource *buffer_ready_source;
+  GSource *input_source;
+  MetaStageView *stage_view;
+  CoglFramebuffer *placeholder_framebuffer;
+  CoglFramebuffer *buffer_framebuffers[MAX_BUFS];
+  int current_buffer;
+  gboolean consumer_active;
+  gboolean frame_clock_inhibited;
+  gboolean frame_pending;
+  gboolean warned_sync_fallback;
+  int64_t pending_global_frame_counter;
+  int64_t pending_view_frame_counter;
+  unsigned int presentation_sequence;
+};
+
+G_DEFINE_TYPE (MetaBackendAnland, meta_backend_anland, META_TYPE_BACKEND_NATIVE)
+
+static void deactivate_consumer (MetaBackendAnland *backend);
+static void release_stage_view (MetaBackendAnland *backend);
+static void schedule_reconnect (MetaBackendAnland *backend);
+
+static void
+on_context_started (MetaContext        *context,
+                    MetaBackendAnland *backend)
+{
+  backend->clipboard = meta_anland_clipboard_new (META_BACKEND (backend));
+  if (!backend->clipboard)
+    g_warning ("Failed to initialize Anland clipboard bridge");
+}
+
+static gboolean
+read_text_payload (MetaBackendAnland  *backend,
+                   uint32_t            size,
+                   const char         *name,
+                   GBytes            **contents)
+{
+  g_autofree char *text = NULL;
+
+  *contents = NULL;
+  if (size > META_ANLAND_MAX_PAYLOAD_SIZE)
+    {
+      g_warning ("Anland rejected oversized %s payload", name);
+      return FALSE;
+    }
+
+  text = g_malloc (size + 1);
+  if (meta_anland_transport_read_input_payload (backend->transport, text,
+                                                size, 100) != 1)
+    return FALSE;
+  text[size] = '\0';
+
+  if (memchr (text, '\0', size) || !g_utf8_validate (text, size, NULL))
+    {
+      g_warning ("Anland ignored invalid UTF-8 %s payload", name);
+      return TRUE;
+    }
+
+  *contents = g_bytes_new (text, size);
+  return TRUE;
+}
+
+static gboolean
+handle_extended_input (MetaBackendAnland       *backend,
+                       const struct InputEvent *event)
+{
+  g_autoptr (GBytes) contents = NULL;
+  g_autofree char *input_text = NULL;
+  const char *text;
+  guint size;
+
+  switch (event->type)
+    {
+    case INPUT_TYPE_CLIPBOARD:
+      if (!read_text_payload (backend, event->clipboard.size, "clipboard",
+                              &contents))
+        return FALSE;
+      break;
+    case INPUT_TYPE_TEXT_INPUT:
+      if (!read_text_payload (backend, event->text_input.size, "text input",
+                              &contents))
+        return FALSE;
+      break;
+    default:
+      return FALSE;
+    }
+
+  if (!contents)
+    return TRUE;
+
+  size = g_bytes_get_size (contents);
+  if (size == 0)
+    return TRUE;
+
+  text = g_bytes_get_data (contents, NULL);
+  if (event->type == INPUT_TYPE_CLIPBOARD)
+    return meta_anland_clipboard_set_from_consumer (backend->clipboard,
+                                                    contents);
+
+  input_text = g_strndup (text, size);
+
+  {
+    MetaContext *context = meta_backend_get_context (META_BACKEND (backend));
+    MetaWaylandCompositor *compositor =
+      meta_context_get_wayland_compositor (context);
+
+    if (compositor && meta_wayland_text_input_commit_string (
+          meta_wayland_compositor_get_text_input (compositor), input_text))
+      return TRUE;
+  }
+
+  return meta_anland_input_inject_text (backend->input, input_text);
+}
+
+static void
+close_resource_fds (int *fds,
+                    int  n_fds)
+{
+  int i;
+
+  for (i = 0; i < n_fds; i++)
+    {
+      if (fds[i] >= 0)
+        close (fds[i]);
+    }
+}
+
+static gboolean
+set_resource_fds_cloexec (int *fds,
+                          int  n_fds)
+{
+  int i;
+
+  for (i = 0; i < n_fds; i++)
+    {
+      int flags = fcntl (fds[i], F_GETFD);
+
+      if (flags < 0 || fcntl (fds[i], F_SETFD, flags | FD_CLOEXEC) < 0)
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+handle_resource_input (MetaBackendAnland       *backend,
+                       const struct InputEvent *event)
+{
+  int fds[ANLAND_MAX_RESOURCE_FDS];
+  int n_fds = 0;
+
+  if (event->resource.fdnum == 0 ||
+      event->resource.fdnum > G_N_ELEMENTS (fds) ||
+      meta_anland_transport_read_input_fds (backend->transport, fds,
+                                            G_N_ELEMENTS (fds), &n_fds, 100) != 1 ||
+      n_fds != (int) event->resource.fdnum)
+    {
+      close_resource_fds (fds, n_fds);
+      return FALSE;
+    }
+
+  if (!set_resource_fds_cloexec (fds, n_fds))
+    {
+      close_resource_fds (fds, n_fds);
+      return FALSE;
+    }
+
+  if (event->resource.type == SERVICE_TYPE_CAMERA && backend->camera)
+    {
+      meta_anland_camera_set_resources (backend->camera, fds[0], &fds[1],
+                                        n_fds - 1);
+      return TRUE;
+    }
+
+  close_resource_fds (fds, n_fds);
+  return TRUE;
+}
+
+static void
+request_camera_resources (MetaBackendAnland *backend)
+{
+  struct OutputEvent event = {
+    .type = OUTPUT_TYPE_RESOURCES_REQUEST,
+    .resources_request.type = SERVICE_TYPE_CAMERA,
+  };
+
+  if (!backend->camera)
+    return;
+
+  meta_anland_transport_send_output_event (backend->transport, &event,
+                                           NULL, 0);
+}
+
+static char *
+get_default_socket_path (void)
+{
+  const char *socket_path = g_getenv ("ANLAND_SOCKET");
+  const char *tmpdir;
+  const char *prefix;
+
+  if (socket_path && *socket_path)
+    return g_strdup (socket_path);
+
+  tmpdir = g_getenv ("TMPDIR");
+  if (tmpdir && *tmpdir)
+    return g_build_filename (tmpdir, "anland", "display_daemon.sock", NULL);
+
+  prefix = g_getenv ("PREFIX");
+  if (prefix && g_str_has_prefix (prefix, "/data/data/com.termux/"))
+    return g_strdup ("/data/data/com.termux/files/usr/tmp/anland/display_daemon.sock");
+
+  return g_strdup ("/tmp/anland/display_daemon.sock");
+}
+
+static gboolean
+validate_screen_info (const struct screen_info  *screen_info,
+                      GError                   **error)
+{
+  if (screen_info->width == 0 || screen_info->height == 0 ||
+      screen_info->width > G_MAXINT || screen_info->height > G_MAXINT ||
+      (screen_info->refresh != 0 && screen_info->refresh < 1000) ||
+      screen_info->refresh > 1000000)
+    {
+      if (error)
+        g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+                     "Anland daemon provided invalid screen information");
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static void
+clear_transport (MetaBackendAnland *backend)
+{
+  deactivate_consumer (backend);
+
+  if (backend->transport)
+    meta_anland_transport_disconnect (backend->transport);
+  backend->transport = NULL;
+}
+
+static gboolean
+connect_transport (MetaBackendAnland  *backend,
+                   GError            **error)
+{
+  struct screen_info screen_info;
+
+  if (backend->transport)
+    return TRUE;
+
+  if (meta_anland_transport_connect (&backend->transport,
+                                     backend->socket_path) < 0)
+    {
+      if (error)
+        g_set_error (error, G_IO_ERROR, G_IO_ERROR_CONNECTION_REFUSED,
+                     "Failed to connect to Anland daemon at %s",
+                     backend->socket_path);
+      return FALSE;
+    }
+
+  if (!meta_anland_transport_get_screen_info (backend->transport, &screen_info) ||
+      !validate_screen_info (&screen_info, error))
+    {
+      clear_transport (backend);
+      return FALSE;
+    }
+
+  backend->screen_info = screen_info;
+  return TRUE;
+}
+
+static gboolean
+update_virtual_monitor (MetaBackendAnland  *backend,
+                        GError            **error)
+{
+  MetaMonitorManager *monitor_manager;
+  float refresh_rate;
+  g_autolist (MetaVirtualModeInfo) mode_infos = NULL;
+
+  if (!backend->transport)
+    return FALSE;
+
+  monitor_manager = meta_backend_get_monitor_manager (META_BACKEND (backend));
+  refresh_rate = backend->screen_info.refresh > 0 ?
+    backend->screen_info.refresh / 1000.0f : 60.0f;
+  mode_infos = g_list_append (mode_infos,
+                              meta_virtual_mode_info_new (
+                                backend->screen_info.width,
+                                backend->screen_info.height,
+                                refresh_rate));
+
+  if (backend->virtual_monitor)
+    {
+      release_stage_view (backend);
+      meta_virtual_monitor_set_modes (backend->virtual_monitor, mode_infos);
+      meta_monitor_manager_reload (monitor_manager);
+      return TRUE;
+    }
+
+  g_autoptr (MetaVirtualMonitorInfo) info =
+    meta_virtual_monitor_info_new ("Anland", "Anland-1", "Anland-1",
+                                   mode_infos);
+  backend->virtual_monitor =
+    meta_monitor_manager_create_virtual_monitor (monitor_manager, info, error);
+  if (!backend->virtual_monitor)
+    return FALSE;
+
+  meta_monitor_manager_reload (monitor_manager);
+  return TRUE;
+}
+
+static void
+inhibit_frame_clock (MetaBackendAnland *backend)
+{
+  if (!backend->stage_view || backend->frame_clock_inhibited)
+    return;
+
+  clutter_frame_clock_inhibit (
+    clutter_stage_view_get_frame_clock (CLUTTER_STAGE_VIEW (backend->stage_view)));
+  backend->frame_clock_inhibited = TRUE;
+}
+
+static void
+uninhibit_frame_clock (MetaBackendAnland *backend)
+{
+  if (!backend->stage_view || !backend->frame_clock_inhibited)
+    return;
+
+  clutter_frame_clock_uninhibit (
+    clutter_stage_view_get_frame_clock (CLUTTER_STAGE_VIEW (backend->stage_view)));
+  backend->frame_clock_inhibited = FALSE;
+}
+
+static void
+release_stage_view (MetaBackendAnland *backend)
+{
+  if (!backend->stage_view)
+    return;
+
+  g_return_if_fail (!backend->consumer_active);
+  g_return_if_fail (!backend->frame_pending);
+
+  uninhibit_frame_clock (backend);
+  g_clear_object (&backend->placeholder_framebuffer);
+  g_clear_object (&backend->stage_view);
+}
+
+static MetaStageView *
+find_stage_view (MetaBackendAnland *backend)
+{
+  MetaRenderer *renderer;
+  MetaCrtc *crtc;
+  MetaRendererView *renderer_view;
+
+  if (!backend->virtual_monitor)
+    return NULL;
+
+  renderer = meta_backend_get_renderer (META_BACKEND (backend));
+  crtc = meta_virtual_monitor_get_crtc (backend->virtual_monitor);
+  renderer_view = meta_renderer_get_view_for_crtc (renderer, crtc);
+
+  return renderer_view ? META_STAGE_VIEW (renderer_view) : NULL;
+}
+
+static gboolean
+ensure_stage_view (MetaBackendAnland  *backend,
+                   GError            **error)
+{
+  MetaStageView *stage_view = find_stage_view (backend);
+
+  if (!stage_view)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Anland virtual monitor does not have a renderer view yet");
+      return FALSE;
+    }
+
+  if (backend->stage_view == stage_view)
+    return TRUE;
+
+  if (backend->consumer_active || backend->frame_pending)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_BUSY,
+                   "Anland renderer view changed while a consumer was active");
+      return FALSE;
+    }
+
+  if (backend->frame_clock_inhibited)
+    uninhibit_frame_clock (backend);
+
+  g_set_object (&backend->stage_view, stage_view);
+  g_set_object (&backend->placeholder_framebuffer,
+                clutter_stage_view_get_onscreen (CLUTTER_STAGE_VIEW (stage_view)));
+  return TRUE;
+}
+
+static gboolean
+validate_buffer_info (const struct buf_info  *buffer_info,
+                      int                     fd,
+                      GError                **error)
+{
+  struct stat stat_buf;
+  uint64_t required_size;
+
+  if (buffer_info->format != ANLAND_PROTOCOL_FORMAT_RGBA_8888 ||
+      buffer_info->modifier != DRM_FORMAT_MOD_LINEAR ||
+      buffer_info->width > G_MAXUINT32 / 4u ||
+      buffer_info->stride < buffer_info->width * 4u ||
+      buffer_info->height > G_MAXUINT64 / buffer_info->stride ||
+      buffer_info->offset > G_MAXUINT64 -
+        (uint64_t) buffer_info->stride * buffer_info->height)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+                   "Anland daemon provided an invalid dma-buf description");
+      return FALSE;
+    }
+
+  required_size = buffer_info->offset +
+    (uint64_t) buffer_info->stride * buffer_info->height;
+  if (fstat (fd, &stat_buf) == 0 && stat_buf.st_size > 0 &&
+      required_size > (uint64_t) stat_buf.st_size)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+                   "Anland dma-buf is smaller than its advertised layout");
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static void
+complete_pending_frame (MetaBackendAnland *backend)
+{
+  ClutterFrameInfo frame_info;
+
+  if (!backend->stage_view || !backend->frame_pending)
+    return;
+
+  frame_info = (ClutterFrameInfo) {
+    .global_frame_counter = backend->pending_global_frame_counter,
+    .view_frame_counter = backend->pending_view_frame_counter,
+    .refresh_rate = clutter_stage_view_get_refresh_rate (
+      CLUTTER_STAGE_VIEW (backend->stage_view)),
+    .presentation_time = g_get_monotonic_time (),
+    .flags = CLUTTER_FRAME_INFO_FLAG_NONE,
+    .sequence = ++backend->presentation_sequence,
+  };
+  clutter_stage_view_notify_presented (CLUTTER_STAGE_VIEW (backend->stage_view),
+                                       &frame_info);
+  backend->frame_pending = FALSE;
+}
+
+static void
+deactivate_consumer (MetaBackendAnland *backend)
+{
+  meta_anland_audio_set_fd (backend->audio, -1);
+  meta_anland_camera_clear (backend->camera);
+  meta_anland_clipboard_set_transport (backend->clipboard, NULL);
+
+  if (backend->input_source)
+    {
+      g_source_destroy (backend->input_source);
+      g_clear_pointer (&backend->input_source, g_source_unref);
+    }
+
+  if (backend->input)
+    meta_anland_input_reset (backend->input);
+
+  if (backend->buffer_ready_source)
+    {
+      g_source_destroy (backend->buffer_ready_source);
+      g_clear_pointer (&backend->buffer_ready_source, g_source_unref);
+    }
+
+  if (backend->stage_view)
+    {
+      clutter_stage_view_set_present_func (
+        CLUTTER_STAGE_VIEW (backend->stage_view), NULL, NULL);
+
+      if (backend->current_buffer >= 0 &&
+          backend->placeholder_framebuffer &&
+          clutter_stage_view_get_onscreen (CLUTTER_STAGE_VIEW (backend->stage_view)) ==
+            backend->buffer_framebuffers[backend->current_buffer])
+        clutter_stage_view_replace_framebuffer (
+          CLUTTER_STAGE_VIEW (backend->stage_view),
+          backend->placeholder_framebuffer);
+
+      if (backend->frame_pending)
+        clutter_stage_view_notify_ready (CLUTTER_STAGE_VIEW (backend->stage_view));
+    }
+
+  for (int i = 0; i < MAX_BUFS; i++)
+    g_clear_object (&backend->buffer_framebuffers[i]);
+
+  backend->consumer_active = FALSE;
+  backend->current_buffer = -1;
+  backend->frame_pending = FALSE;
+  inhibit_frame_clock (backend);
+}
+
+static gboolean
+on_stage_view_present (ClutterStageView *stage_view,
+                       ClutterFrame     *frame,
+                       int64_t           global_frame_counter,
+                       gpointer          user_data)
+{
+  MetaBackendAnland *backend = user_data;
+  CoglFramebuffer *framebuffer;
+  CoglContext *cogl_context;
+  int fence_fd = -1;
+
+  if (!backend->consumer_active || !backend->transport ||
+      meta_anland_transport_is_fallback (backend->transport))
+    return FALSE;
+
+  framebuffer = clutter_stage_view_get_onscreen (stage_view);
+  cogl_context = cogl_framebuffer_get_context (framebuffer);
+  cogl_framebuffer_flush (framebuffer);
+
+  if (cogl_context_has_winsys_feature (cogl_context, COGL_WINSYS_FEATURE_SYNC_FD))
+    fence_fd = cogl_context_get_latest_sync_fd (cogl_context);
+  else
+    {
+      if (!backend->warned_sync_fallback)
+        {
+          g_warning ("Anland backend has no native fence support; using synchronous rendering");
+          backend->warned_sync_fallback = TRUE;
+        }
+      cogl_framebuffer_finish (framebuffer);
+    }
+
+  meta_anland_transport_set_render_fence (backend->transport, fence_fd);
+  if (!meta_anland_transport_notify_frame_done (backend->transport))
+    {
+      clutter_frame_set_result (frame, CLUTTER_FRAME_RESULT_IDLE);
+      return TRUE;
+    }
+
+  backend->pending_global_frame_counter = global_frame_counter;
+  backend->pending_view_frame_counter = clutter_frame_get_count (frame);
+  backend->frame_pending = TRUE;
+  inhibit_frame_clock (backend);
+  clutter_frame_set_result (frame, CLUTTER_FRAME_RESULT_PENDING_PRESENTED);
+  return TRUE;
+}
+
+static gboolean
+input_source_prepare (gpointer user_data)
+{
+  return FALSE;
+}
+
+static gboolean
+input_source_dispatch (gpointer user_data)
+{
+  MetaBackendAnland *backend = META_BACKEND_ANLAND (user_data);
+  struct InputEvent event;
+  int result;
+
+  if (!backend->consumer_active || !backend->transport || !backend->input ||
+      meta_anland_transport_is_fallback (backend->transport))
+    return G_SOURCE_REMOVE;
+
+  while ((result = meta_anland_transport_poll_input_event (
+             backend->transport, &event, 0)) > 0)
+    {
+      MetaAnlandInputEventResult input_result;
+
+      input_result = meta_anland_input_handle_event (backend->input,
+                                                      backend->transport,
+                                                      &event,
+                                                      backend->screen_info.width,
+                                                      backend->screen_info.height);
+      if (input_result == META_ANLAND_INPUT_EVENT_NEEDS_PAYLOAD)
+        {
+          if (!handle_extended_input (backend, &event))
+            {
+              meta_anland_transport_enter_fallback (backend->transport);
+              return G_SOURCE_REMOVE;
+            }
+        }
+      else if (input_result == META_ANLAND_INPUT_EVENT_NEEDS_RESOURCE_FDS)
+        {
+          if (!handle_resource_input (backend, &event))
+            {
+              meta_anland_transport_enter_fallback (backend->transport);
+              return G_SOURCE_REMOVE;
+            }
+        }
+      else if (input_result == META_ANLAND_INPUT_EVENT_ERROR)
+        {
+          meta_anland_transport_enter_fallback (backend->transport);
+          return G_SOURCE_REMOVE;
+        }
+
+      if (!backend->consumer_active)
+        return G_SOURCE_REMOVE;
+    }
+
+  return result < 0 ? G_SOURCE_REMOVE : G_SOURCE_CONTINUE;
+}
+
+static gboolean
+buffer_ready_source_prepare (gpointer user_data)
+{
+  return FALSE;
+}
+
+static gboolean
+buffer_ready_source_dispatch (gpointer user_data)
+{
+  MetaBackendAnland *backend = META_BACKEND_ANLAND (user_data);
+  eventfd_t count;
+  int buffer_ready_fd;
+  int selected_buffer;
+
+  if (!backend->consumer_active || !backend->transport ||
+      meta_anland_transport_is_fallback (backend->transport))
+    return G_SOURCE_REMOVE;
+
+  buffer_ready_fd = meta_anland_transport_get_buffer_ready_fd (backend->transport);
+  if (buffer_ready_fd < 0 || eventfd_read (buffer_ready_fd, &count) < 0 ||
+      count != 1)
+    {
+      meta_anland_transport_enter_fallback (backend->transport);
+      return G_SOURCE_REMOVE;
+    }
+
+  selected_buffer = meta_anland_transport_get_selected_buffer (backend->transport);
+  if (selected_buffer < 0 || selected_buffer >= MAX_BUFS ||
+      !backend->buffer_framebuffers[selected_buffer])
+    {
+      meta_anland_transport_enter_fallback (backend->transport);
+      return G_SOURCE_REMOVE;
+    }
+
+  complete_pending_frame (backend);
+
+  if (backend->current_buffer != selected_buffer)
+    {
+      clutter_stage_view_replace_framebuffer (
+        CLUTTER_STAGE_VIEW (backend->stage_view),
+        backend->buffer_framebuffers[selected_buffer]);
+      backend->current_buffer = selected_buffer;
+    }
+
+  clutter_stage_view_add_redraw_clip (CLUTTER_STAGE_VIEW (backend->stage_view),
+                                      NULL);
+  uninhibit_frame_clock (backend);
+  clutter_stage_view_schedule_update_now (CLUTTER_STAGE_VIEW (backend->stage_view));
+  return G_SOURCE_CONTINUE;
+}
+
+static gboolean
+activate_consumer (MetaBackendAnland *backend)
+{
+  MetaRenderer *renderer = meta_backend_get_renderer (META_BACKEND (backend));
+  MetaRendererNative *renderer_native = META_RENDERER_NATIVE (renderer);
+  CoglFramebuffer *framebuffers[MAX_BUFS] = { NULL, };
+  struct buf_info buffer_info;
+  int n_buffers;
+  int buffer_ready_fd;
+  int buffer_ready_source_fd = -1;
+  int input_fd;
+  int input_source_fd = -1;
+  int i;
+  g_autoptr (GError) error = NULL;
+
+  n_buffers = meta_anland_transport_get_buffer_count (backend->transport);
+  if (n_buffers < 1 || n_buffers > MAX_BUFS ||
+      !meta_anland_transport_get_buffer_info (backend->transport, 0,
+                                              &buffer_info))
+    goto failed;
+
+  if (buffer_info.width != backend->screen_info.width ||
+      buffer_info.height != backend->screen_info.height)
+    {
+      backend->screen_info.width = buffer_info.width;
+      backend->screen_info.height = buffer_info.height;
+      if (!update_virtual_monitor (backend, &error))
+        g_warning ("Failed to update the Anland virtual monitor: %s",
+                   error->message);
+      return FALSE;
+    }
+
+  if (!ensure_stage_view (backend, &error))
+    return FALSE;
+
+  if (!backend->clipboard)
+    {
+      g_set_error (&error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Anland clipboard bridge is unavailable");
+      goto failed;
+    }
+
+  if (cogl_framebuffer_get_width (backend->placeholder_framebuffer) !=
+        (int) buffer_info.width ||
+      cogl_framebuffer_get_height (backend->placeholder_framebuffer) !=
+        (int) buffer_info.height)
+    return FALSE;
+
+  if (backend->screen_info.refresh > 0 &&
+      fabsf (clutter_stage_view_get_refresh_rate (
+               CLUTTER_STAGE_VIEW (backend->stage_view)) -
+             backend->screen_info.refresh / 1000.0f) > 0.01f)
+    return FALSE;
+
+  for (i = 0; i < n_buffers; i++)
+    {
+      int fd;
+      uint32_t stride;
+      uint32_t offset;
+      uint64_t modifier;
+
+      if (!meta_anland_transport_get_buffer_info (backend->transport, i,
+                                                  &buffer_info))
+        goto failed;
+
+      fd = meta_anland_transport_get_buffer_fd (backend->transport, i);
+      if (fd < 0 || !validate_buffer_info (&buffer_info, fd, &error))
+        goto failed;
+
+      stride = buffer_info.stride;
+      offset = buffer_info.offset;
+      modifier = buffer_info.modifier;
+      framebuffers[i] = meta_renderer_native_create_dma_buf_framebuffer (
+        renderer_native, buffer_info.width, buffer_info.height,
+        DRM_FORMAT_ABGR8888, 1, &fd, &stride, &offset, &modifier, &error);
+      if (!framebuffers[i])
+        {
+          g_prefix_error (&error,
+                          "Failed to import Anland buffer %d "
+                          "(%ux%u, stride %u, offset %u, "
+                          "modifier %" G_GUINT64_FORMAT "): ",
+                          i, buffer_info.width, buffer_info.height,
+                          buffer_info.stride, buffer_info.offset,
+                          buffer_info.modifier);
+          goto failed;
+        }
+    }
+
+  buffer_ready_fd = meta_anland_transport_get_buffer_ready_fd (backend->transport);
+  buffer_ready_source_fd = fcntl (buffer_ready_fd, F_DUPFD_CLOEXEC, 3);
+  if (buffer_ready_source_fd < 0)
+    {
+      g_set_error (&error, G_IO_ERROR, g_io_error_from_errno (errno),
+                   "Failed to duplicate Anland buffer-ready eventfd");
+      goto failed;
+    }
+
+  input_fd = meta_anland_transport_get_data_fd (backend->transport);
+  input_source_fd = fcntl (input_fd, F_DUPFD_CLOEXEC, 3);
+  if (input_source_fd < 0)
+    {
+      g_set_error (&error, G_IO_ERROR, g_io_error_from_errno (errno),
+                   "Failed to duplicate Anland data fd");
+      goto failed;
+    }
+
+  for (i = 0; i < n_buffers; i++)
+    backend->buffer_framebuffers[i] = framebuffers[i];
+  backend->consumer_active = TRUE;
+  meta_anland_clipboard_set_transport (backend->clipboard, backend->transport);
+  backend->current_buffer = -1;
+  inhibit_frame_clock (backend);
+  clutter_stage_view_set_present_func (CLUTTER_STAGE_VIEW (backend->stage_view),
+                                       on_stage_view_present, backend);
+  backend->buffer_ready_source = meta_create_fd_source (
+    buffer_ready_source_fd, "[mutter] Anland buffer ready",
+    buffer_ready_source_prepare, buffer_ready_source_dispatch, backend, NULL);
+  g_source_attach (backend->buffer_ready_source, NULL);
+  backend->input_source = meta_create_fd_source (
+    input_source_fd, "[mutter] Anland input",
+    input_source_prepare, input_source_dispatch, backend, NULL);
+  g_source_attach (backend->input_source, NULL);
+  meta_anland_audio_set_fd (backend->audio,
+                            meta_anland_transport_get_audio_fd (
+                              backend->transport));
+  request_camera_resources (backend);
+  return TRUE;
+
+failed:
+  g_warning ("Failed to activate Anland consumer buffers: %s",
+             error ? error->message : "invalid transport state");
+  for (i = 0; i < MAX_BUFS; i++)
+    g_clear_object (&framebuffers[i]);
+  if (buffer_ready_source_fd >= 0)
+    close (buffer_ready_source_fd);
+  if (input_source_fd >= 0)
+    close (input_source_fd);
+  meta_anland_transport_enter_fallback (backend->transport);
+  return FALSE;
+}
+
+static gboolean reconnect_cb (gpointer user_data);
+
+static void
+schedule_reconnect (MetaBackendAnland *backend)
+{
+  if (backend->reconnect_source_id)
+    return;
+
+  backend->reconnect_source_id =
+    g_timeout_add (ANLAND_RECONNECT_INTERVAL_MS, reconnect_cb, backend);
+}
+
+static void
+on_transport_fallback (void *user_data)
+{
+  MetaBackendAnland *backend = user_data;
+
+  deactivate_consumer (backend);
+  schedule_reconnect (backend);
+}
+
+static void
+on_input_display_refresh (uint32_t refresh_mhz,
+                          gpointer user_data)
+{
+  MetaBackendAnland *backend = META_BACKEND_ANLAND (user_data);
+
+  if (backend->screen_info.refresh == refresh_mhz)
+    return;
+
+  backend->screen_info.refresh = refresh_mhz;
+  deactivate_consumer (backend);
+  if (!update_virtual_monitor (backend, NULL))
+    {
+      clear_transport (backend);
+      return;
+    }
+
+  schedule_reconnect (backend);
+}
+
+static gboolean
+reconnect_cb (gpointer user_data)
+{
+  MetaBackendAnland *backend = META_BACKEND_ANLAND (user_data);
+  MetaAnlandTransportPickupResult pickup_result;
+
+  if (!backend->transport)
+    {
+      if (!connect_transport (backend, NULL))
+        return G_SOURCE_CONTINUE;
+      if (!update_virtual_monitor (backend, NULL))
+        {
+          clear_transport (backend);
+          return G_SOURCE_CONTINUE;
+        }
+      meta_anland_transport_set_fallback_callback (backend->transport,
+                                                    on_transport_fallback,
+                                                    backend);
+    }
+
+  pickup_result = meta_anland_transport_try_pickup (backend->transport);
+  switch (pickup_result)
+    {
+    case META_ANLAND_TRANSPORT_PICKUP_READY:
+      if (!activate_consumer (backend))
+        return G_SOURCE_CONTINUE;
+      backend->reconnect_source_id = 0;
+      return G_SOURCE_REMOVE;
+    case META_ANLAND_TRANSPORT_PICKUP_NO_CONSUMER:
+      return G_SOURCE_CONTINUE;
+    case META_ANLAND_TRANSPORT_PICKUP_DAEMON_LOST:
+    case META_ANLAND_TRANSPORT_PICKUP_PROTOCOL_ERROR:
+      clear_transport (backend);
+      return G_SOURCE_CONTINUE;
+    }
+
+  g_assert_not_reached ();
+}
+
+static gboolean
+meta_backend_anland_init_post (MetaBackend  *backend,
+                               GError      **error)
+{
+  MetaBackendClass *parent_class =
+    META_BACKEND_CLASS (meta_backend_anland_parent_class);
+  MetaBackendAnland *backend_anland = META_BACKEND_ANLAND (backend);
+
+  if (!parent_class->init_post (backend, error))
+    return FALSE;
+
+  backend_anland->input = meta_anland_input_new (
+    backend, on_input_display_refresh, backend_anland, error);
+  if (!backend_anland->input)
+    return FALSE;
+
+  backend_anland->audio = meta_anland_audio_new ();
+  if (!backend_anland->audio)
+    g_warning ("Failed to initialize Anland audio bridge");
+
+  backend_anland->camera = meta_anland_camera_new ();
+  if (!backend_anland->camera)
+    g_warning ("Failed to initialize Anland camera bridge");
+
+  g_signal_connect_object (meta_backend_get_context (backend), "started",
+                           G_CALLBACK (on_context_started), backend, 0);
+
+  if (!connect_transport (backend_anland, error))
+    return FALSE;
+
+  meta_anland_transport_set_fallback_callback (backend_anland->transport,
+                                                on_transport_fallback,
+                                                backend_anland);
+  return TRUE;
+}
+
+static void
+meta_backend_anland_update_stage (MetaBackend *backend)
+{
+  MetaBackendAnland *backend_anland = META_BACKEND_ANLAND (backend);
+  MetaBackendClass *parent_class =
+    META_BACKEND_CLASS (meta_backend_anland_parent_class);
+  gboolean had_stage_view = backend_anland->stage_view != NULL;
+
+  if (backend_anland->consumer_active)
+    deactivate_consumer (backend_anland);
+  release_stage_view (backend_anland);
+
+  parent_class->update_stage (backend);
+
+  if (had_stage_view && backend_anland->transport)
+    schedule_reconnect (backend_anland);
+}
+
+static void
+meta_backend_anland_set_property (GObject      *object,
+                                  guint         prop_id,
+                                  const GValue *value,
+                                  GParamSpec   *pspec)
+{
+  MetaBackendAnland *backend = META_BACKEND_ANLAND (object);
+
+  switch (prop_id)
+    {
+    case PROP_ANLAND_SOCKET:
+      if (g_value_get_string (value))
+        {
+          g_free (backend->socket_path);
+          backend->socket_path = g_value_dup_string (value);
+        }
+      break;
+    default:
+      G_OBJECT_CLASS (meta_backend_anland_parent_class)->set_property (object,
+                                                                        prop_id,
+                                                                        value,
+                                                                        pspec);
+      break;
+    }
+}
+
+static void
+meta_backend_anland_dispose (GObject *object)
+{
+  MetaBackendAnland *backend = META_BACKEND_ANLAND (object);
+
+  g_clear_handle_id (&backend->reconnect_source_id, g_source_remove);
+  clear_transport (backend);
+  uninhibit_frame_clock (backend);
+  g_clear_pointer (&backend->audio, meta_anland_audio_free);
+  g_clear_pointer (&backend->camera, meta_anland_camera_free);
+  g_clear_pointer (&backend->clipboard, meta_anland_clipboard_free);
+  g_clear_pointer (&backend->input, meta_anland_input_free);
+  g_clear_object (&backend->placeholder_framebuffer);
+  g_clear_object (&backend->stage_view);
+  g_clear_object (&backend->virtual_monitor);
+  g_clear_pointer (&backend->socket_path, g_free);
+
+  G_OBJECT_CLASS (meta_backend_anland_parent_class)->dispose (object);
+}
+
+static void
+meta_backend_anland_class_init (MetaBackendAnlandClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  MetaBackendClass *backend_class = META_BACKEND_CLASS (klass);
+
+  object_class->set_property = meta_backend_anland_set_property;
+  object_class->dispose = meta_backend_anland_dispose;
+  backend_class->init_post = meta_backend_anland_init_post;
+  backend_class->update_stage = meta_backend_anland_update_stage;
+
+  g_object_class_install_property (
+    object_class, PROP_ANLAND_SOCKET,
+    g_param_spec_string ("anland-socket", NULL, NULL, NULL,
+                         G_PARAM_WRITABLE |
+                         G_PARAM_CONSTRUCT_ONLY |
+                         G_PARAM_STATIC_STRINGS));
+}
+
+static void
+meta_backend_anland_init (MetaBackendAnland *backend_anland)
+{
+  backend_anland->socket_path = get_default_socket_path ();
+  backend_anland->current_buffer = -1;
+}
+
+gboolean
+meta_backend_anland_setup (MetaBackendAnland  *backend,
+                           GError            **error)
+{
+  if (!update_virtual_monitor (backend, error))
+    return FALSE;
+
+  schedule_reconnect (backend);
+  return TRUE;
+}

--- a/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-backend-anland.h
+++ b/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/meta-backend-anland.h
@@ -1,0 +1,14 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+#pragma once
+
+#include "backends/native/meta-backend-native-private.h"
+
+#define META_TYPE_BACKEND_ANLAND (meta_backend_anland_get_type ())
+G_DECLARE_FINAL_TYPE (MetaBackendAnland,
+                      meta_backend_anland,
+                      META, BACKEND_ANLAND,
+                      MetaBackendNative)
+
+gboolean meta_backend_anland_setup (MetaBackendAnland  *backend,
+                                    GError            **error);

--- a/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/vendor/meta-anland-protocol.h
+++ b/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/vendor/meta-anland-protocol.h
@@ -1,0 +1,183 @@
+#ifndef META_ANLAND_PROTOCOL_H
+#define META_ANLAND_PROTOCOL_H
+
+#include <stdint.h>
+
+#define CTRL_MSG_CONSUMER_HELLO 1
+#define CTRL_MSG_PRODUCER_HELLO 2
+#define CTRL_MSG_SCREEN_INFO 7
+#define CTRL_MSG_REJECT 8
+#define CTRL_MSG_PICKUP_FDS 9
+#define CTRL_MSG_FDS_READY 10
+
+#define DATA_MSG_BUF_READY 100
+#define DATA_MSG_REFRESH_DONE 101
+#define DATA_MSG_INPUT_EVENT 102
+#define DATA_MSG_OUTPUT_EVENT 103
+#define DATA_MSG_INPUT_EXTEND_FDS 104
+#define DATA_MSG_BUFS_READY 200
+
+#define MAX_BUFS 8
+
+struct ctrl_msg
+{
+  uint32_t type;
+  uint32_t size;
+  uint8_t payload[];
+} __attribute__ ((packed));
+
+struct data_msg
+{
+  uint32_t type;
+  uint32_t size;
+  uint8_t payload[];
+} __attribute__ ((packed));
+
+struct screen_info
+{
+  uint32_t width;
+  uint32_t height;
+  uint32_t format;
+  uint32_t refresh;
+} __attribute__ ((packed));
+
+struct buf_info
+{
+  uint32_t stride;
+  uint32_t width;
+  uint32_t height;
+  uint32_t format;
+  uint64_t modifier;
+  uint32_t offset;
+} __attribute__ ((packed));
+
+#define INPUT_TYPE_TOUCH 1
+#define INPUT_TYPE_KEY 2
+#define INPUT_TYPE_POINTER_MOTION 3
+#define INPUT_TYPE_POINTER_BUTTON 4
+#define INPUT_TYPE_POINTER_AXIS 5
+#define INPUT_TYPE_TOUCH_FRAME 6
+#define INPUT_TYPE_DISPLAY_REFRESH 7
+#define INPUT_TYPE_CLIPBOARD 8
+#define INPUT_TYPE_TEXT_INPUT 9
+#define INPUT_TYPE_ACTION 10
+#define INPUT_TYPE_RESOURCE 11
+
+#define SERVICE_TYPE_CAMERA 1
+
+#define INPUT_ACTION_DOWN 0
+#define INPUT_ACTION_UP 1
+#define INPUT_ACTION_MOVE 2
+
+#define OUTPUT_TYPE_CLIPBOARD 1
+#define OUTPUT_TYPE_RESOURCES_REQUEST 2
+
+struct InputEvent
+{
+  uint32_t type;
+  union
+  {
+    struct
+    {
+      int32_t action;
+      float x;
+      float y;
+      int32_t pointer_id;
+    } touch;
+    struct
+    {
+      int32_t action;
+      int32_t keycode;
+    } key;
+    struct
+    {
+      float x;
+      float y;
+      float dx;
+      float dy;
+    } pointer_motion;
+    struct
+    {
+      uint32_t button;
+      int32_t pressed;
+    } pointer_button;
+    struct
+    {
+      uint32_t axis;
+      float value;
+      int32_t discrete;
+    } pointer_axis;
+    struct
+    {
+      uint32_t refresh_mhz;
+    } display;
+    struct
+    {
+      uint32_t size;
+    } clipboard;
+    struct
+    {
+      uint32_t size;
+    } text_input;
+    struct
+    {
+      uint32_t action;
+      int32_t value;
+    } input_action;
+    struct
+    {
+      uint32_t type;
+      uint32_t fdnum;
+    } resource;
+    struct
+    {
+      uint32_t padding[4];
+    };
+  };
+} __attribute__ ((packed));
+
+struct OutputEvent
+{
+  uint32_t type;
+  union
+  {
+    struct
+    {
+      uint32_t size;
+    } clipboard;
+    struct
+    {
+      uint32_t type;
+      uint32_t args[3];
+    } resources_request;
+    struct
+    {
+      uint32_t padding[4];
+    };
+  };
+} __attribute__ ((packed));
+
+#define AUDIO_MSG_FORMAT 1
+#define AUDIO_MSG_PCM 2
+
+#define AUDIO_FORMAT_S16LE 0
+
+#define AUDIO_ROLE_PLAYBACK 0
+#define AUDIO_ROLE_CAPTURE 1
+
+struct audio_format
+{
+  uint32_t rate;
+  uint32_t channels;
+  uint32_t format;
+  uint32_t role;
+  uint32_t quantum;
+} __attribute__ ((packed));
+
+struct audio_msg
+{
+  uint32_t type;
+  uint32_t size;
+} __attribute__ ((packed));
+
+#endif /* META_ANLAND_PROTOCOL_H */

--- a/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/vendor/meta-anland-socket-utils.c
+++ b/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/vendor/meta-anland-socket-utils.c
@@ -1,0 +1,210 @@
+#include "meta-anland-socket-utils.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+int
+meta_anland_connect_unix (const char *path)
+{
+  struct sockaddr_un address = { 0 };
+  int fd;
+
+  if (!path || strlen (path) >= sizeof (address.sun_path))
+    {
+      errno = ENAMETOOLONG;
+      return -1;
+    }
+
+  fd = socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd < 0)
+    return -1;
+
+  address.sun_family = AF_UNIX;
+  strcpy (address.sun_path, path);
+  if (connect (fd, (struct sockaddr *) &address, sizeof (address)) < 0)
+    {
+      close (fd);
+      return -1;
+    }
+
+  return fd;
+}
+
+int
+meta_anland_send_all (int         fd,
+                      const void *buffer,
+                      size_t      length)
+{
+  const uint8_t *data = buffer;
+  size_t sent = 0;
+
+  while (sent < length)
+    {
+      ssize_t n = send (fd, data + sent, length - sent, MSG_NOSIGNAL);
+
+      if (n > 0)
+        {
+          sent += n;
+          continue;
+        }
+      if (n < 0 && errno == EINTR)
+        continue;
+
+      return -1;
+    }
+
+  return 0;
+}
+
+int
+meta_anland_recv_all (int    fd,
+                      void  *buffer,
+                      size_t length)
+{
+  uint8_t *data = buffer;
+  size_t received = 0;
+
+  while (received < length)
+    {
+      ssize_t n = recv (fd, data + received, length - received, 0);
+
+      if (n > 0)
+        {
+          received += n;
+          continue;
+        }
+      if (n < 0 && errno == EINTR)
+        continue;
+
+      return -1;
+    }
+
+  return 0;
+}
+
+int
+meta_anland_send_fds (int         fd,
+                      const void *buffer,
+                      size_t      length,
+                      const int  *fds,
+                      int         n_fds)
+{
+  struct iovec iov = { .iov_base = (void *) buffer, .iov_len = length };
+  struct msghdr message = { .msg_iov = &iov, .msg_iovlen = 1 };
+  struct cmsghdr *cmsg;
+  size_t control_length;
+  char *control;
+  ssize_t n;
+
+  if (!buffer || length == 0 || !fds || n_fds <= 0)
+    {
+      errno = EINVAL;
+      return -1;
+    }
+
+  control_length = CMSG_SPACE (sizeof (int) * (size_t) n_fds);
+  control = calloc (1, control_length);
+  if (!control)
+    return -1;
+
+  message.msg_control = control;
+  message.msg_controllen = control_length;
+  cmsg = CMSG_FIRSTHDR (&message);
+  cmsg->cmsg_level = SOL_SOCKET;
+  cmsg->cmsg_type = SCM_RIGHTS;
+  cmsg->cmsg_len = CMSG_LEN (sizeof (int) * (size_t) n_fds);
+  memcpy (CMSG_DATA (cmsg), fds, sizeof (int) * (size_t) n_fds);
+
+  do
+    n = sendmsg (fd, &message, MSG_NOSIGNAL);
+  while (n < 0 && errno == EINTR);
+
+  free (control);
+  return n == (ssize_t) length ? 0 : -1;
+}
+
+int
+meta_anland_recv_fds (int    fd,
+                      void  *buffer,
+                      size_t length,
+                      int   *fds,
+                      int    max_fds,
+                      int   *n_fds)
+{
+  struct iovec iov = { .iov_base = buffer, .iov_len = length };
+  struct msghdr message = { .msg_iov = &iov, .msg_iovlen = 1 };
+  size_t control_length;
+  char *control;
+  ssize_t n;
+
+  if (!buffer || length == 0 || !fds || max_fds <= 0 || !n_fds)
+    {
+      errno = EINVAL;
+      return -1;
+    }
+
+  *n_fds = 0;
+  control_length = CMSG_SPACE (sizeof (int) * (size_t) max_fds);
+  control = calloc (1, control_length);
+  if (!control)
+    return -1;
+
+  message.msg_control = control;
+  message.msg_controllen = control_length;
+  do
+    n = recvmsg (fd, &message, MSG_CMSG_CLOEXEC);
+  while (n < 0 && errno == EINTR);
+
+  if (n <= 0)
+    goto fail;
+
+  for (struct cmsghdr *cmsg = CMSG_FIRSTHDR (&message);
+       cmsg;
+       cmsg = CMSG_NXTHDR (&message, cmsg))
+    {
+      int count;
+      int available;
+      int copy_count;
+
+      if (cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_RIGHTS)
+        continue;
+      if (cmsg->cmsg_len < CMSG_LEN (0) ||
+          (cmsg->cmsg_len - CMSG_LEN (0)) % sizeof (int) != 0)
+        goto fail;
+
+      count = (int) ((cmsg->cmsg_len - CMSG_LEN (0)) / sizeof (int));
+      available = max_fds - *n_fds;
+      copy_count = count < available ? count : available;
+      memcpy (fds + *n_fds, CMSG_DATA (cmsg),
+              sizeof (int) * (size_t) copy_count);
+      *n_fds += copy_count;
+      for (int i = copy_count; i < count; i++)
+        {
+          int received_fd;
+
+          memcpy (&received_fd, (int *) CMSG_DATA (cmsg) + i,
+                  sizeof (received_fd));
+          close (received_fd);
+        }
+    }
+
+  if (!(message.msg_flags & MSG_CTRUNC))
+    {
+      free (control);
+      return (int) n;
+    }
+
+  errno = EMSGSIZE;
+
+fail:
+  for (int i = 0; i < *n_fds; i++)
+    close (fds[i]);
+  *n_fds = 0;
+  free (control);
+  return -1;
+}

--- a/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/vendor/meta-anland-socket-utils.h
+++ b/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/vendor/meta-anland-socket-utils.h
@@ -1,0 +1,27 @@
+#ifndef META_ANLAND_SOCKET_UTILS_H
+#define META_ANLAND_SOCKET_UTILS_H
+
+#include <stddef.h>
+
+int meta_anland_connect_unix (const char *path);
+
+int meta_anland_send_all (int          fd,
+                          const void  *buffer,
+                          size_t       length);
+int meta_anland_recv_all (int    fd,
+                          void  *buffer,
+                          size_t length);
+
+int meta_anland_send_fds (int          fd,
+                          const void  *buffer,
+                          size_t       length,
+                          const int   *fds,
+                          int          n_fds);
+int meta_anland_recv_fds (int    fd,
+                          void  *buffer,
+                          size_t length,
+                          int   *fds,
+                          int    max_fds,
+                          int   *n_fds);
+
+#endif /* META_ANLAND_SOCKET_UTILS_H */

--- a/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/vendor/meta-anland-transport.c
+++ b/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/vendor/meta-anland-transport.c
@@ -1,0 +1,721 @@
+#include "meta-anland-transport.h"
+
+#include "meta-anland-socket-utils.h"
+
+#include <errno.h>
+#include <poll.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define HANDSHAKE_TIMEOUT_MS 100
+#define INITIAL_HANDSHAKE_TIMEOUT_MS 5000
+#define INPUT_TIMEOUT_MS 100
+
+struct _MetaAnlandTransport
+{
+  int control_fd;
+  int data_fd;
+  int buffer_ready_fd;
+  int fence_fd;
+  int shm_fd;
+  int audio_fd;
+  int pending_render_fence_fd;
+  volatile uint32_t *selected_buffer;
+
+  struct screen_info screen_info;
+  int buffer_fds[MAX_BUFS];
+  struct buf_info buffer_infos[MAX_BUFS];
+  int n_buffers;
+  bool fallback;
+
+  void (*fallback_callback) (void *user_data);
+  void *fallback_user_data;
+};
+
+static void
+close_fds (int *fds,
+           int  n_fds)
+{
+  for (int i = 0; i < n_fds; i++)
+    {
+      if (fds[i] >= 0)
+        close (fds[i]);
+    }
+}
+
+static void
+release_consumer_resources (MetaAnlandTransport *transport)
+{
+  for (int i = 0; i < transport->n_buffers; i++)
+    {
+      if (transport->buffer_fds[i] >= 0)
+        {
+          close (transport->buffer_fds[i]);
+          transport->buffer_fds[i] = -1;
+        }
+    }
+  transport->n_buffers = 0;
+
+  if (transport->selected_buffer)
+    {
+      munmap ((void *) transport->selected_buffer, sizeof (uint32_t));
+      transport->selected_buffer = NULL;
+    }
+
+  if (transport->data_fd >= 0)
+    close (transport->data_fd);
+  if (transport->buffer_ready_fd >= 0)
+    close (transport->buffer_ready_fd);
+  if (transport->fence_fd >= 0)
+    close (transport->fence_fd);
+  if (transport->shm_fd >= 0)
+    close (transport->shm_fd);
+  if (transport->audio_fd >= 0)
+    close (transport->audio_fd);
+  if (transport->pending_render_fence_fd >= 0)
+    close (transport->pending_render_fence_fd);
+
+  transport->data_fd = -1;
+  transport->buffer_ready_fd = -1;
+  transport->fence_fd = -1;
+  transport->shm_fd = -1;
+  transport->audio_fd = -1;
+  transport->pending_render_fence_fd = -1;
+}
+
+static void
+enter_fallback (MetaAnlandTransport *transport)
+{
+  if (transport->fallback)
+    return;
+
+  transport->fallback = true;
+  if (transport->fallback_callback)
+    transport->fallback_callback (transport->fallback_user_data);
+  release_consumer_resources (transport);
+}
+
+static int
+wait_for_fd (int fd,
+             short events,
+             int timeout_ms)
+{
+  struct pollfd poll_fd = { .fd = fd, .events = events };
+  int result;
+
+  do
+    result = poll (&poll_fd, 1, timeout_ms);
+  while (result < 0 && errno == EINTR);
+
+  if (result <= 0)
+    return result;
+  if (poll_fd.revents & (POLLERR | POLLHUP | POLLNVAL))
+    return -1;
+  return poll_fd.revents & events ? 1 : -1;
+}
+
+static int
+recv_all_timeout (int    fd,
+                  void  *buffer,
+                  size_t size,
+                  int    timeout_ms)
+{
+  uint8_t *data = buffer;
+  size_t received = 0;
+
+  while (received < size)
+    {
+      ssize_t n = recv (fd, data + received, size - received, MSG_DONTWAIT);
+
+      if (n > 0)
+        {
+          received += n;
+          continue;
+        }
+      if (n == 0)
+        return -1;
+      if (errno == EINTR)
+        continue;
+      if (errno != EAGAIN)
+        return -1;
+      if (wait_for_fd (fd, POLLIN, timeout_ms) != 1)
+        return -1;
+    }
+
+  return 0;
+}
+
+static int
+send_all_timeout (int         fd,
+                  const void *buffer,
+                  size_t      size,
+                  int         timeout_ms)
+{
+  const uint8_t *data = buffer;
+  size_t sent = 0;
+
+  while (sent < size)
+    {
+      ssize_t n = send (fd, data + sent, size - sent,
+                        MSG_NOSIGNAL | MSG_DONTWAIT);
+
+      if (n > 0)
+        {
+          sent += n;
+          continue;
+        }
+      if (n < 0 && errno == EINTR)
+        continue;
+      if (n < 0 && errno == EAGAIN &&
+          wait_for_fd (fd, POLLOUT, timeout_ms) == 1)
+        continue;
+
+      return -1;
+    }
+
+  return 0;
+}
+
+static int
+recv_fds_exact (int    fd,
+                void  *buffer,
+                size_t size,
+                int   *fds,
+                int    max_fds,
+                int   *n_fds)
+{
+  int received;
+
+  received = meta_anland_recv_fds (fd, buffer, size, fds, max_fds, n_fds);
+  if (received < 0)
+    return -1;
+  if ((size_t) received < size &&
+      meta_anland_recv_all (fd, (uint8_t *) buffer + received,
+                            size - (size_t) received) < 0)
+    return -1;
+
+  return 0;
+}
+
+static int
+discard_data_payload (MetaAnlandTransport *transport,
+                      uint32_t             size)
+{
+  uint8_t buffer[4096];
+
+  if (size > META_ANLAND_MAX_PAYLOAD_SIZE)
+    return -1;
+
+  while (size > 0)
+    {
+      size_t chunk = size < sizeof (buffer) ? size : sizeof (buffer);
+
+      if (recv_all_timeout (transport->data_fd, buffer, chunk,
+                            INPUT_TIMEOUT_MS) < 0)
+        return -1;
+      size -= (uint32_t) chunk;
+    }
+
+  return 0;
+}
+
+static MetaAnlandTransportPickupResult
+pickup_fds (MetaAnlandTransport *transport)
+{
+  struct ctrl_msg request = { .type = CTRL_MSG_PICKUP_FDS, .size = 0 };
+  struct ctrl_msg response;
+  int fds[5] = { -1, -1, -1, -1, -1 };
+  int n_fds = 0;
+  int wait_result;
+
+  if (meta_anland_send_all (transport->control_fd, &request,
+                            sizeof (request)) < 0)
+    return META_ANLAND_TRANSPORT_PICKUP_DAEMON_LOST;
+
+  wait_result = wait_for_fd (transport->control_fd, POLLIN,
+                             HANDSHAKE_TIMEOUT_MS);
+  if (wait_result == 0)
+    return META_ANLAND_TRANSPORT_PICKUP_NO_CONSUMER;
+  if (wait_result < 0 ||
+      recv_fds_exact (transport->control_fd, &response, sizeof (response),
+                      fds, 5, &n_fds) < 0)
+    {
+      close_fds (fds, n_fds);
+      return META_ANLAND_TRANSPORT_PICKUP_DAEMON_LOST;
+    }
+
+  if (response.type != CTRL_MSG_FDS_READY || response.size != 0 || n_fds != 5)
+    {
+      close_fds (fds, n_fds);
+      return META_ANLAND_TRANSPORT_PICKUP_PROTOCOL_ERROR;
+    }
+
+  transport->buffer_ready_fd = fds[0];
+  transport->fence_fd = fds[1];
+  transport->data_fd = fds[2];
+  transport->shm_fd = fds[3];
+  transport->audio_fd = fds[4];
+  transport->selected_buffer = mmap (NULL, sizeof (uint32_t), PROT_READ,
+                                     MAP_SHARED, transport->shm_fd, 0);
+  if (transport->selected_buffer == MAP_FAILED)
+    {
+      transport->selected_buffer = NULL;
+      return META_ANLAND_TRANSPORT_PICKUP_PROTOCOL_ERROR;
+    }
+
+  return META_ANLAND_TRANSPORT_PICKUP_READY;
+}
+
+static MetaAnlandTransportPickupResult
+receive_buffers (MetaAnlandTransport *transport)
+{
+  struct data_msg header;
+  struct buf_info buffer_infos[MAX_BUFS];
+  int fds[MAX_BUFS] = { -1, -1, -1, -1, -1, -1, -1, -1 };
+  int n_fds = 0;
+  int n_buffers;
+
+  if (wait_for_fd (transport->data_fd, POLLIN, HANDSHAKE_TIMEOUT_MS) != 1 ||
+      recv_fds_exact (transport->data_fd, &header, sizeof (header),
+                      fds, MAX_BUFS, &n_fds) < 0)
+    {
+      close_fds (fds, n_fds);
+      return META_ANLAND_TRANSPORT_PICKUP_NO_CONSUMER;
+    }
+
+  if (header.type != DATA_MSG_BUFS_READY || header.size == 0 ||
+      header.size % sizeof (struct buf_info) != 0)
+    goto protocol_error;
+
+  n_buffers = (int) (header.size / sizeof (struct buf_info));
+  if (n_buffers != n_fds || n_buffers < 1 || n_buffers > MAX_BUFS ||
+      meta_anland_recv_all (transport->data_fd, buffer_infos,
+                            header.size) < 0)
+    goto protocol_error;
+
+  for (int i = 0; i < n_buffers; i++)
+    {
+      if (buffer_infos[i].width == 0 || buffer_infos[i].height == 0 ||
+          buffer_infos[i].stride == 0 ||
+          (i > 0 && (buffer_infos[i].width != buffer_infos[0].width ||
+                     buffer_infos[i].height != buffer_infos[0].height ||
+                     buffer_infos[i].format != buffer_infos[0].format)))
+        goto protocol_error;
+    }
+
+  for (int i = 0; i < n_buffers; i++)
+    {
+      transport->buffer_fds[i] = fds[i];
+      transport->buffer_infos[i] = buffer_infos[i];
+    }
+  transport->n_buffers = n_buffers;
+  return META_ANLAND_TRANSPORT_PICKUP_READY;
+
+protocol_error:
+  close_fds (fds, n_fds);
+  return META_ANLAND_TRANSPORT_PICKUP_PROTOCOL_ERROR;
+}
+
+int
+meta_anland_transport_connect (MetaAnlandTransport **out_transport,
+                               const char           *socket_path)
+{
+  MetaAnlandTransport *transport;
+  struct ctrl_msg request = { .type = CTRL_MSG_PRODUCER_HELLO, .size = 0 };
+  struct ctrl_msg response;
+  struct screen_info screen_info;
+  int wait_result;
+
+  if (!out_transport || !socket_path)
+    return -1;
+
+  *out_transport = NULL;
+  transport = calloc (1, sizeof (*transport));
+  if (!transport)
+    return -1;
+
+  transport->control_fd = -1;
+  transport->data_fd = -1;
+  transport->buffer_ready_fd = -1;
+  transport->fence_fd = -1;
+  transport->shm_fd = -1;
+  transport->audio_fd = -1;
+  transport->pending_render_fence_fd = -1;
+  transport->fallback = true;
+  for (int i = 0; i < MAX_BUFS; i++)
+    transport->buffer_fds[i] = -1;
+
+  transport->control_fd = meta_anland_connect_unix (socket_path);
+  if (transport->control_fd < 0 ||
+      meta_anland_send_all (transport->control_fd, &request,
+                            sizeof (request)) < 0)
+    goto failed;
+
+  wait_result = wait_for_fd (transport->control_fd, POLLIN,
+                             INITIAL_HANDSHAKE_TIMEOUT_MS);
+  if (wait_result != 1 ||
+      recv_all_timeout (transport->control_fd, &response, sizeof (response),
+                        INITIAL_HANDSHAKE_TIMEOUT_MS) < 0 ||
+      response.type != CTRL_MSG_SCREEN_INFO ||
+      response.size != sizeof (screen_info) ||
+      recv_all_timeout (transport->control_fd, &screen_info,
+                        sizeof (screen_info), INITIAL_HANDSHAKE_TIMEOUT_MS) < 0)
+    goto failed;
+
+  transport->screen_info = screen_info;
+  *out_transport = transport;
+  return 0;
+
+failed:
+  if (transport->control_fd >= 0)
+    close (transport->control_fd);
+  free (transport);
+  return -1;
+}
+
+void
+meta_anland_transport_disconnect (MetaAnlandTransport *transport)
+{
+  if (!transport)
+    return;
+
+  release_consumer_resources (transport);
+  if (transport->control_fd >= 0)
+    close (transport->control_fd);
+  free (transport);
+}
+
+bool
+meta_anland_transport_get_screen_info (MetaAnlandTransport *transport,
+                                       struct screen_info   *screen_info)
+{
+  if (!transport || !screen_info)
+    return false;
+
+  *screen_info = transport->screen_info;
+  return true;
+}
+
+MetaAnlandTransportPickupResult
+meta_anland_transport_try_pickup (MetaAnlandTransport *transport)
+{
+  MetaAnlandTransportPickupResult result;
+
+  if (!transport)
+    return META_ANLAND_TRANSPORT_PICKUP_PROTOCOL_ERROR;
+  if (!transport->fallback)
+    return META_ANLAND_TRANSPORT_PICKUP_READY;
+
+  result = pickup_fds (transport);
+  if (result != META_ANLAND_TRANSPORT_PICKUP_READY)
+    {
+      release_consumer_resources (transport);
+      return result;
+    }
+
+  result = receive_buffers (transport);
+  if (result != META_ANLAND_TRANSPORT_PICKUP_READY)
+    {
+      release_consumer_resources (transport);
+      return result;
+    }
+
+  transport->fallback = false;
+  return META_ANLAND_TRANSPORT_PICKUP_READY;
+}
+
+bool
+meta_anland_transport_is_fallback (MetaAnlandTransport *transport)
+{
+  return !transport || transport->fallback;
+}
+
+void
+meta_anland_transport_enter_fallback (MetaAnlandTransport *transport)
+{
+  if (transport)
+    enter_fallback (transport);
+}
+
+void
+meta_anland_transport_set_fallback_callback (MetaAnlandTransport *transport,
+                                             void                 (*callback) (void *user_data),
+                                             void                  *user_data)
+{
+  transport->fallback_callback = callback;
+  transport->fallback_user_data = user_data;
+}
+
+int
+meta_anland_transport_get_buffer_ready_fd (MetaAnlandTransport *transport)
+{
+  return transport && !transport->fallback ? transport->buffer_ready_fd : -1;
+}
+
+int
+meta_anland_transport_get_data_fd (MetaAnlandTransport *transport)
+{
+  return transport && !transport->fallback ? transport->data_fd : -1;
+}
+
+int
+meta_anland_transport_get_audio_fd (MetaAnlandTransport *transport)
+{
+  return transport && !transport->fallback ? transport->audio_fd : -1;
+}
+
+int
+meta_anland_transport_get_buffer_count (MetaAnlandTransport *transport)
+{
+  return transport && !transport->fallback ? transport->n_buffers : 0;
+}
+
+int
+meta_anland_transport_get_selected_buffer (MetaAnlandTransport *transport)
+{
+  uint32_t selected;
+
+  if (!transport || transport->fallback || !transport->selected_buffer)
+    return -1;
+
+  selected = *transport->selected_buffer;
+  return selected < (uint32_t) transport->n_buffers ? (int) selected : -1;
+}
+
+int
+meta_anland_transport_get_buffer_fd (MetaAnlandTransport *transport,
+                                     int                   index)
+{
+  if (!transport || transport->fallback || index < 0 ||
+      index >= transport->n_buffers)
+    return -1;
+
+  return transport->buffer_fds[index];
+}
+
+bool
+meta_anland_transport_get_buffer_info (MetaAnlandTransport *transport,
+                                       int                   index,
+                                       struct buf_info      *buffer_info)
+{
+  if (!transport || !buffer_info || transport->fallback || index < 0 ||
+      index >= transport->n_buffers)
+    return false;
+
+  *buffer_info = transport->buffer_infos[index];
+  return true;
+}
+
+void
+meta_anland_transport_set_render_fence (MetaAnlandTransport *transport,
+                                        int                   fence_fd)
+{
+  if (!transport)
+    {
+      if (fence_fd >= 0)
+        close (fence_fd);
+      return;
+    }
+
+  if (transport->pending_render_fence_fd >= 0)
+    close (transport->pending_render_fence_fd);
+  transport->pending_render_fence_fd = fence_fd;
+}
+
+bool
+meta_anland_transport_notify_frame_done (MetaAnlandTransport *transport)
+{
+  struct iovec iov;
+  struct msghdr message = { 0 };
+  char byte = 0;
+  union
+  {
+    char bytes[CMSG_SPACE (sizeof (int))];
+    struct cmsghdr align;
+  } control = { 0 };
+  ssize_t n;
+
+  if (!transport)
+    return false;
+  if (transport->fallback)
+    {
+      if (transport->pending_render_fence_fd >= 0)
+        close (transport->pending_render_fence_fd);
+      transport->pending_render_fence_fd = -1;
+      return false;
+    }
+
+  iov.iov_base = &byte;
+  iov.iov_len = sizeof (byte);
+  message.msg_iov = &iov;
+  message.msg_iovlen = 1;
+  if (transport->pending_render_fence_fd >= 0)
+    {
+      struct cmsghdr *cmsg;
+
+      message.msg_control = control.bytes;
+      message.msg_controllen = sizeof (control.bytes);
+      cmsg = CMSG_FIRSTHDR (&message);
+      cmsg->cmsg_level = SOL_SOCKET;
+      cmsg->cmsg_type = SCM_RIGHTS;
+      cmsg->cmsg_len = CMSG_LEN (sizeof (int));
+      memcpy (CMSG_DATA (cmsg), &transport->pending_render_fence_fd,
+              sizeof (transport->pending_render_fence_fd));
+    }
+
+  do
+    n = sendmsg (transport->fence_fd, &message, MSG_NOSIGNAL | MSG_DONTWAIT);
+  while (n < 0 && errno == EINTR);
+
+  if (transport->pending_render_fence_fd >= 0)
+    {
+      close (transport->pending_render_fence_fd);
+      transport->pending_render_fence_fd = -1;
+    }
+
+  if (n == 1)
+    return true;
+
+  enter_fallback (transport);
+  return false;
+}
+
+int
+meta_anland_transport_poll_input_event (MetaAnlandTransport *transport,
+                                        struct InputEvent    *event,
+                                        int                   timeout_ms)
+{
+  struct data_msg header;
+
+  if (!transport || !event || transport->fallback)
+    return 0;
+
+  for (;;)
+    {
+      int wait_result = wait_for_fd (transport->data_fd, POLLIN, timeout_ms);
+
+      if (wait_result == 0)
+        return 0;
+      if (wait_result < 0 ||
+          recv_all_timeout (transport->data_fd, &header, sizeof (header),
+                            INPUT_TIMEOUT_MS) < 0)
+        {
+          enter_fallback (transport);
+          return -1;
+        }
+
+      if (header.type != DATA_MSG_INPUT_EVENT)
+        {
+          if (discard_data_payload (transport, header.size) < 0)
+            {
+              enter_fallback (transport);
+              return -1;
+            }
+          timeout_ms = 0;
+          continue;
+        }
+
+      if (header.size != sizeof (*event) ||
+          recv_all_timeout (transport->data_fd, event, sizeof (*event),
+                            INPUT_TIMEOUT_MS) < 0)
+        {
+          enter_fallback (transport);
+          return -1;
+        }
+
+      return 1;
+    }
+}
+
+int
+meta_anland_transport_read_input_payload (MetaAnlandTransport *transport,
+                                          void                 *payload,
+                                          size_t                size,
+                                          int                   timeout_ms)
+{
+  if (!transport || transport->fallback)
+    return 0;
+  if (size == 0)
+    return 1;
+  if (size > META_ANLAND_MAX_PAYLOAD_SIZE || !payload ||
+      recv_all_timeout (transport->data_fd, payload, size,
+                                    timeout_ms) < 0)
+    {
+      enter_fallback (transport);
+      return -1;
+    }
+
+  return 1;
+}
+
+int
+meta_anland_transport_read_input_fds (MetaAnlandTransport *transport,
+                                      int                  *fds,
+                                      int                   max_fds,
+                                      int                  *n_fds,
+                                      int                   timeout_ms)
+{
+  struct data_msg header;
+
+  if (!n_fds)
+    return -1;
+  *n_fds = 0;
+  if (!transport || transport->fallback)
+    return 0;
+  if (wait_for_fd (transport->data_fd, POLLIN, timeout_ms) != 1 ||
+      recv_fds_exact (transport->data_fd, &header, sizeof (header), fds,
+                      max_fds, n_fds) < 0 ||
+      header.type != DATA_MSG_INPUT_EXTEND_FDS || header.size != 0 ||
+      *n_fds < 1)
+    {
+      close_fds (fds, *n_fds);
+      *n_fds = 0;
+      enter_fallback (transport);
+      return -1;
+    }
+
+  return 1;
+}
+
+bool
+meta_anland_transport_send_output_event (MetaAnlandTransport     *transport,
+                                         const struct OutputEvent *event,
+                                         const void               *payload,
+                                         size_t                    payload_size)
+{
+  struct data_msg header = { .type = DATA_MSG_OUTPUT_EVENT,
+                             .size = sizeof (*event) };
+  size_t size;
+  uint8_t *message;
+
+  if (!transport || !event || transport->fallback ||
+      (payload_size > 0 && !payload) ||
+      payload_size > META_ANLAND_MAX_PAYLOAD_SIZE ||
+      payload_size > SIZE_MAX - sizeof (header) - sizeof (*event))
+    return false;
+
+  size = sizeof (header) + sizeof (*event) + payload_size;
+  message = malloc (size);
+  if (!message)
+    return false;
+
+  memcpy (message, &header, sizeof (header));
+  memcpy (message + sizeof (header), event, sizeof (*event));
+  if (payload_size > 0)
+    memcpy (message + sizeof (header) + sizeof (*event), payload, payload_size);
+
+  if (send_all_timeout (transport->data_fd, message, size,
+                        INPUT_TIMEOUT_MS) < 0)
+    {
+      free (message);
+      enter_fallback (transport);
+      return false;
+    }
+
+  free (message);
+  return true;
+}

--- a/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/vendor/meta-anland-transport.h
+++ b/producers/gnome/Ubuntu2604_v5/mutter/src/backends/anland/vendor/meta-anland-transport.h
@@ -1,0 +1,71 @@
+#ifndef META_ANLAND_TRANSPORT_H
+#define META_ANLAND_TRANSPORT_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "meta-anland-protocol.h"
+
+typedef struct _MetaAnlandTransport MetaAnlandTransport;
+
+#define META_ANLAND_MAX_PAYLOAD_SIZE (1024 * 1024)
+
+typedef enum
+{
+  META_ANLAND_TRANSPORT_PICKUP_READY,
+  META_ANLAND_TRANSPORT_PICKUP_NO_CONSUMER,
+  META_ANLAND_TRANSPORT_PICKUP_DAEMON_LOST = -1,
+  META_ANLAND_TRANSPORT_PICKUP_PROTOCOL_ERROR = -2,
+} MetaAnlandTransportPickupResult;
+
+int meta_anland_transport_connect (MetaAnlandTransport **transport,
+                                   const char           *socket_path);
+void meta_anland_transport_disconnect (MetaAnlandTransport *transport);
+
+bool meta_anland_transport_get_screen_info (MetaAnlandTransport *transport,
+                                            struct screen_info   *screen_info);
+
+MetaAnlandTransportPickupResult
+meta_anland_transport_try_pickup (MetaAnlandTransport *transport);
+
+bool meta_anland_transport_is_fallback (MetaAnlandTransport *transport);
+void meta_anland_transport_enter_fallback (MetaAnlandTransport *transport);
+void meta_anland_transport_set_fallback_callback (MetaAnlandTransport *transport,
+                                                  void                 (*callback) (void *user_data),
+                                                  void                  *user_data);
+
+int meta_anland_transport_get_buffer_ready_fd (MetaAnlandTransport *transport);
+int meta_anland_transport_get_data_fd (MetaAnlandTransport *transport);
+int meta_anland_transport_get_audio_fd (MetaAnlandTransport *transport);
+int meta_anland_transport_get_buffer_count (MetaAnlandTransport *transport);
+int meta_anland_transport_get_selected_buffer (MetaAnlandTransport *transport);
+int meta_anland_transport_get_buffer_fd (MetaAnlandTransport *transport,
+                                         int                   index);
+bool meta_anland_transport_get_buffer_info (MetaAnlandTransport *transport,
+                                            int                   index,
+                                            struct buf_info      *buffer_info);
+
+void meta_anland_transport_set_render_fence (MetaAnlandTransport *transport,
+                                             int                   fence_fd);
+bool meta_anland_transport_notify_frame_done (MetaAnlandTransport *transport);
+
+int meta_anland_transport_poll_input_event (MetaAnlandTransport *transport,
+                                            struct InputEvent    *event,
+                                            int                   timeout_ms);
+int meta_anland_transport_read_input_payload (MetaAnlandTransport *transport,
+                                              void                 *payload,
+                                              size_t                size,
+                                              int                   timeout_ms);
+int meta_anland_transport_read_input_fds (MetaAnlandTransport *transport,
+                                          int                  *fds,
+                                          int                   max_fds,
+                                          int                  *n_fds,
+                                          int                   timeout_ms);
+
+bool meta_anland_transport_send_output_event (MetaAnlandTransport     *transport,
+                                              const struct OutputEvent *event,
+                                              const void               *payload,
+                                              size_t                    payload_size);
+
+#endif /* META_ANLAND_TRANSPORT_H */

--- a/producers/gnome/Ubuntu2604_v5/mutter/src/tests/anland-transport-tests.c
+++ b/producers/gnome/Ubuntu2604_v5/mutter/src/tests/anland-transport-tests.c
@@ -1,0 +1,503 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "meta-anland-socket-utils.h"
+#include "meta-anland-transport.h"
+
+_Static_assert (sizeof (struct ctrl_msg) == 8,
+                "Anland control header ABI changed");
+_Static_assert (sizeof (struct data_msg) == 8,
+                "Anland data header ABI changed");
+_Static_assert (sizeof (struct screen_info) == 16,
+                "Anland screen info ABI changed");
+_Static_assert (sizeof (struct buf_info) == 28,
+                "Anland buffer metadata ABI changed");
+_Static_assert (sizeof (struct InputEvent) == 20,
+                "Anland input event ABI changed");
+_Static_assert (sizeof (struct OutputEvent) == 20,
+                "Anland output event ABI changed");
+_Static_assert (sizeof (struct audio_format) == 20,
+                "Anland audio format ABI changed");
+_Static_assert (sizeof (struct audio_msg) == 8,
+                "Anland audio header ABI changed");
+
+typedef struct
+{
+  int ready;
+  int fence;
+  int data;
+  int audio;
+} MockPeers;
+
+typedef struct
+{
+  int listen_fd;
+  GMutex lock;
+  MockPeers peers;
+  gboolean delay_first_pickup;
+  gboolean failed;
+} MockDaemon;
+
+static void
+close_fd (int *fd)
+{
+  if (*fd >= 0)
+    {
+      close (*fd);
+      *fd = -1;
+    }
+}
+
+static void
+close_peers (MockDaemon *daemon)
+{
+  MockPeers peers;
+
+  g_mutex_lock (&daemon->lock);
+  peers = daemon->peers;
+  daemon->peers = (MockPeers) { -1, -1, -1, -1 };
+  g_mutex_unlock (&daemon->lock);
+
+  close_fd (&peers.ready);
+  close_fd (&peers.fence);
+  close_fd (&peers.data);
+  close_fd (&peers.audio);
+}
+
+static MockPeers
+get_peers (MockDaemon *daemon)
+{
+  MockPeers peers;
+
+  g_mutex_lock (&daemon->lock);
+  peers = daemon->peers;
+  g_mutex_unlock (&daemon->lock);
+  return peers;
+}
+
+static int
+new_memfd (const char *name,
+           size_t      size)
+{
+  int fd = memfd_create (name, MFD_CLOEXEC);
+
+  if (fd < 0 || ftruncate (fd, (off_t) size) < 0)
+    {
+      close_fd (&fd);
+      return -1;
+    }
+
+  return fd;
+}
+
+static gboolean
+send_screen_info (int control_fd)
+{
+  struct ctrl_msg header = {
+    .type = CTRL_MSG_SCREEN_INFO,
+    .size = sizeof (struct screen_info),
+  };
+  struct screen_info info = {
+    .width = 1920,
+    .height = 1080,
+    .format = 1,
+    .refresh = 120000,
+  };
+
+  return meta_anland_send_all (control_fd, &header, sizeof (header)) == 0 &&
+         meta_anland_send_all (control_fd, &info, sizeof (info)) == 0;
+}
+
+static gboolean
+send_buffers (int data_fd)
+{
+  struct data_msg header = {
+    .type = DATA_MSG_BUFS_READY,
+    .size = 2 * sizeof (struct buf_info),
+  };
+  struct buf_info infos[2] = {
+    { .stride = 5120, .width = 1280, .height = 720,
+      .format = 1, .modifier = 0, .offset = 0 },
+    { .stride = 5120, .width = 1280, .height = 720,
+      .format = 1, .modifier = 0, .offset = 0 },
+  };
+  int fds[2] = {
+    new_memfd ("mutter-anland-buffer-0", 4096),
+    new_memfd ("mutter-anland-buffer-1", 4096),
+  };
+  gboolean result;
+
+  result = fds[0] >= 0 && fds[1] >= 0 &&
+           meta_anland_send_fds (data_fd, &header, sizeof (header), fds, 2) == 0 &&
+           meta_anland_send_all (data_fd, infos, sizeof (infos)) == 0;
+  close_fd (&fds[0]);
+  close_fd (&fds[1]);
+  return result;
+}
+
+static gboolean
+publish_consumer (MockDaemon *daemon,
+                  int         control_fd)
+{
+  struct ctrl_msg response = { .type = CTRL_MSG_FDS_READY, .size = 0 };
+  int ready = -1;
+  int fence[2] = { -1, -1 };
+  int data[2] = { -1, -1 };
+  int audio[2] = { -1, -1 };
+  int shm_fd = -1;
+  int producer_fds[5];
+  uint32_t selected = 1;
+  gboolean result = FALSE;
+
+  ready = eventfd (0, EFD_CLOEXEC);
+  if (ready < 0 ||
+      socketpair (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, fence) < 0 ||
+      socketpair (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, data) < 0 ||
+      socketpair (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, audio) < 0)
+    goto out;
+  shm_fd = new_memfd ("mutter-anland-index", sizeof (selected));
+  if (shm_fd < 0 || pwrite (shm_fd, &selected, sizeof (selected), 0) !=
+                   (ssize_t) sizeof (selected))
+    goto out;
+
+  producer_fds[0] = ready;
+  producer_fds[1] = fence[0];
+  producer_fds[2] = data[0];
+  producer_fds[3] = shm_fd;
+  producer_fds[4] = audio[0];
+  if (meta_anland_send_fds (control_fd, &response, sizeof (response),
+                            producer_fds, G_N_ELEMENTS (producer_fds)) < 0)
+    goto out;
+
+  g_mutex_lock (&daemon->lock);
+  daemon->peers = (MockPeers) {
+    .ready = ready, .fence = fence[1], .data = data[1], .audio = audio[1],
+  };
+  g_mutex_unlock (&daemon->lock);
+  ready = fence[1] = data[1] = audio[1] = -1;
+  if (!send_buffers (get_peers (daemon).data))
+    goto out;
+  result = TRUE;
+
+out:
+  close_fd (&ready);
+  close_fd (&fence[0]);
+  close_fd (&fence[1]);
+  close_fd (&data[0]);
+  close_fd (&data[1]);
+  close_fd (&audio[0]);
+  close_fd (&audio[1]);
+  close_fd (&shm_fd);
+  if (!result)
+    close_peers (daemon);
+  return result;
+}
+
+static gpointer
+mock_daemon_thread (gpointer user_data)
+{
+  MockDaemon *daemon = user_data;
+  struct ctrl_msg request;
+  int control_fd = -1;
+
+  control_fd = accept4 (daemon->listen_fd, NULL, NULL, SOCK_CLOEXEC);
+  if (control_fd < 0 ||
+      meta_anland_recv_all (control_fd, &request, sizeof (request)) < 0 ||
+      request.type != CTRL_MSG_PRODUCER_HELLO || request.size != 0 ||
+      !send_screen_info (control_fd))
+    goto failed;
+
+  while (meta_anland_recv_all (control_fd, &request, sizeof (request)) == 0)
+    {
+      if (request.type != CTRL_MSG_PICKUP_FDS || request.size != 0)
+        goto failed;
+      if (daemon->delay_first_pickup)
+        {
+          daemon->delay_first_pickup = FALSE;
+          continue;
+        }
+      if (!publish_consumer (daemon, control_fd))
+        goto failed;
+    }
+
+  close_fd (&control_fd);
+  return NULL;
+
+failed:
+  daemon->failed = TRUE;
+  close_fd (&control_fd);
+  return NULL;
+}
+
+static int
+create_listener (const char *path)
+{
+  struct sockaddr_un address = { 0 };
+  int fd;
+
+  fd = socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd < 0)
+    return -1;
+  address.sun_family = AF_UNIX;
+  if (strlen (path) >= sizeof (address.sun_path))
+    goto failed;
+  strcpy (address.sun_path, path);
+  if (bind (fd, (struct sockaddr *) &address, sizeof (address)) < 0 ||
+      listen (fd, 1) < 0)
+    goto failed;
+
+  return fd;
+
+failed:
+  close (fd);
+  return -1;
+}
+
+static void
+send_data_message (int         fd,
+                   uint32_t    type,
+                   const void *payload,
+                   size_t      size)
+{
+  struct data_msg header = { .type = type, .size = size };
+
+  g_assert_cmpint (meta_anland_send_all (fd, &header, sizeof (header)), ==, 0);
+  if (size > 0)
+    g_assert_cmpint (meta_anland_send_all (fd, payload, size), ==, 0);
+}
+
+static void
+fallback_callback (void *user_data)
+{
+  int *count = user_data;
+
+  (*count)++;
+}
+
+static void
+test_transport_and_reconnect (void)
+{
+  g_autoptr (GError) error = NULL;
+  g_autofree char *directory = g_dir_make_tmp ("mutter-anland-XXXXXX", &error);
+  g_autofree char *socket_path = NULL;
+  MockDaemon daemon = {
+    .listen_fd = -1,
+    .peers = { -1, -1, -1, -1 },
+    .delay_first_pickup = TRUE,
+  };
+  MetaAnlandTransport *transport = NULL;
+  struct screen_info screen_info;
+  struct InputEvent event = { 0 };
+  struct InputEvent received_event;
+  struct OutputEvent output = { 0 };
+  struct data_msg output_header;
+  struct OutputEvent received_output;
+  MockPeers peers;
+  GThread *thread;
+  char text[] = "Anland text";
+  char audio_byte = 'A';
+  char received_audio = 0;
+  char received_text[sizeof (text)] = { 0 };
+  char fence_byte = 1;
+  int resource_fds[2] = { -1, -1 };
+  int received_resource_fds[2] = { -1, -1 };
+  int n_resource_fds = 0;
+  int fence_fds[1] = { -1 };
+  int n_fence_fds = 0;
+  int pipe_fds[2] = { -1, -1 };
+  int fallback_count = 0;
+  eventfd_t ready_value = 5;
+  eventfd_t received_ready = 0;
+
+  g_assert_no_error (error);
+  socket_path = g_build_filename (directory, "display.sock", NULL);
+  daemon.listen_fd = create_listener (socket_path);
+  if (daemon.listen_fd < 0)
+    g_error ("failed to create mock Anland socket %s: %s",
+             socket_path, g_strerror (errno));
+  g_assert_cmpint (daemon.listen_fd, >=, 0);
+  g_mutex_init (&daemon.lock);
+  thread = g_thread_new ("anland-mock-daemon", mock_daemon_thread, &daemon);
+
+  g_assert_cmpint (meta_anland_transport_connect (&transport, socket_path), ==, 0);
+  g_assert_true (meta_anland_transport_get_screen_info (transport, &screen_info));
+  g_assert_cmpuint (screen_info.refresh, ==, 120000);
+  g_assert_cmpint (meta_anland_transport_try_pickup (transport), ==,
+                   META_ANLAND_TRANSPORT_PICKUP_NO_CONSUMER);
+  g_assert_cmpint (meta_anland_transport_try_pickup (transport), ==,
+                   META_ANLAND_TRANSPORT_PICKUP_READY);
+  g_assert_false (meta_anland_transport_is_fallback (transport));
+  g_assert_cmpint (meta_anland_transport_get_buffer_count (transport), ==, 2);
+  g_assert_cmpint (meta_anland_transport_get_selected_buffer (transport), ==, 1);
+  g_assert_cmpint (meta_anland_transport_get_buffer_fd (transport, 0), >=, 0);
+
+  peers = get_peers (&daemon);
+  g_assert_cmpint (eventfd_write (peers.ready, ready_value), ==, 0);
+  g_assert_cmpint (eventfd_read (meta_anland_transport_get_buffer_ready_fd (transport),
+                                 &received_ready), ==, 0);
+  g_assert_cmpuint (received_ready, ==, ready_value);
+  g_assert_cmpint (send (peers.audio, &audio_byte, sizeof (audio_byte), 0), ==, 1);
+  g_assert_cmpint (recv (meta_anland_transport_get_audio_fd (transport),
+                         &received_audio, sizeof (received_audio), 0), ==, 1);
+  g_assert_cmpint (received_audio, ==, audio_byte);
+
+  send_data_message (peers.data, 0xfeed, text, sizeof (text));
+  event.type = INPUT_TYPE_TEXT_INPUT;
+  event.text_input.size = sizeof (text);
+  send_data_message (peers.data, DATA_MSG_INPUT_EVENT, &event, sizeof (event));
+  g_assert_cmpint (meta_anland_send_all (peers.data, text, sizeof (text)), ==, 0);
+  g_assert_cmpint (meta_anland_transport_poll_input_event (transport, &received_event, 100), ==, 1);
+  g_assert_cmpuint (received_event.type, ==, INPUT_TYPE_TEXT_INPUT);
+  g_assert_cmpint (meta_anland_transport_read_input_payload (transport, received_text,
+                                                              sizeof (received_text), 100), ==, 1);
+  g_assert_cmpmem (received_text, sizeof (received_text), text, sizeof (text));
+
+  g_assert_cmpint (pipe2 (resource_fds, O_CLOEXEC), ==, 0);
+  event = (struct InputEvent) {
+    .type = INPUT_TYPE_RESOURCE,
+    .resource = {
+      .type = SERVICE_TYPE_CAMERA,
+      .fdnum = G_N_ELEMENTS (resource_fds),
+    },
+  };
+  send_data_message (peers.data, DATA_MSG_INPUT_EVENT, &event, sizeof (event));
+  output_header = (struct data_msg) {
+    .type = DATA_MSG_INPUT_EXTEND_FDS,
+    .size = 0,
+  };
+  g_assert_cmpint (meta_anland_send_fds (peers.data, &output_header,
+                                         sizeof (output_header), resource_fds,
+                                         G_N_ELEMENTS (resource_fds)), ==, 0);
+  close_fd (&resource_fds[0]);
+  close_fd (&resource_fds[1]);
+  g_assert_cmpint (meta_anland_transport_poll_input_event (transport,
+                                                            &received_event, 100), ==, 1);
+  g_assert_cmpuint (received_event.type, ==, INPUT_TYPE_RESOURCE);
+  g_assert_cmpuint (received_event.resource.type, ==, SERVICE_TYPE_CAMERA);
+  g_assert_cmpuint (received_event.resource.fdnum, ==,
+                    G_N_ELEMENTS (received_resource_fds));
+  g_assert_cmpint (meta_anland_transport_read_input_fds (transport,
+                                                          received_resource_fds,
+                                                          G_N_ELEMENTS (received_resource_fds),
+                                                          &n_resource_fds, 100), ==, 1);
+  g_assert_cmpint (n_resource_fds, ==, G_N_ELEMENTS (received_resource_fds));
+  close_fd (&received_resource_fds[0]);
+  close_fd (&received_resource_fds[1]);
+
+  event.type = INPUT_TYPE_CLIPBOARD;
+  event.clipboard.size = sizeof (text);
+  send_data_message (peers.data, DATA_MSG_INPUT_EVENT, &event, sizeof (event));
+  g_assert_cmpint (meta_anland_send_all (peers.data, text, sizeof (text)), ==, 0);
+  g_assert_cmpint (meta_anland_transport_poll_input_event (transport, &received_event, 100), ==, 1);
+  g_assert_cmpuint (received_event.type, ==, INPUT_TYPE_CLIPBOARD);
+  g_assert_cmpint (meta_anland_transport_read_input_payload (transport, received_text,
+                                                              sizeof (received_text), 100), ==, 1);
+  g_assert_cmpmem (received_text, sizeof (received_text), text, sizeof (text));
+
+  output = (struct OutputEvent) {
+    .type = OUTPUT_TYPE_RESOURCES_REQUEST,
+    .resources_request = { .type = SERVICE_TYPE_CAMERA },
+  };
+  g_assert_true (meta_anland_transport_send_output_event (transport, &output,
+                                                           NULL, 0));
+  g_assert_cmpint (meta_anland_recv_all (peers.data, &output_header,
+                                         sizeof (output_header)), ==, 0);
+  g_assert_cmpuint (output_header.type, ==, DATA_MSG_OUTPUT_EVENT);
+  g_assert_cmpint (meta_anland_recv_all (peers.data, &received_output,
+                                         sizeof (received_output)), ==, 0);
+  g_assert_cmpuint (received_output.type, ==, OUTPUT_TYPE_RESOURCES_REQUEST);
+  g_assert_cmpuint (received_output.resources_request.type, ==,
+                    SERVICE_TYPE_CAMERA);
+
+  event = (struct InputEvent) {
+    .type = INPUT_TYPE_POINTER_MOTION,
+    .pointer_motion = {
+      .x = 640.0f,
+      .y = 360.0f,
+      .dx = -2.5f,
+      .dy = 1.5f,
+    },
+  };
+  send_data_message (peers.data, DATA_MSG_INPUT_EVENT, &event, sizeof (event));
+  g_assert_cmpint (meta_anland_transport_poll_input_event (transport, &received_event, 100), ==, 1);
+  g_assert_cmpuint (received_event.type, ==, INPUT_TYPE_POINTER_MOTION);
+  g_assert_cmpfloat (received_event.pointer_motion.x, ==, 640.0f);
+  g_assert_cmpfloat (received_event.pointer_motion.dy, ==, 1.5f);
+
+  event = (struct InputEvent) {
+    .type = INPUT_TYPE_DISPLAY_REFRESH,
+    .display = { .refresh_mhz = 90000 },
+  };
+  send_data_message (peers.data, DATA_MSG_INPUT_EVENT, &event, sizeof (event));
+  g_assert_cmpint (meta_anland_transport_poll_input_event (transport, &received_event, 100), ==, 1);
+  g_assert_cmpuint (received_event.type, ==, INPUT_TYPE_DISPLAY_REFRESH);
+  g_assert_cmpuint (received_event.display.refresh_mhz, ==, 90000);
+
+  output.type = OUTPUT_TYPE_CLIPBOARD;
+  output.clipboard.size = sizeof (text);
+  g_assert_true (meta_anland_transport_send_output_event (transport, &output,
+                                                           text, sizeof (text)));
+  g_assert_cmpint (meta_anland_recv_all (peers.data, &output_header,
+                                         sizeof (output_header)), ==, 0);
+  g_assert_cmpuint (output_header.type, ==, DATA_MSG_OUTPUT_EVENT);
+  g_assert_cmpint (meta_anland_recv_all (peers.data, &received_output,
+                                         sizeof (received_output)), ==, 0);
+  g_assert_cmpuint (output_header.size, ==, sizeof (received_output));
+  g_assert_cmpuint (received_output.type, ==, OUTPUT_TYPE_CLIPBOARD);
+  g_assert_cmpint (meta_anland_recv_all (peers.data, received_text,
+                                         sizeof (received_text)), ==, 0);
+  g_assert_cmpmem (received_text, sizeof (received_text), text, sizeof (text));
+
+  g_assert_cmpint (pipe2 (pipe_fds, O_CLOEXEC), ==, 0);
+  meta_anland_transport_set_render_fence (transport, pipe_fds[0]);
+  pipe_fds[0] = -1;
+  g_assert_true (meta_anland_transport_notify_frame_done (transport));
+  g_assert_cmpint (meta_anland_recv_fds (peers.fence, &fence_byte,
+                                         sizeof (fence_byte), fence_fds, 1,
+                                         &n_fence_fds), ==, 1);
+  g_assert_cmpint (fence_byte, ==, 0);
+  g_assert_cmpint (n_fence_fds, ==, 1);
+  close_fd (&fence_fds[0]);
+  close_fd (&pipe_fds[1]);
+
+  meta_anland_transport_set_fallback_callback (transport, fallback_callback,
+                                                &fallback_count);
+  g_mutex_lock (&daemon.lock);
+  close_fd (&daemon.peers.data);
+  g_mutex_unlock (&daemon.lock);
+  g_assert_cmpint (meta_anland_transport_poll_input_event (transport, &event, 100), ==, -1);
+  g_assert_true (meta_anland_transport_is_fallback (transport));
+  g_assert_cmpint (fallback_count, ==, 1);
+  close_peers (&daemon);
+
+  g_assert_cmpint (meta_anland_transport_try_pickup (transport), ==,
+                   META_ANLAND_TRANSPORT_PICKUP_READY);
+  g_assert_false (meta_anland_transport_is_fallback (transport));
+  meta_anland_transport_disconnect (transport);
+  g_thread_join (thread);
+  g_assert_false (daemon.failed);
+  close_fd (&daemon.listen_fd);
+  close_peers (&daemon);
+  g_assert_cmpint (g_unlink (socket_path), ==, 0);
+  g_assert_cmpint (g_rmdir (directory), ==, 0);
+  g_mutex_clear (&daemon.lock);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+  g_test_init (&argc, &argv, NULL);
+  g_test_add_func ("/backends/anland/transport-and-reconnect",
+                   test_transport_and_reconnect);
+  return g_test_run ();
+}

--- a/producers/gnome/Ubuntu2604_v5/startup.sh
+++ b/producers/gnome/Ubuntu2604_v5/startup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Linux truncates process names to 15 characters in /proc, so cover both forms.
+gnome_processes=(gnome-shell gnome-session gnome-session-b gnome-session-s gnome-session-service mutter)
+gnome_user_id="$(id -u)"
+for process_name in "${gnome_processes[@]}"; do
+    pkill -TERM -u "$gnome_user_id" -x "$process_name" > /dev/null 2>&1 || true
+done
+sleep 1
+for process_name in "${gnome_processes[@]}"; do
+    pkill -KILL -u "$gnome_user_id" -x "$process_name" > /dev/null 2>&1 || true
+done
+
+export ANLAND=1
+export ANLAND_SOCKET="${1:-/run/display.sock}"
+export QT_QPA_PLATFORM=wayland XDG_CURRENT_DESKTOP=GNOME XDG_SESSION_DESKTOP=gnome XDG_SESSION_TYPE=wayland GNOME_SHELL_SESSION_MODE=gnome
+export WAYLAND_DISPLAY=wayland-anland GNOME_WAYLAND_DISPLAY=wayland-anland
+export ANLAND_DRM_DEVICE=/dev/dri/renderD128
+export MESA_LOADER_DRIVER_OVERRIDE=kgsl TURNIP_KMD=kgsl GALLIUM_DRIVER=freedreno FD_FORCE_KGSL=1
+export XDG_RUNTIME_DIR=/run/user/$(id -u)
+sudo mkdir -p $XDG_RUNTIME_DIR
+sudo chown $(id -un):$(id -gn) $XDG_RUNTIME_DIR
+chmod 700 $XDG_RUNTIME_DIR
+rm -f $XDG_RUNTIME_DIR/wayland-* > /dev/null 2>&1
+sudo mkdir -p /tmp/.X11-unix
+sudo chmod 1777 /tmp/.X11-unix
+gnome-session

--- a/producers/gnome/Ubuntu2604_v5/xwayland.patch
+++ b/producers/gnome/Ubuntu2604_v5/xwayland.patch
@@ -1,0 +1,1 @@
+../../kde/ubuntu2604_v5/xwayland.patch


### PR DESCRIPTION
## Changelog

```text
* backends/anland: Add current Anland transport
* backends/anland: Add headless native backend selection
* backends/anland: Add virtual output and reconnect state
* backends/anland: Render directly into consumer buffers
* backends/anland: Handle input and runtime refresh
* backends/anland: Bridge clipboard and text input
* backends/anland: Add PipeWire audio bridge
* backends/anland: Add camera service and integration tests
* debian/rules: enable anland backend
* debian: Add Anland StageView symbols
* backends/anland: Map input to logical output coordinates
* backends/anland: Release StageView before mode changes
* backends/anland: Recover from consumer activation failures
* backends/anland: Detach consumer before stage rebuilds
* core: Select Anland backend from ANLAND_SOCKET
* wayland: Relax Xwayland socket ownership for Anland
* xwayland: Read displayfd readiness data
* backends/anland: Terminate text payloads before injection
* backends/anland: Keep PipeWire speaker stream alive
* backends/anland: Prefer consumer clipboard on reconnect
```

## 对应的上游版本号

* Mutter
  * Ubuntu 26.04: `50.1-0ubuntu2.2`
  * Debian 13: `48.7-0+deb13u1`
* XWayland: 未设置具体的版本号，`xwayland.patch` 直接通过符号链接引用 `producers/kde` 下对应发行版的 XWayland 补丁。

## 测试环境

* 设备：小米平板 6 Pro
* 处理器：骁龙 8+
* Droidspaces 版本：6.5.0
* Anland 版本：`5.19-bcc4250(313)`

## 快速开始

<details>
  <summary>Ubuntu 26.04</summary>

1. 安装 Gnome 核心包：

   ```sh
   sudo apt install --no-install-recommends gnome-core gnome-shell network-manager-gnome xfonts-base gnome-tweaks
   ```

   【可选】安装 Ubuntu 风格的任务栏、托盘、桌面图标等扩展（安装后需在扩展管理器手动开启需要的扩展）：

   ```sh
   sudo apt install gnome-shell-ubuntu-extensions
   ```

2. 构建并安装 Mutter 和 XWayland：

   ```sh
   chmod +x producers/gnome/Ubuntu2604_v5/build.sh
   producers/gnome/Ubuntu2604_v5/build.sh
   ```

   或者直接安装 Actions 构建的版本（`mutter_62be94c_ubuntu_resolute_arm64`）：https://github.com/lfdevs/anland-fork/actions/runs/32859941175#artifacts

3. 执行启动 GNOME 的脚本：

   ```sh
   chmod +x producers/gnome/Ubuntu2604_v5/startup.sh
   producers/gnome/Ubuntu2604_v5/startup.sh
   ```

</details>

<details>
  <summary>Debian 13</summary>

1. 安装 Gnome 核心包：

   ```sh
   sudo apt install --no-install-recommends gnome-core gnome-shell network-manager-gnome xfonts-base gnome-tweaks
   ```

2. 构建并安装 Mutter 和 XWayland：

   ```sh
   chmod +x producers/gnome/Debian13_v5/build.sh
   producers/gnome/Debian13_v5/build.sh
   ```

   或者直接安装 Actions 构建的版本（`mutter_14aad19_debian_trixie_arm64`）：https://github.com/lfdevs/anland-fork/actions/runs/32868964811#artifacts

3. 执行启动 GNOME 的脚本：

   ```sh
   chmod +x producers/gnome/Debian13_v5/startup.sh
   producers/gnome/Debian13_v5/startup.sh
   ```

</details>

## 截图

### Ubuntu 26.04

<img width="2880" height="1800" alt="Screenshot_2026-08-26-00-53-28-795_com anland consumer" src="https://github.com/user-attachments/assets/f25cc7f7-1abe-4123-858c-e9ceebe8dc22" />

### Debian 13

<img width="2880" height="1800" alt="Screenshot_2026-08-26-00-45-55-989_com anland consumer" src="https://github.com/user-attachments/assets/a1a6d19d-9cb2-4240-bfe7-9c89c73bf72a" />
