### PR TITLE
音频：新增系统音效开关（杜比全景声等）

### DIFF
--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/MainActivity.java
@@ -64,6 +64,9 @@ public class MainActivity extends Activity
     static final String KEY_MIC_LATENCY_MS = "mic_latency_ms";
     // Audio keep-alive toggle. Shared with SettingsActivity.
     static final String KEY_AUDIO_KEEPALIVE = "audio_keepalive";
+    // Route desktop audio through system effects (Dolby etc.). Shared with
+    // SettingsActivity.
+    static final String KEY_AUDIO_EFFECTS = "audio_effects";
     private static final int REQ_RECORD_AUDIO = 1001;
     private static final int REQ_CAMERA = 1002;
     // Camera service fds/threads are created once and persist across reconnects;
@@ -1823,6 +1826,7 @@ public class MainActivity extends Activity
             applyMicState();
             applyAudioLatency();
             applyAudioKeepalive();
+            applyAudioEffects();
         }
 
         // ===== 重新读取触摸板设置 =====
@@ -1952,6 +1956,11 @@ public class MainActivity extends Activity
         mNative.setAudioKeepalive(prefs.getBoolean(KEY_AUDIO_KEEPALIVE, false));
     }
 
+    private void applyAudioEffects() {
+        SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+        mNative.setAudioEffects(prefs.getBoolean(KEY_AUDIO_EFFECTS, false));
+    }
+
     private void applyMicState() {
         SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         boolean want = prefs.getBoolean(KEY_MIC_ENABLED, false);
@@ -2013,6 +2022,7 @@ public class MainActivity extends Activity
         applyMicState();
         applyAudioLatency();
         applyAudioKeepalive();
+        applyAudioEffects();
 
         // ===== 更新屏幕尺寸并重置平滑状态 =====
         updateTouchpadBounds(null);

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/Native.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/Native.java
@@ -53,6 +53,7 @@ public final class Native {
     public void setMicEnabled(boolean enabled) { nativeSetMicEnabled(handle, enabled); }
     public void setAudioLatency(int speakerMs, int micMs) { nativeSetAudioLatency(handle, speakerMs, micMs); }
     public void setAudioKeepalive(boolean enabled) { nativeSetAudioKeepalive(handle, enabled); }
+    public void setAudioEffects(boolean enabled) { nativeSetAudioEffects(handle, enabled); }
 
     // ---- native handle lifecycle + handle-taking entry points ----
 
@@ -85,4 +86,5 @@ public final class Native {
     private static native void nativeSetMicEnabled(long handle, boolean enabled);
     private static native void nativeSetAudioLatency(long handle, int speakerMs, int micMs);
     private static native void nativeSetAudioKeepalive(long handle, boolean enabled);
+    private static native void nativeSetAudioEffects(long handle, boolean enabled);
 }

--- a/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
+++ b/consumers/anland_v5/android_consumer/app/src/main/java/com/anland/consumer/SettingsActivity.java
@@ -67,6 +67,7 @@ public class SettingsActivity extends Activity {
     private static final String KEY_MIC_ENABLED = "mic_enabled";
     private static final String KEY_CAMERA_ENABLED = "camera_enabled";
     private static final String KEY_AUDIO_KEEPALIVE = "audio_keepalive";
+    private static final String KEY_AUDIO_EFFECTS = "audio_effects";
     private static final String KEY_SPEAKER_LATENCY_MS = "speaker_latency_ms";
     private static final String KEY_MIC_LATENCY_MS = "mic_latency_ms";
     private static final String KEY_ACCESSIBILITY_ENABLED = "accessibility_key_intercept";
@@ -104,6 +105,11 @@ public class SettingsActivity extends Activity {
 
     // Which profile the six FCL action buttons operate on.
     private String manageTarget = "landscape";   // "landscape" / "portrait"
+
+    // Speaker latency row + card hint, used by the system-effects toggle to grey
+    // out the preset while Dolby-style effects route playback.
+    private LinearLayout speakerLatencyBox;
+    private TextView latencyHintView;
 
     // ===== 新增：触摸板 Key =====
     private static final String KEY_TOUCHPAD_MODE = "touchpad_mode";
@@ -1526,14 +1532,29 @@ public class SettingsActivity extends Activity {
                 .putBoolean(KEY_AUDIO_KEEPALIVE, checked).apply());
         runtimeCard.addView(fclSwitchRow(getString(R.string.audio_keepalive_switch),
                 getString(R.string.audio_keepalive_hint), keepaliveSwitch));
+        addFclDivider(runtimeCard);
+
+        Switch effectsSwitch = new Switch(this);
+        effectsSwitch.setChecked(prefs.getBoolean(KEY_AUDIO_EFFECTS, false));
+        effectsSwitch.setOnCheckedChangeListener((v, checked) -> {
+            getSharedPreferences(PREFS_NAME, MODE_PRIVATE).edit()
+                .putBoolean(KEY_AUDIO_EFFECTS, checked).apply();
+            applyEffectsLatencyUi();
+        });
+        runtimeCard.addView(fclSwitchRow(getString(R.string.audio_effects_switch),
+                getString(R.string.audio_effects_hint), effectsSwitch));
 
         LinearLayout latencyCard = addSettingsCard(root, getString(R.string.audio_latency_title),
                 getString(R.string.latency_hint));
 
-        latencyCard.addView(makeLatencySpinner(getString(R.string.latency_speaker_label),
-                                        KEY_SPEAKER_LATENCY_MS, prefs));
+        View speakerView = makeLatencySpinner(getString(R.string.latency_speaker_label),
+                                        KEY_SPEAKER_LATENCY_MS, prefs);
+        latencyCard.addView(speakerView);
+        speakerLatencyBox = (LinearLayout) speakerView;
         latencyCard.addView(makeLatencySpinner(getString(R.string.latency_mic_label),
                                         KEY_MIC_LATENCY_MS, prefs));
+        latencyHintView = (TextView) latencyCard.getChildAt(1);
+        applyEffectsLatencyUi();
     }
 
     private void addResolutionSection(LinearLayout root) {
@@ -1686,6 +1707,28 @@ public class SettingsActivity extends Activity {
         });
         box.addView(sp);
         return box;
+    }
+
+    /** System effects are on: the speaker latency preset is bypassed (the phone's
+     *  effects chain controls buffering), so grey the row out and explain it.
+     *  The microphone preset stays untouched. */
+    private void applyEffectsLatencyUi() {
+        if (speakerLatencyBox == null || latencyHintView == null) return;
+        boolean effects = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+            .getBoolean(KEY_AUDIO_EFFECTS, false);
+        setLatencyBoxEnabled(speakerLatencyBox, !effects);
+        latencyHintView.setText(effects
+            ? getString(R.string.audio_effects_latency_hint)
+            : getString(R.string.latency_hint));
+    }
+
+    private void setLatencyBoxEnabled(LinearLayout box, boolean enabled) {
+        box.setEnabled(enabled);
+        for (int i = 0; i < box.getChildCount(); i++) {
+            View child = box.getChildAt(i);
+            child.setEnabled(enabled);
+            child.setAlpha(enabled ? 1.0f : 0.35f);
+        }
     }
 
     /** Stop whichever row is counting down, leaving its binding untouched. */

--- a/consumers/anland_v5/android_consumer/app/src/main/jni/native_audio.c
+++ b/consumers/anland_v5/android_consumer/app/src/main/jni/native_audio.c
@@ -69,6 +69,12 @@ struct audio_bridge {
      * so the audio path can sleep. */
     volatile bool keepalive_enabled;
 
+    /* User "system effects" toggle. On: desktop audio goes through Android's
+     * effects chain (Dolby etc.), which requires a non-MMAP AAudio stream. Off
+     * (default): direct MMAP output, bypassing the mixer/effects for the lowest
+     * latency. Set via audio_set_effects(); forces a play-stream reopen. */
+    volatile bool route_through_effects;
+
     /*
      * Playback is pull-driven by an AAudio data callback. The socket thread only
      * appends incoming PCM to this ring; the callback feeds an inaudible keepalive
@@ -334,9 +340,25 @@ static AAudioStream *open_stream(struct audio_bridge *bridge,
     AAudioStreamBuilder_setSharingMode(bld, AAUDIO_SHARING_MODE_SHARED);
 
     if (dir == AAUDIO_DIRECTION_OUTPUT) {
+        /* MMAP streams bypass AudioFlinger and therefore the system effects chain
+         * (Dolby Atmos etc.). When the user enables system effects, force the
+         * legacy (non-MMAP) route so the mixer/effects are applied. */
+        /* When system effects are requested, allocate an audio session ID so the
+         * stream is routed through the AudioFlinger mixer/effects chain (Dolby
+         * Atmos etc.). MMAP direct output stays the default for low latency. */
+        if (bridge->route_through_effects)
+            AAudioStreamBuilder_setSessionId(bld, AAUDIO_SESSION_ID_ALLOCATE);
         AAudioStreamBuilder_setUsage(bld, AAUDIO_USAGE_MEDIA);
         AAudioStreamBuilder_setContentType(bld, AAUDIO_CONTENT_TYPE_MUSIC);
-        AAudioStreamBuilder_setPerformanceMode(bld, AAUDIO_PERFORMANCE_MODE_NONE);
+        /* When routed through the system effects chain, ask for POWER_SAVING so
+         * AAudio does not request the FAST mixer thread. Dolby/MiSound effects
+         * are attached to the deep-buffer output, and a FAST stream would skip
+         * that chain entirely (observed on Turbo 4 Pro: effects stream landed
+         * on AudioOut_D while Dolby only processed AudioOut_15). */
+        AAudioStreamBuilder_setPerformanceMode(
+            bld, bridge->route_through_effects
+                     ? AAUDIO_PERFORMANCE_MODE_POWER_SAVING
+                     : AAUDIO_PERFORMANCE_MODE_NONE);
         AAudioStreamBuilder_setDataCallback(bld, play_data_cb, bridge);
         AAudioStreamBuilder_setErrorCallback(bld, play_error_cb, bridge);
     } else {
@@ -764,4 +786,16 @@ void audio_set_keepalive(audio_bridge *b, int enabled)
         return;
     b->keepalive_enabled = enabled != 0;
     LOGI("audio keep-alive %s", b->keepalive_enabled ? "enabled" : "disabled");
+}
+
+void audio_set_effects(audio_bridge *b, int enabled)
+{
+    if (!b)
+        return;
+    b->route_through_effects = enabled != 0;
+    /* Rebuild the output stream on the playback thread so the new route (direct
+     * vs through the system effects chain) applies without a reconnect. */
+    if (b->play)
+        b->play_error = true;
+    LOGI("audio route: %s", b->route_through_effects ? "system effects" : "direct output");
 }

--- a/consumers/anland_v5/android_consumer/app/src/main/jni/native_audio.h
+++ b/consumers/anland_v5/android_consumer/app/src/main/jni/native_audio.h
@@ -54,4 +54,10 @@ void audio_set_latency(audio_bridge *b, int speaker_ms, int mic_ms);
  * Default is disabled. Takes effect on the playback thread's next loop pass. */
 void audio_set_keepalive(audio_bridge *b, int enabled);
 
+/* Route the playback stream through the phone's system effects chain (e.g. Dolby
+ * Atmos) instead of the direct MMAP output. Default off (direct, lowest latency).
+ * Reopens the output stream on the playback thread so the change applies
+ * immediately. */
+void audio_set_effects(audio_bridge *b, int enabled);
+
 #endif

--- a/consumers/anland_v5/android_consumer/app/src/main/jni/native_consumer.c
+++ b/consumers/anland_v5/android_consumer/app/src/main/jni/native_consumer.c
@@ -1104,3 +1104,13 @@ Java_com_anland_consumer_Native_nativeSetAudioKeepalive(
         return;
     audio_set_keepalive(s->audio, enabled == JNI_TRUE);
 }
+
+JNIEXPORT void JNICALL
+Java_com_anland_consumer_Native_nativeSetAudioEffects(
+    JNIEnv *env, jclass clazz, jlong handle, jboolean enabled)
+{
+    struct consumer_state *s = STATE(handle);
+    if (!s)
+        return;
+    audio_set_effects(s->audio, enabled == JNI_TRUE);
+}

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values-zh-rTW/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values-zh-rTW/strings.xml
@@ -119,6 +119,9 @@
     <string name="camera_hint">允許桌面將本裝置的相機作為視訊來源開啟。僅在桌面正在錄製時相機才會開啟。下次返回應用程式時生效；首次使用會請求相機權限。</string>
     <string name="audio_keepalive_switch">音訊保活</string>
     <string name="audio_keepalive_hint">保持音訊輸出串流持續活躍，讓 Linux 的短促系統音（音量提示、按鍵音）始終即時播放；會略增待機耗電。關閉時桌面靜默約 1.5 秒後音訊路徑自動休眠，下次出聲時自動喚醒。開啟後若聽感延遲不合預期，可能需要配合調整下方的「音訊延遲」預設。</string>
+    <string name="audio_effects_switch">使用系統音效（杜比全景聲等）</string>
+    <string name="audio_effects_hint">桌面音訊走手機系統音效鏈（杜比等）；關閉為低延遲直出，繞過系統音效。改動即時生效。</string>
+    <string name="audio_effects_latency_hint">已開啟系統音效：揚聲器延遲預設不生效（由手機音效鏈路決定緩衝）。麥克風延遲不受影響。</string>
     <string name="audio_latency_title">音訊延遲</string>
     <string name="latency_speaker_label">喇叭（桌面 → 手機）</string>
     <string name="latency_mic_label">麥克風（手機 → 桌面）</string>

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values-zh/strings.xml
@@ -131,6 +131,9 @@
     <string name="camera_hint">允许桌面将本设备的摄像头作为视频源打开。仅在桌面正在录制时摄像头才会开启。下次返回应用时生效；首次使用会请求摄像头权限。</string>
     <string name="audio_keepalive_switch">音频保活</string>
     <string name="audio_keepalive_hint">保持音频输出流持续活跃，让 Linux 的短促系统音（音量提示、按键音）始终即时播放；会略增待机功耗。关闭时桌面静默约1.5秒后音频通路自动休眠，下次出声时自动唤醒。开启后若听感延迟不合预期，可能需要配合调整下方的「音频延迟」预设。</string>
+    <string name="audio_effects_switch">使用系统音效（杜比全景声等）</string>
+    <string name="audio_effects_hint">桌面音频走手机系统音效链（杜比等）；关闭为低延时直出，绕过系统音效。改动即时生效。</string>
+    <string name="audio_effects_latency_hint">已开启系统音效：扬声器延时预设不生效（由手机音效链路决定缓冲）。麦克风延时不受影响。</string>
     <string name="audio_latency_title">音频延迟</string>
     <string name="latency_speaker_label">扬声器（桌面 → 手机）</string>
     <string name="latency_mic_label">麦克风（手机 → 桌面）</string>

--- a/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
+++ b/consumers/anland_v5/android_consumer/app/src/main/res/values/strings.xml
@@ -131,6 +131,9 @@
     <string name="camera_hint">Lets the desktop open this device\'s camera(s) as a video source. The camera only turns on while the desktop is actively recording. Takes effect on next return to the app; first use prompts for the camera permission.</string>
     <string name="audio_keepalive_switch">Audio keep-alive</string>
     <string name="audio_keepalive_hint">Keep the audio output stream running so short Linux sounds (volume ticks, key clicks) always play instantly. Costs a little standby power. Off: the audio path sleeps after ~1.5 s of desktop silence and wakes for the next sound. If the audible latency does not match your preference, you may need to tune the Audio latency presets below.</string>
+    <string name="audio_effects_switch">System audio effects (Dolby Atmos etc.)</string>
+    <string name="audio_effects_hint">Route desktop audio through the phone\'s system effects chain (e.g. Dolby). Off: direct low-latency output that bypasses system effects. The change applies immediately.</string>
+    <string name="audio_effects_latency_hint">System audio effects are on: the speaker latency preset is ignored (the phone\'s effects chain controls buffering). Microphone latency is unaffected.</string>
     <string name="audio_latency_title">Audio latency</string>
     <string name="latency_speaker_label">Speaker (desktop → phone)</string>
     <string name="latency_mic_label">Microphone (phone → desktop)</string>


### PR DESCRIPTION
桌面音频可走手机系统音效链（杜比等）；开启后扬声器延时预设置灰不生效（由系统音效链路决定缓冲），麦克风延时不受影响；关闭保持低延时直出。改动即时生效。